### PR TITLE
Fixed ID formatting

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PoolSizeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PoolSizeCheck.java
@@ -28,8 +28,8 @@ public class PoolSizeCheck extends BaseCheck<Long>
     // A 5 meter squared pool if a circle would only be roughly 2 meters in diameter.
     public static final double MINIMUM_SIZE_DEFAULT = 5;
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            "The swimming pool with OSM ID {0} with a surface area of {1,number,#.##} meters squared is greater than the expected maximum of {2} meters squared.",
-            "The swimming pool with OSM ID {0} with a surface area of {1,number,#.##} meters squared is smaller than the expected minimum of {2} meters squared.");
+            "The swimming pool with OSM ID {0,number,#} with a surface area of {1,number,#.##} meters squared is greater than the expected maximum of {2} meters squared.",
+            "The swimming pool with OSM ID {0,number,#} with a surface area of {1,number,#.##} meters squared is smaller than the expected minimum of {2} meters squared.");
     // You can use serialver to regenerate the serial UID.
     private static final long serialVersionUID = 1L;
     // Create maximum and minimum size variables to be used later in our flag function.

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -32,7 +32,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
 {
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("Building (id-{0}) intersects road (id-{1})");
+            .asList("Building (id-{0,number,#}) intersects road (id-{1,number,#})");
     private static final long serialVersionUID = 5986017212661374165L;
 
     private static Predicate<Edge> ignoreTags()

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -30,11 +30,11 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class EdgeCrossingEdgeCheck extends BaseCheck<String>
 {
-    private static final String INSTRUCTION_FORMAT = "The road with id {0} has invalid crossings."
+    private static final String INSTRUCTION_FORMAT = "The road with id {0,number,#} has invalid crossings."
             + " If two roads are crossing each other, then they should have nodes at intersection"
             + " locations unless they are explicitly marked as crossing. Otherwise, crossing roads"
             + " should have different layer tags.";
-    private static final String INVALID_EDGE_FORMAT = "Edge {0} is crossing invalidly.";
+    private static final String INVALID_EDGE_FORMAT = "Edge {0,number,#} is crossing invalidly.";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_FORMAT,
             INVALID_EDGE_FORMAT);
     private static final long serialVersionUID = 2146863485833228593L;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
 {
-    private static final String INSTRUCTION_SHORT = "Self-intersecting polyline for feature {0}";
+    private static final String INSTRUCTION_SHORT = "Self-intersecting polyline for feature {0,number,#}";
     private static final String INSTRUCTION_LONG = INSTRUCTION_SHORT + " at {1}";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_SHORT,
             INSTRUCTION_LONG);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -36,7 +36,7 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     public static final double DISTANCE_MINIMUM_METERS_DEFAULT = 100;
     // create a simple instruction stating the Edge with the supplied OSM Identifier is floating.
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("Way '{0}' is floating. Ie. has no incoming or outgoing ways.");
+            .asList("Way '{0,number,#}' is floating. Ie. has no incoming or outgoing ways.");
     private static final long serialVersionUID = -6867668561001117411L;
     // class variable to store the maximum distance for the floating road
     private final Distance maximumDistance;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
@@ -27,8 +27,8 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
 public class SharpAngleCheck extends BaseCheck<Long>
 {
     private static final double THRESHOLD_DEGREES_DEFAULT = 149.0;
-    private static final String TOO_SHARP_INSTRUCTION_1 = "Highway {0} has too sharp an angle at {1}";
-    private static final String TOO_SHARP_INSTRUCTION_2 = "Highway {0} has {1} angles that are too sharp";
+    private static final String TOO_SHARP_INSTRUCTION_1 = "Highway {0,number,#} has too sharp an angle at {1}";
+    private static final String TOO_SHARP_INSTRUCTION_2 = "Highway {0,number,#} has {1} angles that are too sharp";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(TOO_SHARP_INSTRUCTION_1,
             TOO_SHARP_INSTRUCTION_2);
     private static final long serialVersionUID = 285618700794811828L;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
@@ -39,7 +39,7 @@ public class SnakeRoadCheck extends BaseCheck<Long>
 {
     private static final Angle EDGE_HEADING_DIFFERENCE_THRESHOLD = Angle.degrees(60);
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            "The way with id {0} is a snake road. Consider spliting it into two or more separate ways.");
+            "The way with id {0,number,#} is a snake road. Consider spliting it into two or more separate ways.");
     private static final long MINIMUM_EDGES_TO_QUALIFY_AS_SNAKE_ROAD = 3;
     private static final long MINIMUM_VALENCE_TO_QUALIFY_AS_SNAKE_ROAD = 4;
     private static final long serialVersionUID = 6040648590412505891L;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateNodeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateNodeCheck.java
@@ -22,7 +22,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 public class DuplicateNodeCheck extends BaseCheck<Location>
 {
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("Duplicate Node {0} at {1}");
+            .asList("Duplicate Node {0,number,#} at {1}");
     private static final long serialVersionUID = 1055616456230649593L;
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/OrphanNodeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/OrphanNodeCheck.java
@@ -18,8 +18,8 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class OrphanNodeCheck extends BaseCheck<Long>
 {
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("Node with OSM ID {0} is an orphan, no tags and not connected to any ways.");
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "Node with OSM ID {0,number,#} is an orphan, no tags and not connected to any ways.");
     private static final long serialVersionUID = 7621363218174632277L;
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidTurnRestrictionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidTurnRestrictionCheck.java
@@ -23,7 +23,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 public class InvalidTurnRestrictionCheck extends BaseCheck<Long>
 {
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            "Relation ID: {0} is marked as turn restriction, but it is not a well-formed relation (i.e. it is missing required members)");
+            "Relation ID: {0,number,#} is marked as turn restriction, but it is not a well-formed relation (i.e. it is missing required members)");
     private static final long serialVersionUID = -983698716949386657L;
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/AbbreviatedNameCheck.java
@@ -32,7 +32,7 @@ public class AbbreviatedNameCheck extends BaseCheck<String>
     // Abbreviation config
     private static final String ABBREVIATION_KEY = "abbreviations";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            "OSM feature with id {0}'s name tag (`name` = **{1}**) has an abbreviation. Please update the `name` tag to not use abbreviation.");
+            "OSM feature with id {0,number,#}'s name tag (`name` = **{1}**) has an abbreviation. Please update the `name` tag to not use abbreviation.");
     // Splitter to parse name
     private static final Splitter NAME_SPLITTER = Splitter
             .on(CharMatcher.JAVA_LETTER_OR_DIGIT.negate()).omitEmptyStrings();


### PR DESCRIPTION
MessageFormat by default formats all `long` types with comma seperated thousands, which is an incorrect representation of an OSM ID. Changed the instruction formats to specify the formatting of any OSM IDs. 