### PR TITLE
Configuration overrides for countries and groups of countries in Integrity Checks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017, Apple Inc. All rights reserved.
+Copyright (c) 2015-2018, Apple Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:  

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.0.3',
+    atlas: '5.0.8',
     commons:'2.6',
     atlas_generator: '4.0.0',
 ]

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -5,12 +5,18 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.maps.MultiMap;
 import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,19 +44,20 @@ import com.google.common.reflect.ClassPath;
  * </pre>
  *
  * @author brian_l_davis
+ * @author jklamer
  */
 public class CheckResourceLoader
 {
     private static final String DEFAULT_ENABLED_KEY_TEMPLATE = "%s.enabled";
-    private static final Logger logger = LoggerFactory.getLogger(CheckResourceLoader.class);
     private static final String DEFAULT_PACKAGE = "org.openstreetmap.atlas.checks";
     private static final String DEFAULT_TYPE = Check.class.getName();
-
-    private final Configuration configuration;
+    private static final Logger logger = LoggerFactory.getLogger(CheckResourceLoader.class);
     private final Class<?> checkType;
-    private final Set<String> packages;
+    private final Configuration configuration;
+    private final MultiMap<String, String> countryGroups = new MultiMap<>();
     private final Boolean enabledByDefault;
     private final String enabledKeyTemplate;
+    private final Set<String> packages;
 
     /**
      * Default constructor
@@ -64,6 +71,12 @@ public class CheckResourceLoader
         this.packages = Collections.unmodifiableSet(Iterables.asSet((Iterable<String>) configuration
                 .get("CheckResourceLoader.scanUrls", Collections.singletonList(DEFAULT_PACKAGE))
                 .value()));
+        final Map<String, List<String>> groupCountries = configuration
+                .get("groups", Collections.emptyMap()).value();
+        groupCountries.keySet().forEach(group ->
+        {
+            groupCountries.get(group).forEach(country -> this.countryGroups.add(country, group));
+        });
 
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         try
@@ -83,16 +96,42 @@ public class CheckResourceLoader
         this.configuration = configuration;
     }
 
-    /**
-     * Loads checks that are enabled by configuration
-     *
-     * @param <T>
-     *            check type
-     * @return a {@link Set} of checks
-     */
-    public <T extends Check> Set<T> loadChecks()
+    public Configuration getConfiguration()
     {
-        return loadChecks(this::isEnabledByConfiguration);
+        return this.configuration;
+    }
+
+    /**
+     * Get configuration for a specific country, overriding for country specific overrides and group
+     * specific overrides
+     *
+     * @param country
+     *            country string
+     * @return {@link Configuration}
+     */
+    public Configuration getConfigurationForCountry(final String country)
+    {
+        Configuration specializedConfiguration = this.configuration
+                .configurationForKeyword(country);
+
+        if (this.countryGroups.containsKey(country))
+        {
+            for (final String group : this.countryGroups.get(country))
+            {
+                specializedConfiguration = specializedConfiguration.configurationForKeyword(group);
+            }
+        }
+        return specializedConfiguration;
+    }
+
+    public <T extends Check> Set<T> loadChecks(final Predicate<Class> isEnabled)
+    {
+        return loadChecks(isEnabled, this.configuration);
+    }
+
+    public <T extends Check> Set<T> loadChecks(final Configuration configuration)
+    {
+        return loadChecks(this::isEnabledByConfiguration, configuration);
     }
 
     /**
@@ -100,12 +139,16 @@ public class CheckResourceLoader
      *
      * @param isEnabled
      *            {@link Predicate} used to determine if a check is enabled
+     * @param specificConfiguration
+     *            {@link Configuration} used to loadChecks if not the one used to initialize
+     *            {@link CheckResourceLoader}
      * @param <T>
      *            check type
      * @return a {@link Set} of checks
      */
     @SuppressWarnings("unchecked")
-    public <T extends Check> Set<T> loadChecks(final Predicate<Class> isEnabled)
+    public <T extends Check> Set<T> loadChecks(final Predicate<Class> isEnabled,
+            final Configuration specificConfiguration)
     {
         final Set<T> checks = new HashSet<>();
         final Time time = Time.now();
@@ -127,7 +170,7 @@ public class CheckResourceLoader
                                 try
                                 {
                                     check = checkClass.getConstructor(Configuration.class)
-                                            .newInstance(configuration);
+                                            .newInstance(specificConfiguration);
                                 }
                                 catch (final InvocationTargetException oops)
                                 {
@@ -163,6 +206,32 @@ public class CheckResourceLoader
         logger.info("Loaded {} {} in {}", checks.size(), checkType.getSimpleName(),
                 time.elapsedSince());
         return checks;
+    }
+
+    /**
+     * Loads checks that are enabled by configuration
+     *
+     * @param <T>
+     *            check type
+     * @return a {@link Set} of checks
+     */
+    public <T extends Check> Set<T> loadChecks()
+    {
+        return loadChecks(this::isEnabledByConfiguration, this.configuration);
+    }
+
+    public <T extends Check> Map<String, Set<T>> loadChecksForCountries(
+            final Predicate<Class> isEnabled, final Iterable<String> countries)
+    {
+        return StreamSupport.stream(countries.spliterator(), false).collect(Collectors.toMap(
+                Function.identity(),
+                country -> loadChecks(isEnabled, this.getConfigurationForCountry(country))));
+    }
+
+    public <T extends Check> Map<String, Set<T>> loadChecksForCountries(
+            final Iterable<String> countries)
+    {
+        return loadChecksForCountries(this::isEnabledByConfiguration, countries);
     }
 
     private boolean isEnabledByConfiguration(final Class checkClass)

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -71,11 +71,11 @@ public class CheckResourceLoader
         this.packages = Collections.unmodifiableSet(Iterables.asSet((Iterable<String>) configuration
                 .get("CheckResourceLoader.scanUrls", Collections.singletonList(DEFAULT_PACKAGE))
                 .value()));
-        final Map<String, List<String>> groupCountries = configuration
-                .get("groups", Collections.emptyMap()).value();
-        groupCountries.keySet().forEach(group ->
+        final Map<String, List<String>> groups = configuration.get("groups", Collections.emptyMap())
+                .value();
+        groups.keySet().forEach(group ->
         {
-            groupCountries.get(group).forEach(country -> this.countryGroups.add(country, group));
+            groups.get(group).forEach(country -> this.countryGroups.add(country, group));
         });
 
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
@@ -204,10 +204,6 @@ public class IntegrityCheckSparkJob extends SparkJob
             return;
         }
 
-        // Load checks
-        final Map<String, Set<BaseCheck>> checksToExecutePerCountry = checkLoader
-                .loadChecksForCountries(countries);
-
         // Read priority countries from the configuration
         final List<String> priorityCountries = checksConfiguration
                 .get("priority.countries", Collections.EMPTY_LIST).value();
@@ -216,12 +212,12 @@ public class IntegrityCheckSparkJob extends SparkJob
         // Add priority countries first if they are supplied by parameter
         final List<Tuple2<String, Set<BaseCheck>>> countryCheckTuples = new ArrayList<>();
         countries.stream().filter(priorityCountries::contains).forEach(country -> countryCheckTuples
-                .add(new Tuple2<>(country, checksToExecutePerCountry.get(country))));
+                .add(new Tuple2<>(country, checkLoader.loadChecksForCountry(country))));
 
         // Then add the rest of the countries
         countries.stream().filter(country -> !priorityCountries.contains(country))
                 .forEach(country -> countryCheckTuples
-                        .add(new Tuple2<>(country, checksToExecutePerCountry.get(country))));
+                        .add(new Tuple2<>(country, checkLoader.loadChecksForCountry(country))));
 
         // Log countries and integrity
         logger.info("Initialized countries: {}", countryCheckTuples.stream().map(tuple -> tuple._1)

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
@@ -70,35 +70,39 @@ public class IntegrityCheckSparkJob extends SparkJob
     private static final Switch<String> COUNTRIES = new Switch<>("countries",
             "Comma-separated list of country ISO3 codes to be processed", StringConverter.IDENTITY,
             Optionality.REQUIRED);
-    // Indicator key for ignored countries
-    private static final String IGNORED_KEY = "Ignored";
-    private static final String INTERMEDIATE_ATLAS_EXTENSION = FileSuffix.ATLAS.toString()
-            + FileSuffix.GZIP.toString();
     private static final Switch<MapRouletteConfiguration> MAP_ROULETTE = new Switch<>("maproulette",
             "Map roulette server information, format <Host>:<Port>:<ProjectName>:<ApiKey>, projectName is optional.",
             MapRouletteConfiguration::parse, Optionality.OPTIONAL);
-    private static final String METRICS_FILENAME = "check-run-time.csv";
-    private static final String OUTPUT_ATLAS_FOLDER = "atlas";
-    // Outputs
-    private static final String OUTPUT_FLAG_FOLDER = "flag";
-    private static final Switch<Set<OutputFormats>> OUTPUT_FORMATS = new Switch<>("outputFormats",
-            String.format("Comma-separated list of output formats (flags, metrics, geojson)."),
-            csv_formats -> Stream.of(csv_formats.split(","))
-                    .map(format -> Enum.valueOf(OutputFormats.class, format.toUpperCase()))
-                    .collect(Collectors.toSet()),
-            Optionality.OPTIONAL, "flags,metrics");
-    private static final String OUTPUT_GEOJSON_FOLDER = "geojson";
-    private static final String OUTPUT_METRIC_FOLDER = "metric";
     private static final Switch<Rectangle> PBF_BOUNDING_BOX = new Switch<>("pbfBoundingBox",
             "OSM protobuf data will be loaded only in this bounding box", Rectangle::forString,
             Optionality.OPTIONAL);
     private static final Switch<Boolean> PBF_SAVE_INTERMEDIATE_ATLAS = new Switch<>("savePbfAtlas",
             "Saves intermediate atlas files created when processing OSM protobuf data.",
             Boolean::valueOf, Optionality.OPTIONAL, "false");
-    // Thread pool settings
-    private static final Duration POOL_DURATION_BEFORE_KILL = Duration.minutes(300);
+    private static final Switch<Set<OutputFormats>> OUTPUT_FORMATS = new Switch<>("outputFormats",
+            String.format("Comma-separated list of output formats (flags, metrics, geojson)."),
+            csv_formats -> Stream.of(csv_formats.split(","))
+                    .map(format -> Enum.valueOf(OutputFormats.class, format.toUpperCase()))
+                    .collect(Collectors.toSet()),
+            Optionality.OPTIONAL, "flags,metrics");
+
+    // Indicator key for ignored countries
+    private static final String IGNORED_KEY = "Ignored";
+
+    // Outputs
+    private static final String OUTPUT_FLAG_FOLDER = "flag";
+    private static final String OUTPUT_GEOJSON_FOLDER = "geojson";
+    private static final String OUTPUT_ATLAS_FOLDER = "atlas";
+    private static final String INTERMEDIATE_ATLAS_EXTENSION = FileSuffix.ATLAS.toString()
+            + FileSuffix.GZIP.toString();
+    private static final String OUTPUT_METRIC_FOLDER = "metric";
+    private static final String METRICS_FILENAME = "check-run-time.csv";
+
     private static final Logger logger = LoggerFactory.getLogger(IntegrityCheckSparkJob.class);
     private static final long serialVersionUID = 2990087219645942330L;
+
+    // Thread pool settings
+    private static final Duration POOL_DURATION_BEFORE_KILL = Duration.minutes(300);
 
     /**
      * Main entry point for the Spark job

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -1,11 +1,15 @@
 package org.openstreetmap.atlas.checks.base;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.base.checks.CheckResourceLoaderTestCheck;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
@@ -16,17 +20,35 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 public class CheckResourceLoaderTest
 {
     /**
-     * Test to make sure that by explicitly setting the enabled function for a check that it is in
-     * actual fact enabled.
+     * Test the check loading using country keyword specific configurations. Assert that each
+     * country gets its own version of the check.
      */
     @Test
-    public void testEnabledByConfiguration()
+    public void testCountryKeywordCheckLoading()
     {
-        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck.enabled\": true}";
-
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true,\"var1\":1,\"override.ABC.var1\":2}}";
+        final String country1 = "ABC";
+        final String country2 = "XYZ";
+        final List<String> countries = Arrays.asList(country1, country2);
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
-        final Set<Check> loaded = new CheckResourceLoader(configuration).loadChecks();
-        Assert.assertEquals(1, loaded.size());
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+        final Map<String, Set<Check>> loaded = checkResourceLoader
+                .loadChecksForCountries(countries);
+
+        // assert both countries loaded with different check sets
+        Assert.assertNotNull(loaded.get(country1));
+        Assert.assertNotNull(loaded.get(country2));
+        Assert.assertEquals(1, loaded.get(country1).size());
+        Assert.assertEquals(1, loaded.get(country2).size());
+        Assert.assertFalse(Iterables.equals(loaded.get(country1), loaded.get(country2)));
+
+        // assert both configurations overrode properly and thus initialized properly
+        final long country1Var1 = checkResourceLoader.getConfigurationForCountry(country1)
+                .get("CheckResourceLoaderTestCheck.var1").value();
+        final long country2Var2 = checkResourceLoader.getConfigurationForCountry(country2)
+                .get("CheckResourceLoaderTestCheck.var1").value();
+        Assert.assertEquals(country1Var1, 2);
+        Assert.assertEquals(country2Var2, 1);
     }
 
     /**
@@ -44,6 +66,20 @@ public class CheckResourceLoaderTest
     }
 
     /**
+     * Test to make sure that by explicitly setting the enabled function for a check that it is in
+     * actual fact enabled.
+     */
+    @Test
+    public void testEnabledByConfiguration()
+    {
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck.enabled\": true}";
+
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final Set<Check> loaded = new CheckResourceLoader(configuration).loadChecks();
+        Assert.assertEquals(1, loaded.size());
+    }
+
+    /**
      * Test to make sure that if the default behaviour (set in configuration) is that checks are
      * enabled, that the checks are loaded when not setting any explicitly.
      */
@@ -56,5 +92,43 @@ public class CheckResourceLoaderTest
         final Set<Check> loaded = new CheckResourceLoader(configuration)
                 .loadChecks(CheckResourceLoaderTestCheck.class::equals);
         Assert.assertEquals(1, loaded.size());
+    }
+
+    /**
+     * Test Grouped country overrides
+     */
+    @Test
+    public void testGroupedCountryCheckLoading()
+    {
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"groups\":{\"beginningAlphabet\":[\"ABC\",\"DEF\"],\"alphabetEnds\":[\"ABC\",\"XYZ\"]},\"CheckResourceLoaderTestCheck\":{\"enabled\": true,\"var1\":1,\"var2\":\"Hi\",\"override.beginningAlphabet.var1\":2,\"override.alphabetEnds.var2\":\"Bye\"}}";
+        final String country1 = "ABC";
+        final String country2 = "DEF";
+        final String country3 = "XYZ";
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+
+        // assert first group override worked for all 3 countries
+        final long country1Var1 = checkResourceLoader.getConfigurationForCountry(country1)
+                .get("CheckResourceLoaderTestCheck.var1").value();
+        final long country2Var1 = checkResourceLoader.getConfigurationForCountry(country2)
+                .get("CheckResourceLoaderTestCheck.var1").value();
+        final long country3Var1 = checkResourceLoader.getConfigurationForCountry(country3)
+                .get("CheckResourceLoaderTestCheck.var1").value();
+
+        Assert.assertEquals(2, country1Var1);
+        Assert.assertEquals(2, country2Var1);
+        Assert.assertEquals(1, country3Var1);
+
+        // assert second group override worked for all 3 countries
+        final String country1Var2 = checkResourceLoader.getConfigurationForCountry(country1)
+                .get("CheckResourceLoaderTestCheck.var2").value();
+        final String country2Var2 = checkResourceLoader.getConfigurationForCountry(country2)
+                .get("CheckResourceLoaderTestCheck.var2").value();
+        final String country3Var2 = checkResourceLoader.getConfigurationForCountry(country3)
+                .get("CheckResourceLoaderTestCheck.var2").value();
+
+        Assert.assertEquals("Bye", country1Var2);
+        Assert.assertEquals("Hi", country2Var2);
+        Assert.assertEquals("Bye", country3Var2);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -2,7 +2,6 @@ package org.openstreetmap.atlas.checks.base;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -32,15 +31,15 @@ public class CheckResourceLoaderTest
         final List<String> countries = Arrays.asList(country1, country2);
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
-        final Map<String, Set<Check>> loaded = checkResourceLoader
-                .loadChecksForCountries(countries);
+        final Set<Check> loadedCountry1Checks = checkResourceLoader.loadChecksForCountry(country1);
+        final Set<Check> loadedCountry2Checks = checkResourceLoader.loadChecksForCountry(country2);
 
         // assert both countries loaded with different check sets
-        Assert.assertNotNull(loaded.get(country1));
-        Assert.assertNotNull(loaded.get(country2));
-        Assert.assertEquals(1, loaded.get(country1).size());
-        Assert.assertEquals(1, loaded.get(country2).size());
-        Assert.assertFalse(Iterables.equals(loaded.get(country1), loaded.get(country2)));
+        Assert.assertNotNull(loadedCountry1Checks);
+        Assert.assertNotNull(loadedCountry2Checks);
+        Assert.assertEquals(1, loadedCountry1Checks.size());
+        Assert.assertEquals(1, loadedCountry2Checks.size());
+        Assert.assertFalse(Iterables.equals(loadedCountry1Checks, loadedCountry2Checks));
 
         // assert both configurations overrode properly and thus initialized properly
         final long country1Var1 = checkResourceLoader.getConfigurationForCountry(country1)


### PR DESCRIPTION
The PR utilizes keyword overrides to create per country/group configuration options. The check resource loader initializes a set of checks for every country using a configuration specific to the countries overrides and the groups overrides.

The new group interaction can be found as an example below

```
{
  "CheckResourceLoader.scanUrls": ["org.openstreetmap.atlas.checks.base.checks"],
  "groups":{
    "beginningAlphabet":["ABC","DEF"],
    "alphabetEnds":["ABC","XYZ"]
  },
  "CheckResourceLoaderTestCheck":{
    "enabled": true,
    "var1":1,"var2":"Hi",
    "override.beginningAlphabet.var1":2,
    "override.alphabetEnds.var2":"Bye"
    }
}
```
The above configuration will override var1 for ABC and DEF, and var2 for ABC and XYZ. The test can be found in the PR.

**Dependent on https://github.com/osmlab/atlas/pull/77**