### PR TITLE
SelfIntersectingPolylineCheck enhancements

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -95,7 +95,7 @@
     }
   },
   "SelfIntersectingPolylineCheck": {
-    "tags.filter": "highway->*|waterway->*|building->*",
+    "tags.filter":"highway->!proposed&highway->!construction&highway->!footway&highway->!path",
     "challenge": {
       "description": "Verify that the same Polyline does not intersect itself at any point.",
       "blurb": "Modify Polylines such that they do not self intersect.",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -95,7 +95,7 @@
     }
   },
   "SelfIntersectingPolylineCheck": {
-    "tags.filter":"highway->!proposed&highway->!construction&highway->!footway&highway->!path",
+    "tags.filter":"highway->*&highway->!construction&highway->!footway&highway->!path|building->*",
     "challenge": {
       "description": "Verify that the same Polyline does not intersect itself at any point.",
       "blurb": "Modify Polylines such that they do not self intersect.",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
@@ -20,8 +19,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
-import org.openstreetmap.atlas.tags.HighwayTag;
-import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.tags.WaterwayTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
@@ -45,12 +42,6 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
             + "Edge at {1}";
     private static final String POLYLINE_INSTRUCTION = "Self-intersecting polyline for feature "
             + "{0,number,#} at {1}";
-    // Excluded Highway tags
-    private static final Predicate<Taggable> INELIGIBLE_HIGHWAY_TAGS = object -> Validators
-            .isOfType(object, HighwayTag.class, HighwayTag.PROPOSED)
-            || Validators.isOfType(object, HighwayTag.class, HighwayTag.CONSTRUCTION)
-            || Validators.isOfType(object, HighwayTag.class, HighwayTag.FOOTWAY)
-            || Validators.isOfType(object, HighwayTag.class, HighwayTag.PATH);
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(POLYLINE_INSTRUCTION,
             AREA_INSTRUCTION, POLYLINE_BUILDING_INSTRUCTION, DUPLICATE_EDGE_INSTRUCTION);
     private static final Logger logger = LoggerFactory
@@ -84,14 +75,13 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
     public boolean validCheckForObject(final AtlasObject object)
     {
         // Master edges excluding ineligible highway tags
-        return ((object instanceof Edge && ((Edge) object).isMasterEdge()
-                && !INELIGIBLE_HIGHWAY_TAGS.test(object))
+        return object instanceof Edge && ((Edge) object).isMasterEdge()
                 // Areas
-                || (object instanceof Area)
+                || object instanceof Area
                 // Lines excluding ineligible highway tags
-                || (object instanceof Line && !INELIGIBLE_HIGHWAY_TAGS.test(object)))
-                // Exclude waterway tags
-                && !Validators.hasValuesFor(object, WaterwayTag.class);
+                || object instanceof Line
+                        // Exclude waterway tags
+                        && !Validators.hasValuesFor(object, WaterwayTag.class);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -118,7 +118,6 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
             polyline = ((Area) object).asPolygon();
             // Send duplicate Edge instructions if duplicate Edges exist
             localizedInstructionIndex = hasDuplicateEdges(polyline) ? THREE : 1;
-
         }
         else
         {
@@ -183,7 +182,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
     }
 
     /**
-     * Returns true if adjacent {@link Edge} have identical lat,lng sequences
+     * Returns true if adjacent {@link Edge} has identical lat,lng sequences
      *
      * @param polyline
      *            the {@link PolyLine} being examined

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -33,11 +33,12 @@ import org.slf4j.LoggerFactory;
  * {@link Edge}s and {@link Line}s. Both shape point and non-shape point intersections are flagged.
  *
  * @author mgostintsev
+ * @author dbaah
  */
 public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
 {
     private static final String AREA_INSTRUCTION = "Feature {0,number,#} has invalid geometry at {1}";
-    private static final String AREA_BUILDING_INSTRUCTION = "Feature {0,number,#} is a incomplete "
+    private static final String POLYLINE_BUILDING_INSTRUCTION = "Feature {0,number,#} is a incomplete "
             + "building at {1}";
 
     private static final String DUPLICATE_EDGE_INSTRUCTION = "Feature {0,number,#} has a duplicate "
@@ -51,7 +52,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
             || Validators.isOfType(object, HighwayTag.class, HighwayTag.FOOTWAY)
             || Validators.isOfType(object, HighwayTag.class, HighwayTag.PATH);
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(POLYLINE_INSTRUCTION,
-            AREA_INSTRUCTION, AREA_BUILDING_INSTRUCTION, DUPLICATE_EDGE_INSTRUCTION);
+            AREA_INSTRUCTION, POLYLINE_BUILDING_INSTRUCTION, DUPLICATE_EDGE_INSTRUCTION);
     private static final Logger logger = LoggerFactory
             .getLogger(SelfIntersectingPolylineCheck.class);
     public static final Integer THREE = 3;
@@ -182,11 +183,11 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
     }
 
     /**
-     * Returns true if adjacent Edges have identical lat,lng sequences
+     * Returns true if adjacent {@link Edge} have identical lat,lng sequences
      *
      * @param polyline
-     *            the geometry being examined
-     * @return true if the any set of adjacent edges have identical geometries
+     *            the {@link PolyLine} being examined
+     * @return {@code true} if the any set of adjacent edges have identical geometries
      */
     private boolean hasDuplicateEdges(final PolyLine polyline)
     {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -26,7 +26,7 @@ public class SelfIntersectingPolyLineCheckTest
     public void testCheck()
     {
         this.verifier.actual(this.setup.getAtlas(), check);
-        this.verifier.verifyExpectedSize(6);
+        this.verifier.verifyExpectedSize(9);
         this.verifier.verify(flag ->
         {
             Assert.assertTrue(

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
@@ -24,17 +23,100 @@ public class SelfIntersectingPolyLineCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     @Test
-    public void testCheck()
+    public void testValidLineNoSelfIntersection()
     {
-        this.verifier.actual(this.setup.getAtlas(), check);
-        this.verifier.verifyExpectedSize(9);
-        this.verifier.verify(flag ->
-        {
-            Assert.assertTrue(
-                    this.setup.getInvalidAtlasEntityIdentifiers().contains(flag.getIdentifier()));
-            Assert.assertFalse(
-                    this.setup.getValidAtlasEntityIdentifiers().contains(flag.getIdentifier()));
-        });
+        this.verifier.actual(this.setup.getValidLineNoSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(0);
     }
 
+    @Test
+    public void testInvalidLineNonShapeSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidLineNonShapeSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidLineShapePointSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidLineShapePointSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidLineGeometryWaterwayTag()
+    {
+        this.verifier.actual(this.setup.getInvalidLineGeometryWaterwayTag(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidLineGeometryHighwayFootwayTag()
+    {
+        this.verifier.actual(this.setup.getInvalidLineGeometryHighwayFootwayTag(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testValidEdgeNoSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getValidEdgeNoSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidEdgeNonShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeNonShapeIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeGeometryHighwayPrimaryTag()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeGeometryHighwayPrimaryTag(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeGeometryBuildingTag()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeGeometryBuildingTag(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testValidAreaNoSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getValidAreaNoSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidAreaNonShapeSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidAreaNonShapeSelfIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidAreaShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidAreaShapeIntersection(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidAreaBuildTag()
+    {
+        this.verifier.actual(this.setup.getInvalidAreaBuildingTag(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -13,8 +13,9 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  */
 public class SelfIntersectingPolyLineCheckTest
 {
-    private static final SelfIntersectingPolylineCheck check = new SelfIntersectingPolylineCheck(
-            ConfigurationResolver.emptyConfiguration());
+    private final SelfIntersectingPolylineCheck check = new SelfIntersectingPolylineCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"SelfIntersectingPolylineCheck\":{\"tags.filter\":\"highway->!proposed&highway->!construction&highway->!footway&highway->!path\"}}"));
 
     @Rule
     public SelfIntersectingPolylineTestCaseRule setup = new SelfIntersectingPolylineTestCaseRule();

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
@@ -21,13 +21,18 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
 {
     public static final String VALID_EDGE_ID = "101740465";
     public static final String VALID_LINE_ID = "102740465";
+    public static final String VALID_LINE_ID_2 = "10283065";
+    public static final String VALID_LINE_ID_3 = "10284065";
     public static final String VALID_AREA_ID = "103740465";
     public static final String INVALID_EDGE_ID_1 = "104740465";
     public static final String INVALID_EDGE_ID_2 = "105540465";
+    public static final String INVALID_EDGE_ID_3 = "105640465";
+    public static final String INVALID_EDGE_ID_4 = "105740465";
     public static final String INVALID_LINE_ID_1 = "106740465";
     public static final String INVALID_LINE_ID_2 = "107740465";
     public static final String INVALID_AREA_ID_1 = "108740465";
     public static final String INVALID_AREA_ID_2 = "109740465";
+    public static final String INVALID_AREA_ID_3 = "109840465";
     private static final String ONE = "-0.8385242, -80.4892702";
     private static final String TWO = "-0.8385546, -80.4891487";
     private static final String THREE = "-0.8386005, -80.4892233";
@@ -53,7 +58,15 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
                     // Invalid Line with a shape-point self-intersection
                     @Line(id = INVALID_LINE_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR) }) },
+                            @Loc(value = FIVE), @Loc(value = FOUR) }),
+                    // Invalid Line geometry with Waterway tag
+                    @Line(id = VALID_LINE_ID_2, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "waterway=river" }),
+                    // Invalid Line geometry with highway=path tag
+                    @Line(id = VALID_LINE_ID_3, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "highway=footway" }) },
 
             edges = {
                     // Valid Edge with no self-intersections
@@ -66,24 +79,35 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
                     // Invalid Edge with a shape-point self-intersection
                     @Edge(id = INVALID_EDGE_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=trunk" }) },
+                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=trunk" }),
+                    // Invalid Edge geometry with highway=primary tag
+                    @Edge(id = INVALID_EDGE_ID_3, coordinates = { @Loc(value = ONE),
+                            @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=primary" }),
+                    // Invalid Edge geometry with Building tag
+                    @Edge(id = INVALID_EDGE_ID_4, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FOUR) }, tags = { "building=yes" }), },
 
             areas = {
-                    // Valid Area with no self-intersections
-                    @Area(id = VALID_AREA_ID, coordinates = { @Loc(value = ONE),
-                            @Loc(value = THREE), @Loc(value = TWO), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // Invalid Area with a non shape-point self-intersection
-                    @Area(id = INVALID_AREA_ID_1, coordinates = { @Loc(value = ONE),
+                    // // Valid Area with no self-intersections
+                    // @Area(id = VALID_AREA_ID, coordinates = { @Loc(value = ONE),
+                    // @Loc(value = THREE), @Loc(value = TWO), @Loc(value = FOUR),
+                    // @Loc(value = ONE) }, tags = { "leisure=park" }),
+                    // // Invalid Area with a non shape-point self-intersection
+                    // @Area(id = INVALID_AREA_ID_1, coordinates = { @Loc(value = ONE),
+                    // @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
+                    // @Loc(value = ONE) }, tags = { "leisure=park" }),
+
+                    // Duplicate Edge Area Building
+                    @Area(id = INVALID_AREA_ID_3, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // Invalid Area with a shape point self-intersection
-                    @Area(id = INVALID_AREA_ID_2, coordinates = { @Loc(value = ONE),
-                            @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }) })
+                            @Loc(value = THREE), @Loc(value = FOUR),
+                            @Loc(value = ONE) }, tags = { "building=yes" }) })
 
     private Atlas atlas;
+
+    // TODO create invalid Edge with building=yes
 
     public Atlas getAtlas()
     {
@@ -97,6 +121,8 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
         invalidIdentifiers.add(INVALID_LINE_ID_2);
         invalidIdentifiers.add(INVALID_EDGE_ID_1);
         invalidIdentifiers.add(INVALID_EDGE_ID_2);
+        invalidIdentifiers.add(INVALID_EDGE_ID_3);
+        invalidIdentifiers.add(INVALID_EDGE_ID_4);
         invalidIdentifiers.add(INVALID_AREA_ID_1);
         invalidIdentifiers.add(INVALID_AREA_ID_2);
         return invalidIdentifiers;
@@ -108,6 +134,8 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
         validIdentifiers.add(VALID_EDGE_ID);
         validIdentifiers.add(VALID_LINE_ID);
         validIdentifiers.add(VALID_AREA_ID);
+        validIdentifiers.add(VALID_LINE_ID_2);
+        validIdentifiers.add(VALID_LINE_ID_3);
         return validIdentifiers;
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
@@ -1,8 +1,5 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
@@ -38,110 +35,205 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
     private static final String THREE = "-0.8386005, -80.4892233";
     private static final String FOUR = "-0.8384783, -80.4891956";
     private static final String FIVE = "-0.83855, -80.48922";
-    @TestAtlas(
 
-            nodes = {
-
-                    @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)),
-                    @Node(id = "3", coordinates = @Loc(value = THREE)),
-                    @Node(id = "4", coordinates = @Loc(value = FOUR)),
-                    @Node(id = "5", coordinates = @Loc(value = FIVE)) },
-
-            lines = {
-                    // Valid Line with no self-intersections
+    // Valid Line with no self-intersections
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = VALID_LINE_ID, coordinates = { @Loc(value = ONE),
-                            @Loc(value = THREE), @Loc(value = TWO) }),
-                    // Invalid Line with a non-shape self-intersection
+                            @Loc(value = THREE), @Loc(value = TWO) }) })
+    private Atlas validLineNoSelfIntersection;
+
+    // Invalid Line with a non-shape self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = INVALID_LINE_ID_1, coordinates = { @Loc(value = ONE),
-                            @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR) }),
-                    // Invalid Line with a shape-point self-intersection
+                            @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR) }) })
+    private Atlas invalidLineNonShapeSelfIntersection;
+
+    // Invalid Line with a shape-point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = INVALID_LINE_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR) }),
-                    // Invalid Line geometry with Waterway tag
+                            @Loc(value = FIVE), @Loc(value = FOUR) }) })
+    private Atlas invalidLineShapePointSelfIntersection;
+
+    // Invalid Line geometry with Waterway tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = VALID_LINE_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FOUR) }, tags = { "waterway=river" }),
-                    // Invalid Line geometry with highway=path tag
+                            @Loc(value = FOUR) }, tags = { "waterway=river" }) })
+    private Atlas invalidLineGeometryWaterwayTag;
+
+    // Invalid Line geometry with highway=footway tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, lines = {
                     @Line(id = VALID_LINE_ID_3, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FOUR) }, tags = { "highway=footway" }) },
+                            @Loc(value = FOUR) }, tags = { "highway=footway" }) })
+    private Atlas invalidLineGeometryHighwayFootwayTag;
 
-            edges = {
-                    // Valid Edge with no self-intersections
+    // Valid Edge with no self-intersections
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, edges = {
                     @Edge(id = VALID_EDGE_ID, coordinates = { @Loc(value = ONE),
-                            @Loc(value = THREE), @Loc(value = TWO) }, tags = { "highway=trunk" }),
-                    // Invalid Edge with a non-shape self-intersection
+                            @Loc(value = THREE), @Loc(value = TWO) }, tags = { "highway=trunk" }) })
+    private Atlas validEdgeNoSelfIntersection;
+
+    // Invalid Edge with a non-shape self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)) }, edges = {
                     @Edge(id = INVALID_EDGE_ID_1, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FOUR) }, tags = { "highway=trunk" }),
-                    // Invalid Edge with a shape-point self-intersection
+                            @Loc(value = FOUR) }, tags = { "highway=trunk" }) })
+    private Atlas invalidEdgeNonShapeIntersection;
+
+    // Invalid Edge with a shape-point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)),
+            @Node(id = "5", coordinates = @Loc(value = FIVE)) }, edges = {
                     @Edge(id = INVALID_EDGE_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=trunk" }),
-                    // Invalid Edge geometry with highway=primary tag
+                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=trunk" }) })
+    private Atlas invalidEdgeShapeIntersection;
+
+    // Invalid Edge geometry with highway=primary tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)),
+            @Node(id = "5", coordinates = @Loc(value = FIVE)) }, edges = {
                     @Edge(id = INVALID_EDGE_ID_3, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FIVE), @Loc(value = FOUR) }, tags = { "highway=primary" }),
-                    // Invalid Edge geometry with Building tag
+                            @Loc(value = FIVE),
+                            @Loc(value = FOUR) }, tags = { "highway=primary" }) })
+    private Atlas invalidEdgeGeometryHighwayPrimaryTag;
+
+    // Invalid Edge geometry with Building tag
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)),
+            @Node(id = "4", coordinates = @Loc(value = FOUR)) }, edges = {
                     @Edge(id = INVALID_EDGE_ID_4, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE),
-                            @Loc(value = FOUR) }, tags = { "building=yes" }), },
+                            @Loc(value = FOUR) }, tags = { "building=yes" }) })
+    private Atlas invalidEdgeGeometryBuildingTag;
 
-            areas = {
-                    // Valid Area with no self-intersections
+    // Valid Area with no self-intersections
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
                     @Area(id = VALID_AREA_ID, coordinates = { @Loc(value = ONE),
                             @Loc(value = THREE), @Loc(value = TWO), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // Invalid Area with a non shape-point self-intersection
+                            @Loc(value = ONE) }, tags = { "leisure=park" }) })
+    private Atlas validAreaNoSelfIntersection;
+
+    // Invalid Area with a non shape-point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
                     @Area(id = INVALID_AREA_ID_1, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // Invalid Area with a shape point self-intersection
+                            @Loc(value = ONE) }, tags = { "leisure=park" }) })
+    private Atlas invalidAreaNonShapeSelfIntersection;
+
+    // Invalid Area with a shape point self-intersection
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
                     @Area(id = INVALID_AREA_ID_2, coordinates = { @Loc(value = ONE),
                             @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
                             @Loc(value = FIVE), @Loc(value = FOUR),
-                            @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // Invalid Duplicate Edge Area Building
+                            @Loc(value = ONE) }, tags = { "leisure=park" }) })
+    private Atlas invalidAreaShapeIntersection;
+
+    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+            @Node(id = "2", coordinates = @Loc(value = TWO)),
+            @Node(id = "3", coordinates = @Loc(value = THREE)) }, areas = {
                     @Area(id = INVALID_AREA_ID_3, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
                             @Loc(value = THREE), @Loc(value = FOUR),
                             @Loc(value = ONE) }, tags = { "building=yes" }) })
+    private Atlas invalidAreaBuildingTag;
 
-    private Atlas atlas;
-
-    // TODO create invalid Edge with building=yes
-
-    public Atlas getAtlas()
+    public Atlas getValidLineNoSelfIntersection()
     {
-        return this.atlas;
+        return this.validLineNoSelfIntersection;
     }
 
-    public Set<String> getInvalidAtlasEntityIdentifiers()
+    public Atlas getInvalidLineNonShapeSelfIntersection()
     {
-        final Set<String> invalidIdentifiers = new HashSet<>();
-        invalidIdentifiers.add(INVALID_LINE_ID_1);
-        invalidIdentifiers.add(INVALID_LINE_ID_2);
-        invalidIdentifiers.add(INVALID_EDGE_ID_1);
-        invalidIdentifiers.add(INVALID_EDGE_ID_2);
-        invalidIdentifiers.add(INVALID_EDGE_ID_3);
-        invalidIdentifiers.add(INVALID_EDGE_ID_4);
-        invalidIdentifiers.add(INVALID_AREA_ID_1);
-        invalidIdentifiers.add(INVALID_AREA_ID_2);
-        invalidIdentifiers.add(INVALID_AREA_ID_3);
-        return invalidIdentifiers;
+        return this.invalidLineNonShapeSelfIntersection;
     }
 
-    public Set<String> getValidAtlasEntityIdentifiers()
+    public Atlas getInvalidLineShapePointSelfIntersection()
     {
-        final Set<String> validIdentifiers = new HashSet<>();
-        validIdentifiers.add(VALID_EDGE_ID);
-        validIdentifiers.add(VALID_LINE_ID);
-        validIdentifiers.add(VALID_AREA_ID);
-        validIdentifiers.add(VALID_LINE_ID_2);
-        validIdentifiers.add(VALID_LINE_ID_3);
-        return validIdentifiers;
+        return this.invalidLineShapePointSelfIntersection;
     }
 
+    public Atlas getInvalidLineGeometryWaterwayTag()
+    {
+        return this.invalidLineGeometryWaterwayTag;
+    }
+
+    public Atlas getInvalidLineGeometryHighwayFootwayTag()
+    {
+        return this.invalidLineGeometryHighwayFootwayTag;
+    }
+
+    public Atlas getValidEdgeNoSelfIntersection()
+    {
+        return this.validEdgeNoSelfIntersection;
+    }
+
+    public Atlas getInvalidEdgeNonShapeIntersection()
+    {
+        return this.invalidEdgeNonShapeIntersection;
+    }
+
+    public Atlas getInvalidEdgeShapeIntersection()
+    {
+        return this.invalidEdgeShapeIntersection;
+    }
+
+    public Atlas getInvalidEdgeGeometryHighwayPrimaryTag()
+    {
+        return this.invalidEdgeGeometryHighwayPrimaryTag;
+    }
+
+    public Atlas getInvalidEdgeGeometryBuildingTag()
+    {
+        return this.invalidEdgeGeometryBuildingTag;
+    }
+
+    public Atlas getValidAreaNoSelfIntersection()
+    {
+        return this.validAreaNoSelfIntersection;
+    }
+
+    public Atlas getInvalidAreaNonShapeSelfIntersection()
+    {
+        return this.invalidAreaNonShapeSelfIntersection;
+    }
+
+    public Atlas getInvalidAreaShapeIntersection()
+    {
+        return this.invalidAreaShapeIntersection;
+    }
+
+    public Atlas getInvalidAreaBuildingTag()
+    {
+        return this.invalidAreaBuildingTag;
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineTestCaseRule.java
@@ -90,16 +90,20 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
                             @Loc(value = FOUR) }, tags = { "building=yes" }), },
 
             areas = {
-                    // // Valid Area with no self-intersections
-                    // @Area(id = VALID_AREA_ID, coordinates = { @Loc(value = ONE),
-                    // @Loc(value = THREE), @Loc(value = TWO), @Loc(value = FOUR),
-                    // @Loc(value = ONE) }, tags = { "leisure=park" }),
-                    // // Invalid Area with a non shape-point self-intersection
-                    // @Area(id = INVALID_AREA_ID_1, coordinates = { @Loc(value = ONE),
-                    // @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
-                    // @Loc(value = ONE) }, tags = { "leisure=park" }),
-
-                    // Duplicate Edge Area Building
+                    // Valid Area with no self-intersections
+                    @Area(id = VALID_AREA_ID, coordinates = { @Loc(value = ONE),
+                            @Loc(value = THREE), @Loc(value = TWO), @Loc(value = FOUR),
+                            @Loc(value = ONE) }, tags = { "leisure=park" }),
+                    // Invalid Area with a non shape-point self-intersection
+                    @Area(id = INVALID_AREA_ID_1, coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
+                            @Loc(value = ONE) }, tags = { "leisure=park" }),
+                    // Invalid Area with a shape point self-intersection
+                    @Area(id = INVALID_AREA_ID_2, coordinates = { @Loc(value = ONE),
+                            @Loc(value = FIVE), @Loc(value = TWO), @Loc(value = THREE),
+                            @Loc(value = FIVE), @Loc(value = FOUR),
+                            @Loc(value = ONE) }, tags = { "leisure=park" }),
+                    // Invalid Duplicate Edge Area Building
                     @Area(id = INVALID_AREA_ID_3, coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO), @Loc(value = THREE), @Loc(value = FOUR),
                             @Loc(value = THREE), @Loc(value = FOUR),
@@ -125,6 +129,7 @@ public class SelfIntersectingPolylineTestCaseRule extends CoreTestRule
         invalidIdentifiers.add(INVALID_EDGE_ID_4);
         invalidIdentifiers.add(INVALID_AREA_ID_1);
         invalidIdentifiers.add(INVALID_AREA_ID_2);
+        invalidIdentifiers.add(INVALID_AREA_ID_3);
         return invalidIdentifiers;
     }
 


### PR DESCRIPTION
The main goal of this PR is to improve the clarity of flags by classifying various cases of self-intersection.

- Line features w/ building tags
- Area features w/ duplicate Edges
- Area features w/ invalid geometries 
- Roads w/ invalid geometries

This also removes all flags containing following tags Highway tags: _PROPOSED, CONSTRUCTION, FOOTWAY, PATH_, as well as all Waterway tags.