### PR TITLE
Make CheckFlag serializable

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,13 +44,13 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 {
     private static final long serialVersionUID = -1287808902452203852L;
     private final String identifier;
-    private Optional<String> challengeName = Optional.empty();
+    private String challengeName = null;
     private final List<String> instructions = new ArrayList<>();
     private final Set<FlaggedObject> flaggedObjects = new HashSet<>();
 
     /**
      * A basic constructor that simply flags some identifying value
-     * 
+     *
      * @param identifier
      *            the identifying value to flag
      */
@@ -99,7 +100,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 
     /**
      * Adds any instructions that may help communicate why the {@link AtlasObject}(s) were flagged
-     * 
+     *
      * @param instruction
      *            a free form instruction
      */
@@ -114,7 +115,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     /**
      * Adds a list of instructions that may help communicate why the {@link AtlasObject}(s) were
      * flagged. This can be useful if multiple rules were violated
-     * 
+     *
      * @param instructions
      *            a list of free form instruction
      */
@@ -202,7 +203,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 
     /**
      * Flags a list of {@code point} {@link Location}s
-     * 
+     *
      * @param points
      *            the {@code point} {@link Location}s to flag
      */
@@ -220,8 +221,21 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     @Override
     public boolean equals(final Object other)
     {
-        return other instanceof CheckFlag
-                && StringUtils.equals(this.identifier, ((CheckFlag) other).getIdentifier());
+        if (this == other)
+        {
+            return true;
+        }
+
+        if (!(other instanceof CheckFlag))
+        {
+            return false;
+        }
+
+        final CheckFlag otherFlag = (CheckFlag) other;
+        return Objects.equals(this.identifier, otherFlag.identifier)
+                && Objects.equals(this.challengeName, otherFlag.challengeName)
+                && Objects.equals(this.instructions, otherFlag.instructions)
+                && Objects.equals(this.flaggedObjects, otherFlag.flaggedObjects);
     }
 
     /**
@@ -229,7 +243,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public Optional<String> getChallengeName()
     {
-        return challengeName;
+        return Optional.ofNullable(this.challengeName);
     }
 
     /**
@@ -369,7 +383,8 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     @Override
     public int hashCode()
     {
-        return this.flaggedObjects.hashCode() + this.identifier.hashCode();
+        return Objects.hash(this.identifier, this.challengeName, this.instructions,
+                this.flaggedObjects);
     }
 
     @Override
@@ -399,13 +414,13 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 
     /**
      * Sets a Challenge name for this Flag
-     * 
+     *
      * @param challengeName
      *            a Challenge name
      */
     public void setChallengeName(final String challengeName)
     {
-        this.challengeName = Optional.ofNullable(challengeName);
+        this.challengeName = challengeName;
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedObject.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedObject.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.checks.flag;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
@@ -15,6 +16,25 @@ public abstract class FlaggedObject implements Serializable
 {
     protected static final String COUNTRY_MISSING = "NA";
     private static final long serialVersionUID = -2898518269816777421L;
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+
+        if (!(other instanceof FlaggedObject))
+        {
+            return false;
+        }
+
+        final FlaggedObject otherObject = (FlaggedObject) other;
+        return Objects.equals(this.getCountry(), otherObject.getCountry())
+                && Objects.equals(this.getGeometry(), otherObject.getGeometry())
+                && Objects.equals(this.getProperties(), otherObject.getProperties());
+    }
 
     /**
      * @return the flagged object's country code
@@ -40,5 +60,11 @@ public abstract class FlaggedObject implements Serializable
     public boolean hasCountry()
     {
         return !getCountry().equals(COUNTRY_MISSING);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(this.getCountry(), this.getGeometry(), this.getProperties());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
@@ -1,0 +1,96 @@
+package org.openstreetmap.atlas.checks.flag;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test for {@link CheckFlag}.
+ *
+ * @author mkalender
+ */
+public class CheckFlagTest
+{
+    @Rule
+    public CheckFlagTestRule setup = new CheckFlagTestRule();
+
+    private static CheckFlag deserialize(final byte[] flagAsBytes)
+            throws IOException, ClassNotFoundException
+    {
+        final ByteArrayInputStream byteOutputStream = new ByteArrayInputStream(flagAsBytes);
+        final ObjectInputStream objectOutputStream = new ObjectInputStream(byteOutputStream);
+        return (CheckFlag) objectOutputStream.readObject();
+    }
+
+    private static byte[] serialize(final CheckFlag flag) throws IOException
+    {
+        final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+        final ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteOutputStream);
+        objectOutputStream.writeObject(flag);
+        objectOutputStream.close();
+        return byteOutputStream.toByteArray();
+    }
+
+    private static void testSerialization(final CheckFlag flag)
+            throws ClassNotFoundException, IOException
+    {
+        final CheckFlag deserializedFlag = deserialize(serialize(flag));
+        Assert.assertEquals(flag, deserializedFlag);
+    }
+
+    @Test
+    public void testSerializationWithAllFields() throws IOException, ClassNotFoundException
+    {
+        final CheckFlag flag = new CheckFlag("a-identifier");
+        flag.setChallengeName("sample-challenge");
+        flag.addInstruction("first instruction");
+        flag.addInstruction("second instruction");
+        this.setup.getAtlas().entities().forEach(entity -> flag.addObject(entity));
+        testSerialization(flag);
+    }
+
+    @Test
+    public void testSerializationWithChallenge() throws IOException, ClassNotFoundException
+    {
+        final CheckFlag flag = new CheckFlag("a-identifier");
+        flag.setChallengeName("sample-challenge");
+        testSerialization(flag);
+    }
+
+    @Test
+    public void testSerializationWithIdentifier() throws IOException, ClassNotFoundException
+    {
+        final CheckFlag flag = new CheckFlag("a-identifier");
+        testSerialization(flag);
+    }
+
+    @Test
+    public void testSerializationWithInstructions() throws IOException, ClassNotFoundException
+    {
+        final CheckFlag flag = new CheckFlag("a-identifier");
+        flag.addInstruction("first instruction");
+        flag.addInstruction("second instruction");
+        testSerialization(flag);
+    }
+
+    @Test
+    public void testSerializationWithNullIdentifier() throws IOException, ClassNotFoundException
+    {
+        final CheckFlag flag = new CheckFlag(null);
+        testSerialization(flag);
+    }
+
+    @Test
+    public void testSerializationWithObjects() throws IOException, ClassNotFoundException
+    {
+        final CheckFlag flag = new CheckFlag("a-identifier");
+        this.setup.getAtlas().entities().forEach(entity -> flag.addObject(entity));
+        testSerialization(flag);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTestRule.java
@@ -1,0 +1,55 @@
+package org.openstreetmap.atlas.checks.flag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+
+/**
+ * {@link CheckFlagTest} data generator
+ *
+ * @author mkalender
+ */
+public class CheckFlagTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "31.335310,-121.009566";
+    private static final String TEST_2 = "32.331417,-122.030487";
+    private static final String TEST_3 = "33.325440,-123.033948";
+    private static final String TEST_4 = "34.332451,-124.028932";
+    private static final String TEST_5 = "35.317585,-125.052138";
+    private static final String TEST_6 = "36.390535,-126.031007";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1), tags = { "a-tag=a-value" }),
+                    @Node(coordinates = @Loc(value = TEST_2), tags = {
+                            "another-tag=another-value" }),
+                    @Node(coordinates = @Loc(value = TEST_3), tags = { "third-tag=" }) },
+            // points
+            points = {
+                    @Point(coordinates = @Loc(value = TEST_4), tags = {
+                            "sample-tag=sample-value" }),
+                    @Point(coordinates = @Loc(value = TEST_5), tags = { "test-tag=sample-value" }),
+                    @Point(coordinates = @Loc(value = TEST_6)) },
+            // lines
+            lines = { @Line(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_6),
+                    @Loc(value = TEST_1) }, tags = { "sample-tag=sample-value" }) },
+            // edges
+            edges = { @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                    @Loc(value = TEST_3) }, tags = { "highway=primary" }) },
+            // areas
+            areas = { @Area(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_2),
+                    @Loc(value = TEST_4), @Loc(value = TEST_1),
+                    @Loc(value = TEST_6) }, tags = { "building=yes" }) })
+    private Atlas atlas;
+
+    public Atlas getAtlas()
+    {
+        return this.atlas;
+    }
+}


### PR DESCRIPTION
`CheckFlag` fails to serialize because `challengeName` member is of `Optional` type - not serializable. This PR makes `CheckFlag` fully serializable by removing `Optional` wrapper around `challengeName` value. 

To test this change I created `CheckFlagTest` class. I serialized and deserialized several `CheckFlag` instances. While doing that, I realized that `equals` method in `CheckFlag` was just for equality between identifiers. I updated that method to include other class members in equality check. Also updated `hashCode` method and made it consistent with `equals` method.

Equality check in `CheckFlag` was checking for equality between `FlaggedObject` instances. I implemented `equals` and `hashCode` methods there to make sure we are not failing equality because of references, but we rely on values.