### PR TITLE
Updating BuildingRoadIntersectionCheck to take into account the layer…

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -15,6 +15,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.tags.BuildingTag;
 import org.openstreetmap.atlas.tags.CoveredTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.LayerTag;
 import org.openstreetmap.atlas.tags.TunnelTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
@@ -40,6 +41,8 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
     {
         return edge -> HighwayTag.isCoreWay(edge)
                 && edge.asPolyLine().intersects(building.asPolygon())
+                && LayerTag.getTaggedValue(edge).orElse(0L)
+                        .equals(LayerTag.getTaggedValue(building).orElse(0L))
                 && !isValidIntersection(building, edge);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -55,4 +55,16 @@ public class BuildingRoadIntersectionCheckTest
         this.verifier.actual(this.setup.getTunnelBuildingIntersect(), check);
         this.verifier.verifyExpectedSize(0);
     }
+
+    /**
+     * Unit test to make sure that when layer tag is used on highways that they are handled
+     * properly. And so if highway layer tag = -1 then it does not intersect with the building. As
+     * in this particular case it goes under it.
+     */
+    @Test
+    public void testLayered()
+    {
+        this.verifier.actual(this.setup.getLayeredAtlas(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -100,11 +100,9 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                             @Loc(value = TEST_3) }, tags = { "highway=primary", "layer=-1" }) },
 
             areas = {
-                    // Regular building - flagged
                     @Area(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
                             @Loc(value = TEST_6) }, tags = { "building=yes" }),
-                    // Non-Pedestrian Area - flagged
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
                             @Loc(value = TEST_6) }, tags = { "highway=primary",

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -88,6 +88,28 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                     @Loc(value = TEST_2_5), @Loc(value = TEST_2_2), @Loc(value = TEST_2_3),
                     @Loc(value = TEST_2_4), @Loc(value = TEST_2_0) }, tags = { "building=yes" }) })
     private Atlas tunnelBuildingIntersect;
+    @TestAtlas(
+
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=primary", "layer=-1" }) },
+
+            areas = {
+                    // Regular building - flagged
+                    @Area(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "building=yes" }),
+                    // Non-Pedestrian Area - flagged
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "highway=primary",
+                                    "building=house" }) })
+    private Atlas layered;
 
     public Atlas getAtlas()
     {
@@ -102,5 +124,10 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
     public Atlas getTunnelBuildingIntersect()
     {
         return this.tunnelBuildingIntersect;
+    }
+
+    public Atlas getLayeredAtlas()
+    {
+        return this.layered;
     }
 }


### PR DESCRIPTION
… tag.

Checking the building and edge layer tags, if the layer tags are different then we can assume that the building and road are on different layers and so then technically don't intersect.

For this we are adding a check for layer tags on the edge and building, so if the edge and building layer tag values are different then we can assume that the intersection is actually fine.