### PR TITLE
Updating the BuildingRoadIntersectionCheck 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -104,7 +104,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
     {
         final Area building = (Area) object;
         final Iterable<Edge> intersectingEdges = Iterables.filter(building.getAtlas()
-                        .edgesIntersecting(building.bounds(), intersectsCoreWayInvalidly(building)),
+                .edgesIntersecting(building.bounds(), intersectsCoreWayInvalidly(building)),
                 ignoreTags());
         final CheckFlag flag = new CheckFlag(getTaskIdentifier(building));
         flag.addObject(building);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -7,16 +7,18 @@ import java.util.function.Predicate;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.tags.BuildingTag;
 import org.openstreetmap.atlas.tags.CoveredTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.TunnelTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
-
-import com.google.common.collect.Iterables;
 
 /**
  * Flags buildings that intersect/touch centerlines of roads. This doesn't address cases where
@@ -28,10 +30,51 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
 {
     private static final long serialVersionUID = 5986017212661374165L;
 
-    private static Predicate<Edge> intersectsCoreWay(final Area building)
+    private static Predicate<Edge> ignoreTags()
+    {
+        return edge -> !(Validators.isOfType(edge, CoveredTag.class, CoveredTag.YES)
+                || Validators.isOfType(edge, TunnelTag.class, TunnelTag.BUILDING_PASSAGE));
+    }
+
+    private static Predicate<Edge> intersectsCoreWayInvalidly(final Area building)
     {
         return edge -> HighwayTag.isCoreWay(edge)
-                && edge.asPolyLine().intersects(building.asPolygon());
+                && edge.asPolyLine().intersects(building.asPolygon())
+                && !isValidIntersection(building, edge);
+    }
+
+    /**
+     * An edge intersecting with a building that doesn't have the proper tags is only valid iff it
+     * intersects at one single node and that node is shared with an edge that has the proper tags
+     * and it is not enclosed in the building
+     *
+     * @param building
+     *            the building being processed
+     * @param edge
+     *            the edge being examined
+     * @return true if the intersection is valid, false otherwise
+     */
+    private static boolean isValidIntersection(final Area building, final Edge edge)
+    {
+        final Node edgeStart = edge.start();
+        final Node edgeEnd = edge.end();
+        final Set<Location> intersections = building.asPolygon().intersections(edge.asPolyLine());
+        if (intersections.size() == 1
+                && !building.asPolygon().fullyGeometricallyEncloses(edge.asPolyLine()))
+        {
+            if (intersections.contains(edgeStart.getLocation())
+                    && edge.inEdges().stream().anyMatch(ignoreTags().negate()))
+            {
+                return true;
+            }
+            if (intersections.contains(edgeEnd.getLocation())
+                    && edge.outEdges().stream().anyMatch(ignoreTags().negate()))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -52,19 +95,20 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
         // Since intersections will be flagged for any feature, it makes sense to loop over the
         // smallest of the three sets - buildings (for most countries). This may change over time.
         return object instanceof Area && BuildingTag.isBuilding(object)
-                && !HighwayTag.isHighwayArea(object);
+                && !HighwayTag.isHighwayArea(object)
+                && !Validators.isOfType(object, BuildingTag.class, BuildingTag.ROOF);
     }
 
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Area building = (Area) object;
-        final Iterable<Edge> intersectingEdges = Iterables.filter(
-                object.getAtlas().edgesIntersecting(object.bounds(), intersectsCoreWay(building)),
-                edge -> !Validators.isOfType(edge, CoveredTag.class, CoveredTag.YES));
-        final CheckFlag flag = new CheckFlag(getTaskIdentifier(object));
-        flag.addObject(object);
-        handleIntersections(intersectingEdges, flag, object);
+        final Iterable<Edge> intersectingEdges = Iterables.filter(building.getAtlas()
+                        .edgesIntersecting(building.bounds(), intersectsCoreWayInvalidly(building)),
+                ignoreTags());
+        final CheckFlag flag = new CheckFlag(getTaskIdentifier(building));
+        flag.addObject(building);
+        this.handleIntersections(intersectingEdges, flag, building);
 
         if (flag.getPolyLines().size() > 1)
         {
@@ -86,7 +130,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
      *            the building being processed
      */
     private void handleIntersections(final Iterable<Edge> intersectingEdges, final CheckFlag flag,
-            final AtlasObject building)
+            final Area building)
     {
         final Set<Edge> knownIntersections = new HashSet<>();
         for (final Edge edge : intersectingEdges)
@@ -103,5 +147,4 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
             }
         }
     }
-
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -43,4 +43,16 @@ public class BuildingRoadIntersectionCheckTest
         this.verifier.actual(this.setup.getCoveredAtlas(), check);
         this.verifier.verifyExpectedSize(0);
     }
+
+    /**
+     * Unit Test to make sure that the tunnel = building passage tag is not being counted as an
+     * intersection edge. This test also checks to make sure valid single point intersections are
+     * not flagged.
+     */
+    @Test
+    public void testTunnel()
+    {
+        this.verifier.actual(this.setup.getTunnelBuildingIntersect(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -53,7 +53,7 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
                             @Loc(value = TEST_6) }, tags = { "highway=pedestrian",
-                            "building=house" }),
+                                    "building=house" }),
                     // Another variation of a Pedestrian Area - not flagged
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -17,11 +17,18 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
 {
     private static final String TEST_1 = "37.335310,-122.009566";
     private static final String TEST_2 = "37.3314171,-122.0304871";
+    private static final String TEST_2_0 = "10.12352901009, -80.76485349564";
+    private static final String TEST_2_1 = "10.12309410805, -80.7054341158";
+    private static final String TEST_2_2 = "10.04451299889, -80.70602752863";
+    private static final String TEST_2_3 = "10.04494800701, -80.76544690847";
+    private static final String TEST_2_4 = "10.09373688925, -80.76507849106";
+    private static final String TEST_2_5 = "10.0750348474, -80.70579705713";
+    private static final String TEST_2_6 = "10.10700231854, -80.82073863728";
+    private static final String TEST_2_7 = "10.05567718163, -80.65485033146";
     private static final String TEST_3 = "37.325440,-122.033948";
     private static final String TEST_4 = "37.332451,-122.028932";
     private static final String TEST_5 = "37.317585,-122.052138";
     private static final String TEST_6 = "37.390535,-122.031007";
-
     @TestAtlas(
 
             nodes = { @Node(coordinates = @Loc(value = TEST_1)),
@@ -46,15 +53,41 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
                             @Loc(value = TEST_6) }, tags = { "highway=pedestrian",
-                                    "building=house" }),
+                            "building=house" }),
                     // Another variation of a Pedestrian Area - not flagged
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
                             @Loc(value = TEST_6) }, tags = { "highway=pedestrian", "area=yes" }) })
     private Atlas atlas;
-
     @TestAtlas(loadFromTextResource = "covered.atlas")
     private Atlas coveredAtlas;
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_2_5)),
+            @Node(coordinates = @Loc(value = TEST_2_4)),
+            @Node(coordinates = @Loc(value = TEST_2_3)),
+            @Node(coordinates = @Loc(value = TEST_2_2)),
+            @Node(coordinates = @Loc(value = TEST_2_1)),
+            @Node(coordinates = @Loc(value = TEST_2_0)),
+            @Node(coordinates = @Loc(value = TEST_2_7)),
+            @Node(coordinates = @Loc(value = TEST_2_6)) },
+
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_2_4), @Loc(value = TEST_2_5) }, tags = {
+                            "tunnel=building_passage", "highway=service" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2_5), @Loc(value = TEST_2_4) }, tags = {
+                            "tunnel=building_passage", "highway=service" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2_6), @Loc(value = TEST_2_4) }, tags = {
+                            "highway=service" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2_4), @Loc(value = TEST_2_6) }, tags = {
+                            "highway=service" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2_7), @Loc(value = TEST_2_5) }, tags = {
+                            "highway=service" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2_5), @Loc(value = TEST_2_7) }, tags = {
+                            "highway=service" }) },
+
+            areas = { @Area(coordinates = { @Loc(value = TEST_2_0), @Loc(value = TEST_2_1),
+                    @Loc(value = TEST_2_5), @Loc(value = TEST_2_2), @Loc(value = TEST_2_3),
+                    @Loc(value = TEST_2_4), @Loc(value = TEST_2_0) }, tags = { "building=yes" }) })
+    private Atlas tunnelBuildingIntersect;
 
     public Atlas getAtlas()
     {
@@ -64,5 +97,10 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
     public Atlas getCoveredAtlas()
     {
         return this.coveredAtlas;
+    }
+
+    public Atlas getTunnelBuildingIntersect()
+    {
+        return this.tunnelBuildingIntersect;
     }
 }


### PR DESCRIPTION
Updating this check to account for valid intersections between roads and buildings that were being flagged. Specifically, now ignoring intersection when building=roof or tunnel=building_passage. In addition, this update ignores intersection when a Edge approaches a building, intersects at one single point at the end of the Edge, and then continues through the building with proper tagging (e.g.
 Toll booths). 