### PR TITLE
Add AbbreviatedNameCheck

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheck.java
@@ -1,0 +1,118 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.tags.names.NameTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
+
+/**
+ * Flags names that have abbreviations in them. Per OSM wiki, if the name can be spelled without an
+ * abbreviation, then it must not be abbreviated. Computers can easily shorten words, but not the
+ * other way (St. could be Street or Saint).
+ *
+ * @see <a href="http://wiki.openstreetmap.org/wiki/Names#Abbreviation_.28don.27t_do_it.29">wiki</a>
+ *      for more information.
+ * @author mkalender
+ */
+public class AbbreviatedNameCheck extends BaseCheck<String>
+{
+    private static final long serialVersionUID = -3648610800112828238L;
+
+    // Abbreviation config
+    private static final String ABBREVIATION_KEY = "abbreviations";
+
+    // Config to create Locale object
+    private static final String LOCALE_KEY = "locale";
+
+    // Splitter to parse name
+    private static final Splitter NAME_SPLITTER = Splitter
+            .on(CharMatcher.JAVA_LETTER_OR_DIGIT.negate()).omitEmptyStrings();
+
+    private final Set<String> abbreviations;
+    private final Locale locale;
+
+    /**
+     * Generates a unique identifier given an {@link AtlasEntity}. OSM/Atlas objects with different
+     * types can share the identifier (way 12345 - node 12345). This method makes sure we generate a
+     * truly unique identifier among different types for an {@link AtlasEntity}.
+     *
+     * @param entity
+     *            {@link AtlasEntity} to generate unique identifier for
+     * @return unique object identifier among different types
+     */
+    private static String getUniqueObjectIdentifier(final AtlasEntity entity)
+    {
+        return String.format("%s%s", entity.getType().toShortString(), entity.getOsmIdentifier());
+    }
+
+    /**
+     * Default constructor
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public AbbreviatedNameCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.locale = this.configurationValue(configuration, LOCALE_KEY,
+                Locale.getDefault().getLanguage(), locale -> new Locale(locale));
+        this.abbreviations = this
+                .configurationValue(configuration, ABBREVIATION_KEY, new ArrayList<String>(),
+                        Sets::newHashSet)
+                .stream().map(abbreviation -> abbreviation.toLowerCase(this.locale))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof AtlasEntity
+                && !this.isFlagged(getUniqueObjectIdentifier((AtlasEntity) object));
+    }
+
+    /**
+     * Flags {@link AtlasObject}s that has names with abbreviations.
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        // Mark OSM identifier as we are processing it
+        this.markAsFlagged(getUniqueObjectIdentifier((AtlasEntity) object));
+
+        // Fetch the name
+        final Optional<String> optionalName = NameTag.getNameOf(object);
+        if (!optionalName.isPresent())
+        {
+            return Optional.empty();
+        }
+
+        // Lowercase name and parse it into tokens
+        final String name = optionalName.get();
+        final String lowercaseName = name.toLowerCase(this.locale);
+        final Set<String> tokens = Sets.newHashSet(NAME_SPLITTER.split(lowercaseName));
+
+        // Flag if it has any abbreviations
+        if (tokens.stream().anyMatch(this.abbreviations::contains))
+        {
+            final CheckFlag flag = this.createFlag(object,
+                    String.format(
+                            "OSM feature with id %s's name tag (`name` = **%s**) has an abbreviation. Please update the `name` tag to not use abbreviation.",
+                            object.getOsmIdentifier(), name));
+            return Optional.of(flag);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheckTest.java
@@ -1,0 +1,66 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link AbbreviatedNameCheck}.
+ *
+ * @author mkalender
+ */
+public class AbbreviatedNameCheckTest
+{
+    @Rule
+    public AbbreviatedNameCheckTestRule setup = new AbbreviatedNameCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testAbbreviationsWithAllAbbreviationsConfig()
+    {
+        this.verifier.actual(this.setup.atlasWithAbbreviations(),
+                new AbbreviatedNameCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"AbbreviatedNameCheck\":{\"locale\": \"en\", \"abbreviations\": [\"ave\", \"St\", \"Dr\", \"NE\", \"Cir\", \"Pl\", \"Apt\"]}}")));
+        this.verifier.verifyNotEmpty();
+
+        // one node and six edge should be flagged
+        this.verifier.verifyExpectedSize(7);
+    }
+
+    @Test
+    public void testAbbreviationsWithEmptyConfig()
+    {
+        this.verifier.actual(this.setup.atlasWithAbbreviations(),
+                new AbbreviatedNameCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"AbbreviatedNameCheck\":{\"locale\": \"en\", \"abbreviations\": []}}")));
+
+        // no abbreviations provided through config, so we shouldn't flag
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testAbbreviationsWithSomeAbbreviationsConfig()
+    {
+        this.verifier.actual(this.setup.atlasWithAbbreviations(),
+                new AbbreviatedNameCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"AbbreviatedNameCheck\":{\"locale\": \"en\", \"abbreviations\": [\"ave\", \"St\", \"Dr\", \"NE\", \"Cir\", \"Pl\"]}}")));
+        this.verifier.verifyNotEmpty();
+
+        // Apt is not in the list, so six edge should be flagged
+        this.verifier.verifyExpectedSize(6);
+    }
+
+    @Test
+    public void testNoAbbreviationsWithAllAbbreviationsConfig()
+    {
+        this.verifier.actual(this.setup.atlasWithoutAbbreviations(),
+                new AbbreviatedNameCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"AbbreviatedNameCheck\":{\"locale\": \"en\", \"abbreviations\": [\"ave\", \"St\", \"Dr\", \"NE\", \"Cir\", \"Pl\", \"Apt\"]}}")));
+
+        // data doesn't have any abbreviations
+        this.verifier.verifyEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheckTestRule.java
@@ -1,0 +1,100 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * {@link AbbreviatedNameCheckTest} data generator.
+ *
+ * @author mkalender
+ */
+public class AbbreviatedNameCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "37.335310,-122.009566";
+    private static final String TEST_2 = "37.331471,-122.030481";
+    private static final String TEST_3 = "37.325440,-122.033948";
+    private static final String TEST_4 = "37.332451,-122.028932";
+    private static final String TEST_5 = "37.317585,-122.052138";
+    private static final String TEST_6 = "37.390535,-122.031007";
+
+    @TestAtlas(nodes = {
+            // nodes
+            @Node(id = "1234567891000000", coordinates = @Loc(value = TEST_1), tags = {
+                    "name=Test Apt" }),
+            @Node(id = "2234567891000000", coordinates = @Loc(value = TEST_2)),
+            @Node(id = "3234567891000000", coordinates = @Loc(value = TEST_3)),
+            @Node(id = "4234567891000000", coordinates = @Loc(value = TEST_4)),
+            @Node(id = "5234567891000000", coordinates = @Loc(value = TEST_5)),
+            @Node(id = "6234567891000000", coordinates = @Loc(value = TEST_6)) },
+            // edges
+            edges = { @Edge(id = "1234567891000000", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2) }, tags = { "highway=secondary", "name=Test St." }),
+                    @Edge(id = "-1234567891000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_1) }, tags = { "highway=secondary",
+                                    "name=Test St." }),
+                    @Edge(id = "2234567891000001", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=secondary", "name=Test Dr" }),
+                    @Edge(id = "2234567891000002", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_6) }, tags = { "highway=secondary", "name=Test Dr" }),
+                    @Edge(id = "3234567891000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4), @Loc(value = TEST_2) }, tags = {
+                                    "highway=secondary", "name=Test Ave" }),
+                    @Edge(id = "4234567891000000", coordinates = { @Loc(value = TEST_4),
+                            @Loc(value = TEST_6) }, tags = { "highway=secondary",
+                                    "name=Test Ave. NE" }),
+                    @Edge(id = "5234567891000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_5) }, tags = { "highway=secondary", "name=Test Pl" }),
+                    @Edge(id = "6234567891000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4) }, tags = { "highway=secondary",
+                                    "name=Test Cir" }) })
+    private Atlas atlasWithAbbreviations;
+
+    @TestAtlas(nodes = {
+            // nodes
+            @Node(id = "1234567891000000", coordinates = @Loc(value = TEST_1), tags = {
+                    "name=Test Apartment" }),
+            @Node(id = "2234567891000000", coordinates = @Loc(value = TEST_2)),
+            @Node(id = "3234567891000000", coordinates = @Loc(value = TEST_3)),
+            @Node(id = "4234567891000000", coordinates = @Loc(value = TEST_4)),
+            @Node(id = "5234567891000000", coordinates = @Loc(value = TEST_5)),
+            @Node(id = "6234567891000000", coordinates = @Loc(value = TEST_6)) },
+            // edges
+            edges = { @Edge(id = "1234567891000000", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2) }, tags = { "highway=secondary", "name=Test Street" }),
+                    @Edge(id = "-1234567891000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_1) }, tags = { "highway=secondary",
+                                    "name=Test Street" }),
+                    @Edge(id = "2234567891000001", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=secondary",
+                                    "name=Test Drive" }),
+                    @Edge(id = "2234567891000002", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_6) }, tags = { "highway=secondary",
+                                    "name=Test Drive" }),
+                    @Edge(id = "3234567891000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4), @Loc(value = TEST_2) }, tags = {
+                                    "highway=secondary", "name=Test Avenue" }),
+                    @Edge(id = "4234567891000000", coordinates = { @Loc(value = TEST_4),
+                            @Loc(value = TEST_6) }, tags = { "highway=secondary",
+                                    "name=Test Avenue North East" }),
+                    @Edge(id = "5234567891000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_5) }, tags = { "highway=secondary",
+                                    "name=Test Place" }),
+                    @Edge(id = "6234567891000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4) }, tags = { "highway=secondary",
+                                    "name=Test Circle" }) })
+    private Atlas atlasWithoutAbbreviations;
+
+    public Atlas atlasWithAbbreviations()
+    {
+        return this.atlasWithAbbreviations;
+    }
+
+    public Atlas atlasWithoutAbbreviations()
+    {
+        return this.atlasWithoutAbbreviations;
+    }
+}


### PR DESCRIPTION
This PR introduces `AbbreviatedNameCheck` to check if `name` tag has any abbreviations in it. [OSM wiki page](http://wiki.openstreetmap.org/wiki/Names#Abbreviation_.28don.27t_do_it.29) clearly says not using any abbreviations.

I implemented the check in a way so that we can use configuration to provide `locale` and `abbreviations` as a list. Atlas object's name will be fetched, lowercased and then split into tokens. Each token will be tested against set of abbreviations. If token matches to an abbreviation, then object will be flagged.

Here is a sample configuration to check for abbreviations in names with English locale:
```
{
  "locale": "en",
  "abbreviations": ["ave", "st", "dr", "ne", "cir", "pl", "apt"]
}
```