### PR TITLE
Adding new Check: UnusualLayerTagCheck

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheck.java
@@ -1,0 +1,149 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.BridgeTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.JunctionTag;
+import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.Taggable;
+import org.openstreetmap.atlas.tags.TunnelTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Checks {@link Edge}'s {@link LayerTag} and flags it if the value is unusual. Also see
+ * http://wiki.openstreetmap.org/wiki/Key:layer
+ *
+ * @author mkalender
+ */
+public class UnusualLayerTagsCheck extends BaseCheck<Long>
+{
+    // Instructions
+    public static final String INVALID_LAYER_INSTRUCTION = String.format(
+            "A layer tag must have a value in [%d, %d] and 0 should not be used explicitly.",
+            LayerTag.getMinValue(), LayerTag.getMaxValue());
+    public static final String JUNCTION_INSTRUCTION = "Junction edges with valid layer value "
+            + "must include bridge or tunnel tags";
+    private static final Predicate<Taggable> ALLOWED_TAGS;
+    private static final long BRIDGE_LAYER_TAG_MAX_VALUE = LayerTag.getMaxValue();
+    // Constants for bridge checks
+    private static final long BRIDGE_LAYER_TAG_MIN_VALUE = 1;
+    public static final String BRIDGE_INSTRUCTION = String.format(
+            "Bridge edges must have no layer tag or a layer tag set to a value in [%d, %d].",
+            BRIDGE_LAYER_TAG_MIN_VALUE, BRIDGE_LAYER_TAG_MAX_VALUE);
+    private static final int THREE = 3;
+    private static final long TUNNEL_LAYER_TAG_MAX_VALUE = -1;
+    // Constants for tunnel checks
+    private static final long TUNNEL_LAYER_TAG_MIN_VALUE = LayerTag.getMinValue();
+    public static final String TUNNEL_INSTRUCTION = String.format(
+            "Tunnel edges must have layer tag set to a value in [%d, %d].",
+            TUNNEL_LAYER_TAG_MIN_VALUE, TUNNEL_LAYER_TAG_MAX_VALUE);
+    public static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(TUNNEL_INSTRUCTION,
+            JUNCTION_INSTRUCTION, BRIDGE_INSTRUCTION, INVALID_LAYER_INSTRUCTION);
+    // tunnel=building_passage should be excluded from eligible candidates
+    private static final Predicate<Taggable> ELIGIBLE_TUNNEL_TAGS = object -> Validators
+            .hasValuesFor(object, TunnelTag.class)
+            && !(Validators.isOfType(object, TunnelTag.class, TunnelTag.BUILDING_PASSAGE));
+    private static final long serialVersionUID = 7040472721500502360L;
+
+    /**
+     * Initializes a predicate to limit check for tunnels, junctions, bridges and edges with layer
+     * tag values
+     */
+    static
+    {
+        ALLOWED_TAGS = Validators.hasValuesFor(JunctionTag.class)
+                .or(Validators.hasValuesFor(BridgeTag.class))
+                .or(Validators.hasValuesFor(LayerTag.class)).or(ELIGIBLE_TUNNEL_TAGS);
+    }
+
+    /**
+     * Configuration required to construct any Check
+     *
+     * @param configuration
+     *            {@link Configuration}
+     */
+    public UnusualLayerTagsCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * Validate if given {@link AtlasObject} is actually an {@link Edge} and make sure the edge has
+     * one of the following tags: tunnel, junction, bridge, layer
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Edge
+                // must be highway navigable
+                && HighwayTag.isCarNavigableHighway(object)
+                // and one of the following
+                && ALLOWED_TAGS.test(object)
+                // removes one of two bi-directional edge candidates
+                && ((Edge) object).isMasterEdge()
+                // remove way sectioned duplicates
+                && !this.isFlagged(object.getOsmIdentifier());
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * Flag an {@link Edge} if it's {@link LayerTag} value is unusual
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        // Retrieve layer tag value and evaluate it
+        final Optional<Long> layerTagValue = LayerTag.getTaggedOrImpliedValue(object, 0L);
+        final boolean isTagValueValid = layerTagValue.isPresent();
+
+        // mark osm id as flagged
+        this.markAsFlagged(object.getOsmIdentifier());
+
+        // Rule: tunnel edges must have a layer tag value in [-5, -1]
+        if (TunnelTag.isTunnel(object)
+                && (!isTagValueValid || layerTagValue.get() > TUNNEL_LAYER_TAG_MAX_VALUE
+                        || layerTagValue.get() < TUNNEL_LAYER_TAG_MIN_VALUE))
+        {
+            return Optional.of(createFlag(object, this.getLocalizedInstruction(0)));
+        }
+
+        // Rule: bridge edges must have no layer tag or a layer tag value in [1, 5]
+        if (BridgeTag.isBridge(object) && (!isTagValueValid || layerTagValue.get() != 0)
+                && (!isTagValueValid || layerTagValue.get() > BRIDGE_LAYER_TAG_MAX_VALUE
+                        || layerTagValue.get() < BRIDGE_LAYER_TAG_MIN_VALUE))
+        {
+            return Optional.of(createFlag(object, this.getLocalizedInstruction(2)));
+        }
+
+        // Rule: Junction edges with valid layer must include bridge or tunnel tag
+        if (JunctionTag.isRoundabout(object) && (isTagValueValid && layerTagValue.get() != 0L)
+                && !(TunnelTag.isTunnel(object) || BridgeTag.isBridge(object)))
+        {
+            return Optional.of(createFlag(object, this.getLocalizedInstruction(1)));
+        }
+
+        // Verify that if layer tag is present it should have a valid long value
+        // We are doing this verification here (after other more specific checks) to let above
+        // checks create a more specific flag
+        if (!isTagValueValid)
+        {
+            return Optional.of(createFlag(object, this.getLocalizedInstruction(THREE)));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTest.java
@@ -1,0 +1,496 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * {@link UnusualLayerTagsCheck} unit test
+ *
+ * @author mkalender
+ */
+public class UnusualLayerTagsCheckTest
+{
+    private static final UnusualLayerTagsCheck check = new UnusualLayerTagsCheck(
+            ConfigurationResolver.emptyConfiguration());
+
+    @Rule
+    public UnusualLayerTagsCheckTestRule setup = new UnusualLayerTagsCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void noEdgeAtlas()
+    {
+        this.verifier.actual(this.setup.noEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testInvalidBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.invalidLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testInvalidJunctionLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.invalidLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testInvalidLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.invalidLayerTagEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testInvalidTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.invalidLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testMinusFiveTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusFiveLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMinusFourTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusFourLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMinusInfinityBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusInfinityLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testMinusInfinityLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusInfinityLayerTagEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testMinusInfinityTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusInfinityLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testMinusOneBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusOneLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testMinusOneLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusOneLayerTagEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMinusOneTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusOneLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMinusSixTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusSixLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testMinusThreeTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusThreeLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMinusTwoTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.minusTwoLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMissingBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.missingLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMissingJunctionLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.missingLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMissingLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.missingLayerTagEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMissingTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.missingLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testNullBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.nullLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testNullJunctionLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.nullLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.JUNCTION_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testNullLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.nullLayerTagEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testNullTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.nullLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testPlusFiveBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusFiveLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testPlusFourBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusFourLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testPlusInfinityBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusInfinityLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testPlusInfinityLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusInfinityLayerTagEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testPlusInfinityTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusInfinityLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testPlusOneBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusOneLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testPlusOneLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusOneLayerTagEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testPlusOneTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusOneLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testPlusSixBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusSixLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testPlusThreeBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusThreeLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testPlusTwoBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.plusTwoLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testWhitespaceBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.whitespaceLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testWhitespaceJunctionLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.whitespaceLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.JUNCTION_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testWhitespaceLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.whitespaceLayerTagEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testWhitespaceTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.whitespaceLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testZeroBridgeLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.zeroLayerTagBridgeEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.BRIDGE_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testZeroJunctionLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.zeroLayerTagJunctionEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testZeroLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.zeroLayerTagEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions()
+                    .contains(UnusualLayerTagsCheck.INVALID_LAYER_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testZeroTunnelLayerTagEdge()
+    {
+        this.verifier.actual(this.setup.zeroLayerTagTunnelEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.TUNNEL_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testValidLayerTagRoundaboutEdgeAtlas()
+    {
+        this.verifier.actual(this.setup.validLayerTagRoundaboutEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testMissingBridgeTagJunctionLayerEdgeAtlas()
+    {
+        this.verifier.actual(this.setup.missingBridgeTagJunctionLayerEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.JUNCTION_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testInvalidBridgeTunnelTagLayerEdgeAtlas()
+    {
+        this.verifier.actual(this.setup.whitespaceBridgeRoundaboutLayerTagEdgeAtlas(), check);
+        this.verifier.verifyNotEmpty();
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(
+                    flag.getInstructions().contains(UnusualLayerTagsCheck.JUNCTION_INSTRUCTION));
+        });
+    }
+
+    @Test
+    public void testValidBuildingPassageTunnelLayerEdgeAtlas()
+    {
+        this.verifier.actual(this.setup.validBuildingPassageTunnelLayerEdgeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
@@ -1,0 +1,581 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * {@link UnusualLayerTagsCheck} test data
+ *
+ * @author mkalender
+ */
+public class UnusualLayerTagsCheckTestRule extends CoreTestRule
+{
+    private static final String COMPANY_STORE = "37.3314171,-122.0304871";
+    private static final String APPLE_CAMPUS_2 = "37.33531,-122.009566";
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=iaminvalid", "highway=service" }) })
+    private Atlas invalidLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=iaminvalid", "bridge=yes", "highway=secondary" }) })
+    private Atlas invalidLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=iaminvalid", "junction=roundabout", "highway=secondary" }) })
+    private Atlas invalidLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=iaminvalid", "tunnel=yes", "highway=secondary" }) })
+    private Atlas invalidLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }) })
+    private Atlas missingLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "bridge=yes" }) })
+    private Atlas missingLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "junction=roundabout" }) })
+    private Atlas missingLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "tunnel=yes", "highway=residential" }) })
+    private Atlas missingLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) })
+    private Atlas noEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=null", "highway=primary" }) })
+    private Atlas nullLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=null", "bridge=yes", "highway=primary" }) })
+    private Atlas nullLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=null", "junction=roundabout" }) })
+    private Atlas nullLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=null", "tunnel=yes", "highway=primary" }) })
+    private Atlas nullLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer= ",
+                            "highway=primary" }) })
+    private Atlas whitespaceLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer= ",
+                            "bridge=yes", "highway=service" }) })
+    private Atlas whitespaceLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer= ",
+                            "junction=roundabout" }) })
+    private Atlas whitespaceLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer= ",
+                            "tunnel=yes", "highway=service" }) })
+    private Atlas whitespaceLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=0",
+                            "bridge=yes", "highway=secondary" }) })
+    private Atlas zeroLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=0",
+                            "junction=roundabout", "highway=service" }) })
+    private Atlas zeroLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=0",
+                            "tunnel=yes", "highway=service" }) })
+    private Atlas zeroLayerTagTunnelEdgeAtlas;
+
+    // More atlases
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-2147483648", "highway=service" }) })
+    private Atlas minusInfinityLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-1" }) })
+    private Atlas minusOneLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=0",
+                            "highway=motorway" }) })
+    private Atlas zeroLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1" }) })
+    private Atlas plusOneLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=2147483647", "highway=service" }) })
+    private Atlas plusInfinityLayerTagEdgeAtlas;
+
+    // More junction atlases
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-2147483648", "junction=roundabout" }) })
+    private Atlas minusInfinityLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-1", "junction=roundabout" }) })
+    private Atlas minusOneLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1",
+                            "junction=roundabout" }) })
+    private Atlas plusOneLayerTagJunctionEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=2147483647", "junction=roundabout" }) })
+    private Atlas plusInfinityLayerTagJunctionEdgeAtlas;
+
+    // More bridge atlases
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-2147483648", "bridge=yes", "highway=secondary" }) })
+    private Atlas minusInfinityLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-1", "bridge=yes", "highway=service" }) })
+    private Atlas minusOneLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1", "bridge=yes" }) })
+    private Atlas plusOneLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=2", "bridge=yes" }) })
+    private Atlas plusTwoLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=3", "bridge=yes" }) })
+    private Atlas plusThreeLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=4", "bridge=yes" }) })
+    private Atlas plusFourLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=5", "bridge=yes" }) })
+    private Atlas plusFiveLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=6",
+                            "bridge=yes", "highway=service" }) })
+    private Atlas plusSixLayerTagBridgeEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=2147483647", "bridge=yes", "highway=secondary" }) })
+    private Atlas plusInfinityLayerTagBridgeEdgeAtlas;
+
+    // More tunnel atlases
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-2147483648", "tunnel=yes", "highway=primary" }) })
+    private Atlas minusInfinityLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=-6", "tunnel=yes", "highway=secondary" }) })
+    private Atlas minusSixLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-5", "tunnel=yes" }) })
+    private Atlas minusFiveLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-4", "tunnel=yes" }) })
+    private Atlas minusFourLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-3", "tunnel=yes" }) })
+    private Atlas minusThreeLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-2", "tunnel=yes" }) })
+    private Atlas minusTwoLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=-1", "tunnel=yes" }) })
+    private Atlas minusOneLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=1",
+                            "tunnel=yes", "highway=service" }) })
+    private Atlas plusOneLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "layer=2147483647", "tunnel=yes", "highway=service" }) })
+    private Atlas plusInfinityLayerTagTunnelEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=4",
+                            "junction=roundabout", "highway=service", "bridge=yes" }) })
+    private Atlas validLayerTagRoundaboutEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=4",
+                            "highway=service", "junction=roundabout" }) })
+    private Atlas missingBridgeTagJunctionLayerEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = { "layer=4",
+                            "highway=service", "bridge= ", "junction=roundabout" }) })
+    private Atlas whitespaceBridgeRoundaboutLayerTagEdgeAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
+            @Node(coordinates = @Loc(value = APPLE_CAMPUS_2)) }, edges = { @Edge(coordinates = {
+                    @Loc(value = COMPANY_STORE), @Loc(value = APPLE_CAMPUS_2) }, tags = {
+                            "tunnel=building_passage", "highway=service" }) })
+    private Atlas validBuildingPassageTunnelLayerEdgeAtlas;
+
+    public Atlas invalidLayerTagBridgeEdgeAtlas()
+    {
+        return this.invalidLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas invalidLayerTagEdgeAtlas()
+    {
+        return this.invalidLayerTagEdgeAtlas;
+    }
+
+    public Atlas invalidLayerTagJunctionEdgeAtlas()
+    {
+        return this.invalidLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas invalidLayerTagTunnelEdgeAtlas()
+    {
+        return this.invalidLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas minusFiveLayerTagTunnelEdgeAtlas()
+    {
+        return this.minusFiveLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas minusFourLayerTagTunnelEdgeAtlas()
+    {
+        return this.minusFourLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas minusInfinityLayerTagBridgeEdgeAtlas()
+    {
+        return this.minusInfinityLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas minusInfinityLayerTagEdgeAtlas()
+    {
+        return this.minusInfinityLayerTagEdgeAtlas;
+    }
+
+    public Atlas minusInfinityLayerTagJunctionEdgeAtlas()
+    {
+        return this.minusInfinityLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas minusInfinityLayerTagTunnelEdgeAtlas()
+    {
+        return this.minusInfinityLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas minusOneLayerTagBridgeEdgeAtlas()
+    {
+        return this.minusOneLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas minusOneLayerTagEdgeAtlas()
+    {
+        return this.minusOneLayerTagEdgeAtlas;
+    }
+
+    public Atlas minusOneLayerTagJunctionEdgeAtlas()
+    {
+        return this.minusOneLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas minusOneLayerTagTunnelEdgeAtlas()
+    {
+        return this.minusOneLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas minusSixLayerTagTunnelEdgeAtlas()
+    {
+        return this.minusSixLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas minusThreeLayerTagTunnelEdgeAtlas()
+    {
+        return this.minusThreeLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas minusTwoLayerTagTunnelEdgeAtlas()
+    {
+        return this.minusTwoLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas missingLayerTagBridgeEdgeAtlas()
+    {
+        return this.missingLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas missingLayerTagEdgeAtlas()
+    {
+        return this.missingLayerTagEdgeAtlas;
+    }
+
+    public Atlas missingLayerTagJunctionEdgeAtlas()
+    {
+        return this.missingLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas missingLayerTagTunnelEdgeAtlas()
+    {
+        return this.missingLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas noEdgeAtlas()
+    {
+        return this.noEdgeAtlas;
+    }
+
+    public Atlas nullLayerTagBridgeEdgeAtlas()
+    {
+        return this.nullLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas nullLayerTagEdgeAtlas()
+    {
+        return this.nullLayerTagEdgeAtlas;
+    }
+
+    public Atlas nullLayerTagJunctionEdgeAtlas()
+    {
+        return this.nullLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas nullLayerTagTunnelEdgeAtlas()
+    {
+        return this.nullLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas plusFiveLayerTagBridgeEdgeAtlas()
+    {
+        return this.plusFiveLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas plusFourLayerTagBridgeEdgeAtlas()
+    {
+        return this.plusFourLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas plusInfinityLayerTagBridgeEdgeAtlas()
+    {
+        return this.plusInfinityLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas plusInfinityLayerTagEdgeAtlas()
+    {
+        return this.plusInfinityLayerTagEdgeAtlas;
+    }
+
+    public Atlas plusInfinityLayerTagJunctionEdgeAtlas()
+    {
+        return this.plusInfinityLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas plusInfinityLayerTagTunnelEdgeAtlas()
+    {
+        return this.plusInfinityLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas plusOneLayerTagBridgeEdgeAtlas()
+    {
+        return this.plusOneLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas plusOneLayerTagEdgeAtlas()
+    {
+        return this.plusOneLayerTagEdgeAtlas;
+    }
+
+    public Atlas plusOneLayerTagJunctionEdgeAtlas()
+    {
+        return this.plusOneLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas plusOneLayerTagTunnelEdgeAtlas()
+    {
+        return this.plusOneLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas plusSixLayerTagBridgeEdgeAtlas()
+    {
+        return this.plusSixLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas plusThreeLayerTagBridgeEdgeAtlas()
+    {
+        return this.plusThreeLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas plusTwoLayerTagBridgeEdgeAtlas()
+    {
+        return this.plusTwoLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas whitespaceLayerTagBridgeEdgeAtlas()
+    {
+        return this.whitespaceLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas whitespaceLayerTagEdgeAtlas()
+    {
+        return this.whitespaceLayerTagEdgeAtlas;
+    }
+
+    public Atlas whitespaceLayerTagJunctionEdgeAtlas()
+    {
+        return this.whitespaceLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas whitespaceLayerTagTunnelEdgeAtlas()
+    {
+        return this.whitespaceLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas zeroLayerTagBridgeEdgeAtlas()
+    {
+        return this.zeroLayerTagBridgeEdgeAtlas;
+    }
+
+    public Atlas zeroLayerTagEdgeAtlas()
+    {
+        return this.zeroLayerTagEdgeAtlas;
+    }
+
+    public Atlas zeroLayerTagJunctionEdgeAtlas()
+    {
+        return this.zeroLayerTagJunctionEdgeAtlas;
+    }
+
+    public Atlas zeroLayerTagTunnelEdgeAtlas()
+    {
+        return this.zeroLayerTagTunnelEdgeAtlas;
+    }
+
+    public Atlas validLayerTagRoundaboutEdgeAtlas()
+    {
+        return this.validLayerTagRoundaboutEdgeAtlas;
+    }
+
+    public Atlas missingBridgeTagJunctionLayerEdgeAtlas()
+    {
+        return this.missingBridgeTagJunctionLayerEdgeAtlas;
+    }
+
+    public Atlas whitespaceBridgeRoundaboutLayerTagEdgeAtlas()
+    {
+        return whitespaceBridgeRoundaboutLayerTagEdgeAtlas;
+    }
+
+    public Atlas validBuildingPassageTunnelLayerEdgeAtlas()
+    {
+        return validBuildingPassageTunnelLayerEdgeAtlas;
+    }
+}


### PR DESCRIPTION
The "UnusualLayerTagCheck” is intended to validate layer tag values when accompanied by tunnel and bridge tags.
The check is implemented using the following rules:
1. Layer tag value should be an integer, ranging from -5 to 5, excluding 0 
2. Ways passed above other Ways with valid layer tag (above), accompanied by the bridge* *tag containing one of the following values:
    - YES, VIADUCT, AQUEDUCT, BOARDWALK, MOVABLE, SUSPENSION, CULVERT, ABANDONED, LOW_WATER_CROSSING, SIMPLE_BRUNNEL, COVERED
3. Ways passed above other Ways with valid layer tag, accompanied by a tunnel tag containing one of the following values:
    - YES, CULVERT, BUILDING_PASSAGE 
4. Ways with junction=ROUNDABOUT tag must not contain layer tag