### PR TITLE
Added helper functions for building a unique identifier for flagging …

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -15,6 +15,7 @@ import org.openstreetmap.atlas.checks.maproulette.data.ChallengeDifficulty;
 import org.openstreetmap.atlas.checks.maproulette.serializer.ChallengeDeserializer;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.tags.ManMadeTag;
 import org.openstreetmap.atlas.tags.filters.TaggableFilter;
@@ -288,6 +289,34 @@ public abstract class BaseCheck<T> implements Check, Serializable
     protected void markAsFlagged(final T identifier)
     {
         this.flaggedIdentifiers.add(identifier);
+    }
+
+    /**
+     * Generates a unique identifier given an {@link AtlasEntity}. OSM/Atlas objects with different
+     * types can share the identifier (way 12345 - node 12345). This method makes sure we generate a
+     * truly unique identifier, based on the OSM identifier, among different types for an
+     * {@link AtlasEntity}.
+     *
+     * @param entity
+     *            {@link AtlasEntity} to generate unique identifier for
+     * @return unique object identifier among different types
+     */
+    protected String getUniqueOSMIdentifier(final AtlasEntity entity)
+    {
+        return String.format("%s%s", entity.getType().toShortString(), entity.getOsmIdentifier());
+    }
+
+    /**
+     * Similar to {@link BaseCheck#getUniqueOSMIdentifier(AtlasEntity)} except instead of using the
+     * OSM identifier we use the Atlas identifier
+     *
+     * @param entity
+     *            {@link AtlasEntity} to generate unique identifier for
+     * @return unique object identifier among different types
+     */
+    protected String getUniqueObjectIdentifier(final AtlasEntity entity)
+    {
+        return String.format("%s%s", entity.getType().toShortString(), entity.getIdentifier());
     }
 
     private String formatKey(final String name, final String key)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheck.java
@@ -44,20 +44,6 @@ public class AbbreviatedNameCheck extends BaseCheck<String>
     private final Locale locale;
 
     /**
-     * Generates a unique identifier given an {@link AtlasEntity}. OSM/Atlas objects with different
-     * types can share the identifier (way 12345 - node 12345). This method makes sure we generate a
-     * truly unique identifier among different types for an {@link AtlasEntity}.
-     *
-     * @param entity
-     *            {@link AtlasEntity} to generate unique identifier for
-     * @return unique object identifier among different types
-     */
-    private static String getUniqueObjectIdentifier(final AtlasEntity entity)
-    {
-        return String.format("%s%s", entity.getType().toShortString(), entity.getOsmIdentifier());
-    }
-
-    /**
      * Default constructor
      *
      * @param configuration
@@ -67,7 +53,7 @@ public class AbbreviatedNameCheck extends BaseCheck<String>
     {
         super(configuration);
         this.locale = this.configurationValue(configuration, LOCALE_KEY,
-                Locale.getDefault().getLanguage(), locale -> new Locale(locale));
+                Locale.getDefault().getLanguage(), Locale::new);
         this.abbreviations = this
                 .configurationValue(configuration, ABBREVIATION_KEY, new ArrayList<String>(),
                         Sets::newHashSet)
@@ -79,7 +65,7 @@ public class AbbreviatedNameCheck extends BaseCheck<String>
     public boolean validCheckForObject(final AtlasObject object)
     {
         return object instanceof AtlasEntity
-                && !this.isFlagged(getUniqueObjectIdentifier((AtlasEntity) object));
+                && !this.isFlagged(this.getUniqueOSMIdentifier((AtlasEntity) object));
     }
 
     /**
@@ -89,7 +75,7 @@ public class AbbreviatedNameCheck extends BaseCheck<String>
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         // Mark OSM identifier as we are processing it
-        this.markAsFlagged(getUniqueObjectIdentifier((AtlasEntity) object));
+        this.markAsFlagged(this.getUniqueOSMIdentifier((AtlasEntity) object));
 
         // Fetch the name
         final Optional<String> optionalName = NameTag.getNameOf(object);


### PR DESCRIPTION
…objects that don't conflict with other OSM types

In OSM a way and node can share the same identifier, this is not a problem because they are different types, however atlas-checks flagging mechanism to say that you had already processed a particular item didn't take into account type. So if you flag a way then you will not process the node with the same identifier. This PR simply adds two helper function that allows you to build the identifiers used for the flags so that you don't run into that particular conflict.