### PR TITLE
Adding instruction localization for Atlas Check Flags

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -313,7 +313,10 @@ public abstract class BaseCheck<T> implements Check, Serializable
      *
      * @return The set of instructions to fall back to if configuration results in none.
      */
-    protected abstract List<String> getFallbackInstructions();
+    protected List<String> getFallbackInstructions()
+    {
+        return Collections.emptyList();
+    }
 
     protected Set<T> getFlaggedIdentifiers()
     {

--- a/src/main/java/org/openstreetmap/atlas/checks/persistence/SparkFileHelper.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/persistence/SparkFileHelper.java
@@ -511,17 +511,20 @@ public class SparkFileHelper implements Serializable
      */
     public void write(final String directory, final String filename, final String content)
     {
-        final WritableResource resource = FileSystemHelper
-                .writableResource(combine(directory, filename), this.sparkContext);
-        try (BufferedWriter out = new BufferedWriter(
-                new OutputStreamWriter(resource.write(), StandardCharsets.UTF_8)))
+        IO_RETRY.run(() ->
         {
-            out.write(content);
-        }
-        catch (final Exception e)
-        {
-            throw new CoreException(String.format("Could not save into %s.", resource.getName()),
-                    e);
-        }
+            final WritableResource resource = FileSystemHelper
+                    .writableResource(combine(directory, filename), this.sparkContext);
+            try (BufferedWriter out = new BufferedWriter(
+                    new OutputStreamWriter(resource.write(), StandardCharsets.UTF_8)))
+            {
+                out.write(content);
+            }
+            catch (final Exception e)
+            {
+                throw new CoreException(
+                        String.format("Could not save into %s.", resource.getName()), e);
+            }
+        });
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PoolSizeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PoolSizeCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.areas;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
@@ -15,7 +17,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  *
  * @author mcuthbert
  */
-public class PoolSizeCheck extends BaseCheck
+public class PoolSizeCheck extends BaseCheck<Long>
 {
     // The worlds largest swimming pool is at the San Alfonso del Mar resort in Algarrobo and
     // measures 1,013 meters in length, which is 4,856,227.71 square meters. So we can use a even
@@ -25,6 +27,9 @@ public class PoolSizeCheck extends BaseCheck
     public static final double MAXIMUM_SIZE_DEFAULT = 5000000;
     // A 5 meter squared pool if a circle would only be roughly 2 meters in diameter.
     public static final double MINIMUM_SIZE_DEFAULT = 5;
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "The swimming pool with OSM ID {0} with a surface area of {1,number,#.##} meters squared is greater than the expected maximum of {2} meters squared.",
+            "The swimming pool with OSM ID {0} with a surface area of {1,number,#.##} meters squared is smaller than the expected minimum of {2} meters squared.");
     // You can use serialver to regenerate the serial UID.
     private static final long serialVersionUID = 1L;
     // Create maximum and minimum size variables to be used later in our flag function.
@@ -81,19 +86,21 @@ public class PoolSizeCheck extends BaseCheck
             // we are purposefully separating our if statements to have more specific instructions
             if (surfaceArea > this.maximumSize)
             {
-                return Optional.of(this.createFlag(object,
-                        String.format(
-                                "The swimming pool with OSM ID %s with a surface area of %.2f meters squared is greater than the expected maximum of %s meters squared.",
-                                object.getOsmIdentifier(), surfaceArea, this.maximumSize)));
+                return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0,
+                        object.getOsmIdentifier(), surfaceArea, this.maximumSize)));
             }
             else if (surfaceArea < this.minimumSize)
             {
-                return Optional.of(this.createFlag(object,
-                        String.format(
-                                "The swimming pool with OSM ID %s with a surface area of %.2f meters squared is smaller than the expected minimum of %s meters squared.",
-                                object.getOsmIdentifier(), surfaceArea, this.minimumSize)));
+                return Optional.of(this.createFlag(object, this.getLocalizedInstruction(1,
+                        object.getOsmIdentifier(), surfaceArea, this.minimumSize)));
             }
         }
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -1,6 +1,8 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -27,8 +29,10 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  *
  * @author mgostintsev
  */
-public class BuildingRoadIntersectionCheck extends BaseCheck
+public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
 {
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Building (id-{0}) intersects road (id-{1})");
     private static final long serialVersionUID = 5986017212661374165L;
 
     private static Predicate<Edge> ignoreTags()
@@ -121,6 +125,12 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
         return Optional.empty();
     }
 
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
     /**
      * Loops through all intersecting {@link Edge}s, and keeps track of reverse and already seen
      * intersections
@@ -140,8 +150,9 @@ public class BuildingRoadIntersectionCheck extends BaseCheck
         {
             if (!knownIntersections.contains(edge))
             {
-                flag.addObject(edge, "Building (id " + building.getOsmIdentifier()
-                        + ") intersects road (id " + edge.getOsmIdentifier() + ")");
+                flag.addObject(edge, this.getLocalizedInstruction(0, building.getOsmIdentifier(),
+                        edge.getOsmIdentifier()));
+
                 knownIntersections.add(edge);
                 if (edge.hasReverseEdge())
                 {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -29,12 +30,14 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class EdgeCrossingEdgeCheck extends BaseCheck<String>
 {
-    private static final long serialVersionUID = 2146863485833228593L;
-    private static final String INSTRUCTION_FORMAT = "The road with id %s has invalid crossings."
+    private static final String INSTRUCTION_FORMAT = "The road with id {0} has invalid crossings."
             + " If two roads are crossing each other, then they should have nodes at intersection"
             + " locations unless they are explicitly marked as crossing. Otherwise, crossing roads"
             + " should have different layer tags.";
-    private static final String INVALID_EDGE_FORMAT = "Edge %s is crossing invalidly.";
+    private static final String INVALID_EDGE_FORMAT = "Edge {0} is crossing invalidly.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_FORMAT,
+            INVALID_EDGE_FORMAT);
+    private static final long serialVersionUID = 2146863485833228593L;
 
     /**
      * Checks whether given {@link PolyLine}s can cross each other.
@@ -169,18 +172,24 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<String>
         {
             final CheckFlag newFlag = new CheckFlag(getTaskIdentifier(object));
             newFlag.addObject(object);
-            newFlag.addInstruction(String.format(INSTRUCTION_FORMAT, object.getOsmIdentifier()));
+            newFlag.addInstruction(this.getLocalizedInstruction(0, object.getOsmIdentifier()));
 
             invalidEdges.forEach(invalidEdge ->
             {
                 newFlag.addObject(invalidEdge);
                 newFlag.addInstruction(
-                        String.format(INVALID_EDGE_FORMAT, invalidEdge.getOsmIdentifier()));
+                        this.getLocalizedInstruction(1, invalidEdge.getOsmIdentifier()));
             });
 
             return Optional.of(newFlag);
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -26,13 +28,13 @@ import org.slf4j.LoggerFactory;
  */
 public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
 {
-    private static final long serialVersionUID = 2722288442633787006L;
-
-    private static final String INSTRUCTION_SHORT = "Self-intersecting polyline for feature %s";
-    private static final String INSTRUCTION_LONG = INSTRUCTION_SHORT + " at %s";
-
+    private static final String INSTRUCTION_SHORT = "Self-intersecting polyline for feature {0}";
+    private static final String INSTRUCTION_LONG = INSTRUCTION_SHORT + " at {1}";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_SHORT,
+            INSTRUCTION_LONG);
     private static final Logger logger = LoggerFactory
             .getLogger(SelfIntersectingPolylineCheck.class);
+    private static final long serialVersionUID = 2722288442633787006L;
 
     /**
      * Default constructor
@@ -93,7 +95,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
         {
             final CheckFlag flag = new CheckFlag(Long.toString(object.getIdentifier()));
             flag.addObject(object);
-            flag.addInstruction(String.format(INSTRUCTION_LONG, object.getOsmIdentifier(),
+            flag.addInstruction(this.getLocalizedInstruction(1, object.getOsmIdentifier(),
                     selfIntersections.toString()));
             selfIntersections.forEach(flag::addPoint);
             response = Optional.of(flag);
@@ -126,7 +128,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
             if (!isJtsValid)
             {
                 response = Optional.of(createFlag(object,
-                        String.format(INSTRUCTION_SHORT, object.getOsmIdentifier())));
+                        this.getLocalizedInstruction(0, object.getOsmIdentifier())));
             }
             else
             {
@@ -135,5 +137,11 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
         }
 
         return response;
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
@@ -32,6 +34,9 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     // road, anything smaller will be ignored. This can be updated through configuration and set
     // prior to runtime with a custom value.
     public static final double DISTANCE_MINIMUM_METERS_DEFAULT = 100;
+    // create a simple instruction stating the Edge with the supplied OSM Identifier is floating.
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Way '{0}' is floating. Ie. has no incoming or outgoing ways.");
     private static final long serialVersionUID = -6867668561001117411L;
     // class variable to store the maximum distance for the floating road
     private final Distance maximumDistance;
@@ -103,13 +108,18 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
                 && edge.length().isLessThanOrEqualTo(this.maximumDistance)
                 && this.hasNoConnectedEdges(edge) && this.isNotOnSyntheticBoundary(edge))
         {
-            // create a simple instruction stating the Edge with the supplied OSM Identifier is
-            // floating.
-            final String instruction = "Way '" + object.getOsmIdentifier()
-                    + "' is floating. Ie. has no incoming or outgoing ways.";
-            return Optional.of(this.createFlag(edge, instruction));
+            // return a flag created using the object and the flag that was either defined in the
+            // configuration or above.
+            return Optional.of(this.createFlag(edge,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,8 +27,11 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
 public class SharpAngleCheck extends BaseCheck<Long>
 {
     private static final double THRESHOLD_DEGREES_DEFAULT = 149.0;
+    private static final String TOO_SHARP_INSTRUCTION_1 = "Highway {0} has too sharp an angle at {1}";
+    private static final String TOO_SHARP_INSTRUCTION_2 = "Highway {0} has {1} angles that are too sharp";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(TOO_SHARP_INSTRUCTION_1,
+            TOO_SHARP_INSTRUCTION_2);
     private static final long serialVersionUID = 285618700794811828L;
-
     private final Angle threshold;
 
     /**
@@ -70,14 +74,14 @@ public class SharpAngleCheck extends BaseCheck<Long>
             if (offendingAngles.size() == 1)
             {
                 // Single offending angle - output the location.
-                checkMessage = String.format("Highway %s has too sharp an angle at %s",
-                        object.getOsmIdentifier(), offendingAngles.get(0).getSecond());
+                checkMessage = this.getLocalizedInstruction(0, object.getOsmIdentifier(),
+                        offendingAngles.get(0).getSecond());
             }
             else
             {
                 // Multiple such angles - output the total count.
-                checkMessage = String.format("Highway %s has %s angles that are too sharp",
-                        object.getOsmIdentifier(), offendingAngles.size());
+                checkMessage = this.getLocalizedInstruction(1, object.getOsmIdentifier(),
+                        offendingAngles.size());
             }
 
             final List<Location> offendingLocations = buildLocationList(offendingAngles);
@@ -85,6 +89,12 @@ public class SharpAngleCheck extends BaseCheck<Long>
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 
     private List<Location> buildLocationList(final List<Tuple<Angle, Location>> angleTuples)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -1,7 +1,9 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -29,12 +31,13 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class SinkIslandCheck extends BaseCheck<Long>
 {
-    public static final long TREE_SIZE_DEFAULT = 50;
     public static final float LOAD_FACTOR = 0.8f;
+    public static final long TREE_SIZE_DEFAULT = 50;
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Road is impossible to get out of.");
     private static final long serialVersionUID = -1432150496331502258L;
-
-    private final int treeSize;
     private final int storeSize;
+    private final int treeSize;
 
     /**
      * Default constructor
@@ -145,7 +148,13 @@ public class SinkIslandCheck extends BaseCheck<Long>
 
         // Create the flag if and only if the empty flag value is not set to false
         return emptyFlag ? Optional.empty()
-                : Optional.of(createFlag(explored, "Road is impossible to get out of."));
+                : Optional.of(createFlag(explored, this.getLocalizedInstruction(0)));
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
@@ -35,12 +37,12 @@ import org.openstreetmap.atlas.utilities.scalars.Angle;
  */
 public class SnakeRoadCheck extends BaseCheck<Long>
 {
+    private static final Angle EDGE_HEADING_DIFFERENCE_THRESHOLD = Angle.degrees(60);
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "The way with id {0} is a snake road. Consider spliting it into two or more separate ways.");
     private static final long MINIMUM_EDGES_TO_QUALIFY_AS_SNAKE_ROAD = 3;
     private static final long MINIMUM_VALENCE_TO_QUALIFY_AS_SNAKE_ROAD = 4;
-    private static final Angle EDGE_HEADING_DIFFERENCE_THRESHOLD = Angle.degrees(60);
-
     private static final long serialVersionUID = 6040648590412505891L;
-    private static final String FLAG_INSTRUCTION = "The way with id %s is a snake road. Consider spliting it into two or more separate ways.";
 
     /**
      * Validates whether a given {@link Edge} should be considered as a candidate to be part of a
@@ -107,11 +109,17 @@ public class SnakeRoadCheck extends BaseCheck<Long>
             if (networkWalkQualifiesAsSnakeRoad(walk))
             {
                 return Optional.of(createFlag(walk.getVisitedEdges(),
-                        String.format(FLAG_INSTRUCTION, object.getOsmIdentifier())));
+                        this.getLocalizedInstruction(0, object.getOsmIdentifier())));
             }
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateNodeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateNodeCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
@@ -19,7 +21,15 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
  */
 public class DuplicateNodeCheck extends BaseCheck<Location>
 {
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Duplicate Node {0} at {1}");
     private static final long serialVersionUID = 1055616456230649593L;
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
 
     /**
      * Default constructor
@@ -51,7 +61,7 @@ public class DuplicateNodeCheck extends BaseCheck<Location>
                         && dupe.getLocation().equals(node.getLocation()))
                 {
                     this.markAsFlagged(node.getLocation());
-                    return Optional.of(createFlag(object, String.format("Duplicate Node %s at %s",
+                    return Optional.of(createFlag(object, this.getLocalizedInstruction(0,
                             object.getOsmIdentifier(), node.getLocation())));
                 }
             }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/OrphanNodeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/OrphanNodeCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
@@ -14,8 +16,10 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  *
  * @author cuthbertm
  */
-public class OrphanNodeCheck extends BaseCheck
+public class OrphanNodeCheck extends BaseCheck<Long>
 {
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Node with OSM ID {0} is an orphan, no tags and not connected to any ways.");
     private static final long serialVersionUID = 7621363218174632277L;
 
     /**
@@ -59,8 +63,12 @@ public class OrphanNodeCheck extends BaseCheck
     {
 
         return Optional.of(this.createFlag(object,
-                String.format(
-                        "Node with OSM ID %s is an orphan, no tags and not connected to any ways.",
-                        object.getOsmIdentifier())));
+                this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidTurnRestrictionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidTurnRestrictionCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.relations;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -20,6 +22,8 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class InvalidTurnRestrictionCheck extends BaseCheck<Long>
 {
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "Relation ID: {0} is marked as turn restriction, but it is not a well-formed relation (i.e. it is missing required members)");
     private static final long serialVersionUID = -983698716949386657L;
 
     /**
@@ -49,8 +53,8 @@ public class InvalidTurnRestrictionCheck extends BaseCheck<Long>
         {
             final Set<AtlasObject> members = relation.members().stream()
                     .map(RelationMember::getEntity).collect(Collectors.toSet());
-            result = Optional.of(createFlag(members, "Relation ID: " + relation.getOsmIdentifier()
-                    + " is marked as turn restriction, but it is not a well-formed relation (i.e. it is missing required members)"));
+            result = Optional.of(createFlag(members,
+                    this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
         }
         else
         {
@@ -58,6 +62,12 @@ public class InvalidTurnRestrictionCheck extends BaseCheck<Long>
         }
 
         return result;
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/checks/BaseTestCheck.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/checks/BaseTestCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.base.checks;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
@@ -48,6 +50,12 @@ public class BaseTestCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        return Optional.of(this.createFlag(object, "Default Instruction"));
+        return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0)));
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return Arrays.asList("Default Instruction");
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/checks/CheckResourceLoaderTestCheck.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/checks/CheckResourceLoaderTestCheck.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.checks.base.checks;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
@@ -50,6 +51,12 @@ public class CheckResourceLoaderTestCheck extends BaseCheck<Long>
      */
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        return null;
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
     {
         return null;
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/checks/PierTestCheck.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/checks/PierTestCheck.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.base.checks;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -57,6 +59,12 @@ public class PierTestCheck extends BaseCheck<Long>
     {
         final Map<String, String> tags = object.getTags();
         tags.computeIfPresent(HighwayTag.KEY, (key, value) -> "primary");
-        return Optional.of(this.createFlag(object, "test"));
+        return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0)));
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return Arrays.asList("test");
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
@@ -15,6 +16,9 @@ public class BuildingRoadIntersectionCheckTest
 
     private static final BuildingRoadIntersectionCheck check = new BuildingRoadIntersectionCheck(
             ConfigurationResolver.emptyConfiguration());
+    private static final BuildingRoadIntersectionCheck spanishCheck = new BuildingRoadIntersectionCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"CheckResourceLoader\": {\"scanUrls\": [\"org.openstreetmap.atlas.checks\"]},\"BuildingRoadIntersectionCheck\":{\"enabled\":true,\"locale\":\"es\",\"flags\":{\"en\":[\"Building (id-{0}) intersects road (id-{1})\"],\"es\":[\"Edificio(id-{0}) cruza calle(id-{0})\"]}}}"));
 
     @Rule
     public BuildingRoadIntersectionTestCaseRule setup = new BuildingRoadIntersectionTestCaseRule();
@@ -42,6 +46,21 @@ public class BuildingRoadIntersectionCheckTest
     {
         this.verifier.actual(this.setup.getCoveredAtlas(), check);
         this.verifier.verifyExpectedSize(0);
+    }
+
+    /**
+     * Test to confirm the locality functionality of the check. Changing the instruction to spanish.
+     */
+    @Test
+    public void testSpanishCheck()
+    {
+        this.verifier.actual(this.setup.getAtlas(), spanishCheck);
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions().contains("Edificio(id-0) cruza calle(id-0)"));
+        });
+        this.verifier.verifyExpectedSize(2);
+
     }
 
     /**


### PR DESCRIPTION
An example configuration
```
"BuildingRoadIntersectionCheck":
{
"enabled":true,
  "locale":"es",
  "flags":{
    "en":["Building (id-{0}) intersects road (id-{1})"],
    "es":["Edificio(id-{0}) cruza calle(id-{1})"]
  }
}
```
Results in Instructions like:
"1. Edificio(id-465465839) cruza calle(id-443627253)"

Where a configuration like this:
```
"BuildingRoadIntersectionCheck":
{
"enabled":true,
  "locale":"en",
  "flags":{
    "en":["Building (id-{0}) intersects road (id-{1})"],
    "es":["Edificio(id-{0}) cruza calle(id-{1})"]
  }
}
```
If no flags are provided in the configuration then `getLocalizedInstruction(int, Object…)` in BaseCheck will return the instruction provided by `getFallbackInstructructions()`. If a specific language set of instructions does not have all instructions then the fallback instructions will be used. If the specified language does not have instructions at all, then the default language instructions will be used. Default Locale (as specified by language) currently set to English. 

When there are multiple Instructions, they are all added to a list whose key is the two letter language abbreviation(as seen above). Instructions that have the same meaning in different languages should be in the same spot of the list for all languages. The instructions themselves are formatted using the MessageFormat class, where the number in the bracket refers to an index in an varargs object array passed to the `getLocalizedInstruction(int, Object…)` method.

Note: Many changes are simply IDE formatting.