### PR TITLE
Making unique identifer function in BaseCheck more robust. Updating S…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ configurations
     integrationTestRuntime.extendsFrom testRuntime
 }
 
-dependencies 
+dependencies
 {
     compile packages.commons
     compile packages.atlas
@@ -296,7 +296,7 @@ task runChecks(type: JavaExec, dependsOn: 'assemble', description: 'Executes the
     // add log4j config to the classpath
     classpath('./config/log4j')
 
-    // uncomment to change jvm args 
+    // uncomment to change jvm args
     // jvmArgs(["-Xmx8g","-Xms8g"])
 
     // uncomment to enable jvm debugging

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -115,9 +115,9 @@
   "SharpAngleCheck": {
     "threshold.degrees": 149.0,
     "challenge": {
-      "description": "Each task has edges that have an angle that is too sharp within their polyline. Sharp angles may indicate inaccurate digitization once this threshold is exceeded. There may be other factors in play here such as number of intersections, type of highway, etc. But the main breaking point is any angles that are greater than 149.",
+      "description": "Each task has edges that have an angle that is too sharp within their polyline. Sharp angles may indicate inaccurate digitization once this threshold is exceeded. There may be other factors in play here such as number of intersections, type of highway, etc. But the main breaking point is any angles that are less than 31.",
       "blurb": "Modify angles that are too acute for possible inaccurate digitization.",
-      "instruction": "Modify angles between two edges in polylines that are less than 31 degrees.",
+      "instruction": "Modify angles between two edges in polylines that are less than 31.",
       "difficulty": "NORMAL",
       "defaultPriority": "LOW",
       "highPriorityRule": {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.0.0',
+    atlas: '5.0.3',
     commons:'2.6',
     atlas_generator: '4.0.0',
 ]

--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -292,31 +292,48 @@ public abstract class BaseCheck<T> implements Check, Serializable
     }
 
     /**
-     * Generates a unique identifier given an {@link AtlasEntity}. OSM/Atlas objects with different
+     * Generates a unique identifier given an {@link AtlasObject}. OSM/Atlas objects with different
      * types can share the identifier (way 12345 - node 12345). This method makes sure we generate a
      * truly unique identifier, based on the OSM identifier, among different types for an
-     * {@link AtlasEntity}.
+     * {@link AtlasObject}. If the AtlasObject is an instanceof AtlasEntity then it will simply use
+     * the type for the first part of the identifier, otherwise it will use the simple class name.
      *
-     * @param entity
-     *            {@link AtlasEntity} to generate unique identifier for
+     * @param object
+     *            {@link AtlasObject} to generate unique identifier for
      * @return unique object identifier among different types
      */
-    protected String getUniqueOSMIdentifier(final AtlasEntity entity)
+    protected String getUniqueOSMIdentifier(final AtlasObject object)
     {
-        return String.format("%s%s", entity.getType().toShortString(), entity.getOsmIdentifier());
+        if (object instanceof AtlasEntity)
+        {
+            return String.format("%s%s", ((AtlasEntity) object).getType().toShortString(),
+                    object.getOsmIdentifier());
+        }
+        else
+        {
+            return String.format("%s%s", object.getClass().getSimpleName(), object.getIdentifier());
+        }
     }
 
     /**
-     * Similar to {@link BaseCheck#getUniqueOSMIdentifier(AtlasEntity)} except instead of using the
+     * Similar to {@link BaseCheck#getUniqueOSMIdentifier(AtlasObject)} except instead of using the
      * OSM identifier we use the Atlas identifier
      *
-     * @param entity
-     *            {@link AtlasEntity} to generate unique identifier for
+     * @param object
+     *            {@link AtlasObject} to generate unique identifier for
      * @return unique object identifier among different types
      */
-    protected String getUniqueObjectIdentifier(final AtlasEntity entity)
+    protected String getUniqueObjectIdentifier(final AtlasObject object)
     {
-        return String.format("%s%s", entity.getType().toShortString(), entity.getIdentifier());
+        if (object instanceof AtlasEntity)
+        {
+            return String.format("%s%s", ((AtlasEntity) object).getType().toShortString(),
+                    object.getIdentifier());
+        }
+        else
+        {
+            return String.format("%s%s", object.getClass().getSimpleName(), object.getIdentifier());
+        }
     }
 
     private String formatKey(final String name, final String key)

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
@@ -200,6 +200,7 @@ public class IntegrityCheckSparkJob extends SparkJob
         final Set<BaseCheck> checksToExecute = checkLoader.loadChecks();
         if (!isValidInput(countries, checksToExecute))
         {
+            logger.error("No countries supplied or checks enabled, exiting!");
             return;
         }
 
@@ -350,20 +351,9 @@ public class IntegrityCheckSparkJob extends SparkJob
         {
             final String country = countryPathPair._1();
             final Set<SparkFilePath> paths = countryPathPair._2();
-            logger.info("[{}] Renaming outputs: {}", country, paths);
+            logger.info("[{}] Committing outputs: {}", country, paths);
 
-            paths.forEach(path ->
-            {
-                try
-                {
-                    logger.debug("Renaming {}.", path);
-                    fileHelper.rename(path.getTemporaryPath(), path.getTargetPath());
-                }
-                catch (final Exception e)
-                {
-                    logger.warn("Renaming {} failed!", path, e);
-                }
-            });
+            paths.forEach(fileHelper::commit);
         });
 
         try
@@ -417,7 +407,6 @@ public class IntegrityCheckSparkJob extends SparkJob
     {
         if (countries.size() == 0 || checksToExecute.size() == 0)
         {
-            logger.debug("No countries supplied or checks enabled, exiting!");
             return false;
         }
         return true;


### PR DESCRIPTION
…park helper functions.

For the unique identifier function, updating so that it takes an AtlasObject object instead of AtlasEntity. If the object is of type AtlasEntity then it will use the type otherwise will use the simplified class name.

he SparkFileHelper was extended with a commit() method that checks if the given output directory exists, renaming the individual files when it does.

A timestamp is appended to the metrics filename to create a unique metrics file for each run.