### PR TITLE
Update SignPostCheck with off/on ramp specific logic

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -134,7 +134,14 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     {
         if (object instanceof AtlasItem)
         {
-            this.flaggedObjects.add(new FlaggedPolyline(object));
+            if (object instanceof LocationItem)
+            {
+                this.flaggedObjects.add(new FlaggedPoint(((LocationItem) object).getLocation()));
+            }
+            else
+            {
+                this.flaggedObjects.add(new FlaggedPolyline(object));
+            }
         }
     }
 
@@ -168,8 +175,8 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public void addObject(final AtlasObject object, final String instruction)
     {
-        addObject(object);
-        addInstruction(instruction);
+        this.addObject(object);
+        this.addInstruction(instruction);
     }
 
     /**
@@ -180,14 +187,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public void addObjects(final Iterable<AtlasObject> objects)
     {
-        Iterables.stream(objects).filter(object -> object instanceof AtlasItem).map(item ->
-        {
-            if (item instanceof LocationItem)
-            {
-                return new FlaggedPoint(((LocationItem) item).getLocation());
-            }
-            return new FlaggedPolyline(item);
-        }).forEach(this.flaggedObjects::add);
+        Iterables.stream(objects).forEach(this::addObject);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -1,54 +1,75 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 
+import org.apache.directory.api.util.Strings;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Heading;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.tags.DestinationTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Angle;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
- * The SignPostCheck is used to help identify segments that are missing the proper tagging for sign
- * posts. The basic logic of the check is to first find all motorway and trunk edges which have link
- * edges departing them. Once you have identified these candidates a flag is thrown if one or both
- * of the following conditions are met.
+ * This check is used to help identify segments that are missing the proper tagging for sign posts.
+ * The basic logic of the check is to first find all edges with given filter with on and off ramps.
+ * Once ramps are identified and filtered, a flag is thrown if one or both of the following
+ * conditions are met.
  * <p>
- * 1) The shared node is missing the highway=motorway_junction tag<br>
- * 2) The exiting link edge is missing the destination tag<br>
+ * 1) The starting node for the ramp is missing the highway=motorway_junction tag<br>
+ * 2) The ramp road is missing the destination tag<br>
  * <p>
- * If either of these cases is true and the link edge is over a certain length then a flag is
- * signalled.
+ * If either of these cases is true and ramp is over a certain length then a flag is created.
  *
  * @author ericgodwin
+ * @author mkalender
  */
 public class SignPostCheck extends BaseCheck<String>
 {
     private static final long serialVersionUID = 8042255121118115024L;
 
     // Instruction
-    private static final String INSTRUCTION = "Junction node is missing the following tags: {0}.";
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION);
+    private static final String NODE_INSTRUCTION = "Junction node {0,number,#} is missing the following tags: {1}.";
+    private static final String EDGE_INSTRUCTION = "Way {0,number,#} ({1}) is missing the following tags: {2}.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(NODE_INSTRUCTION,
+            EDGE_INSTRUCTION);
+    private static final String OFF_RAMP_KEY = "off-ramp";
+    private static final String ON_RAMP_KEY = "on-ramp";
 
-    // Predicate defining the type of outbound links we are looking for.
-    private static final Predicate<Edge> LINK_PREDICATE = edge -> edge
-            .highwayTag() == HighwayTag.MOTORWAY_LINK || edge.highwayTag() == HighwayTag.TRUNK_LINK;
+    // Default values for configurable settings
+    private static final double DISTANCE_MINIMUM_METERS_DEFAULT = 50;
+    private static final String SOURCE_EDGE_FILTER_DEFAULT = "highway->motorway,trunk";
+    private static final String RAMP_FILTER_DEFAULT = "highway->motorway,motorway_link,trunk,trunk_link";
+    private static final double RAMP_ANGLE_DIFFERENCE_DEFAULT = 30;
 
-    // The default minimum link length which will trigger the check.
-    public static final double DISTANCE_MINIMUM_METERS_DEFAULT = 50;
+    // Maximum number of hops while collecting ramp edges
+    private static final int MAX_EDGE_COUNT_FOR_RAMP = 5;
 
     // The minimum link length to examine.
     private final Distance minimumLinkLength;
+
+    // A filter to filter source edges for flagging
+    private final TaggableFilter sourceEdgeFilter;
+
+    // A filter to filter ramp edges
+    private final TaggableFilter rampEdgeFilter;
+
+    // A tag to differentiate ramps from roads with the same classification
+    private final String rampDifferentiatorTag;
+
+    // Maximum angle difference between ramp edges
+    private final Angle rampAngleDifference;
 
     /**
      * The default constructor that must be supplied. The Atlas Checks framework will generate the
@@ -64,10 +85,18 @@ public class SignPostCheck extends BaseCheck<String>
 
         this.minimumLinkLength = configurationValue(configuration, "linkLength.minimum.meters",
                 DISTANCE_MINIMUM_METERS_DEFAULT, Distance::meters);
+        this.sourceEdgeFilter = configurationValue(configuration, "source.filter",
+                SOURCE_EDGE_FILTER_DEFAULT, value -> new TaggableFilter(value));
+        this.rampEdgeFilter = configurationValue(configuration, "ramp.filter", RAMP_FILTER_DEFAULT,
+                value -> new TaggableFilter(value));
+        this.rampDifferentiatorTag = configurationValue(configuration, "ramp.differentiator.tag",
+                null);
+        this.rampAngleDifference = configurationValue(configuration,
+                "ramp.angle.difference.degrees", RAMP_ANGLE_DIFFERENCE_DEFAULT, Angle::degrees);
     }
 
     /**
-     * This function will validate if the supplied atlas object is valid for the check.
+     * Validates if the supplied {@link AtlasObject} is valid for the check.
      *
      * @param object
      *            the atlas object supplied by the Atlas-Checks framework for evaluation
@@ -76,8 +105,7 @@ public class SignPostCheck extends BaseCheck<String>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TypePredicates.IS_EDGE.test(object) && Validators.isOfType(object, HighwayTag.class,
-                HighwayTag.MOTORWAY, HighwayTag.TRUNK, HighwayTag.PRIMARY, HighwayTag.PRIMARY_LINK);
+        return TypePredicates.IS_EDGE.test(object) && this.sourceEdgeFilter.test(object);
     }
 
     /**
@@ -91,45 +119,64 @@ public class SignPostCheck extends BaseCheck<String>
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Edge edge = (Edge) object;
-        final Set<String> missingTags = new HashSet<String>();
-        final Set<AtlasObject> offendingObjects = new HashSet<AtlasObject>();
+        final HighwayTag highwayTag = edge.highwayTag();
+        final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(object));
 
-        // First find any motorway_link edges going out of the edge
-        edge.outEdges().stream().filter(LINK_PREDICATE).forEach(outEdge ->
-        {
-            // Let's ignore really short segments as they are often connectors
-            // between doubly digitized trunk roads.
-            if (outEdge.length().isGreaterThan(this.minimumLinkLength))
-            {
-                // Check to see if the node leaving the mainline is missing the
-                // junction tag
-                if (!Validators.isOfType(outEdge.start(), HighwayTag.class,
-                        HighwayTag.MOTORWAY_JUNCTION))
+        // First find off ramps
+        edge.end().outEdges().stream()
+                .filter(connectedEdge -> isPossiblyRamp(edge, highwayTag, connectedEdge))
+                .forEach(outEdge ->
                 {
-                    missingTags.add(String.format("%s=%s", HighwayTag.KEY,
-                            HighwayTag.MOTORWAY_JUNCTION.getTagValue()));
-                    offendingObjects.add(outEdge.start());
-                }
+                    // Check to see if start node is missing junction tag
+                    final Node start = outEdge.start();
+                    if (!Validators.isOfType(start, HighwayTag.class, HighwayTag.MOTORWAY_JUNCTION))
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(0,
+                                start.getOsmIdentifier(), String.format("%s=%s", HighwayTag.KEY,
+                                        HighwayTag.MOTORWAY_JUNCTION.getTagValue())));
+                        flag.addObject(start);
+                    }
 
-                // See if the out edge has the destination tag.
-                if (!outEdge.getTag(DestinationTag.KEY).isPresent())
+                    // Check if edge is missing destination tag
+                    if (!outEdge.getTag(DestinationTag.KEY).isPresent())
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(1,
+                                outEdge.getOsmIdentifier(), OFF_RAMP_KEY, DestinationTag.KEY));
+                        flag.addObject(outEdge);
+                    }
+                });
+
+        // Then repeat the work for on ramps
+        edge.start().inEdges().stream()
+                .filter(connectedEdge -> isPossiblyRamp(edge, highwayTag, connectedEdge))
+                .forEach(inEdge ->
                 {
-                    missingTags.add(DestinationTag.KEY);
+                    // Find the source of in-ramp
+                    final Edge rampEdge = findFirstRampEdge(inEdge);
 
-                    // Instead of adding the edge we are adding the node so
-                    // that a single point in the task is highlighted.
-                    offendingObjects.add(outEdge.start());
-                }
-            }
-        });
+                    // Check to see if start node is missing junction tag
+                    final Node start = rampEdge.start();
+                    if (!Validators.isOfType(start, HighwayTag.class, HighwayTag.MOTORWAY_JUNCTION))
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(0,
+                                start.getOsmIdentifier(), String.format("%s=%s", HighwayTag.KEY,
+                                        HighwayTag.MOTORWAY_JUNCTION.getTagValue())));
+                        flag.addObject(start);
+                    }
 
-        // If it has an out link edge make sure that the end node has the appropriate
-        // highway=motorway_junction tag.
-        if (!offendingObjects.isEmpty())
+                    // Check if edge is missing destination tag
+                    if (!rampEdge.getTag(DestinationTag.KEY).isPresent())
+                    {
+                        flag.addInstruction(this.getLocalizedInstruction(1,
+                                rampEdge.getOsmIdentifier(), ON_RAMP_KEY, DestinationTag.KEY));
+                        flag.addObject(rampEdge);
+                    }
+                });
+
+        // Return the flag if it has any flagged objects in it
+        if (!flag.getFlaggedObjects().isEmpty())
         {
-            final String instruction = this.getLocalizedInstruction(0,
-                    String.join(", ", missingTags));
-            return Optional.of(this.createFlag(offendingObjects, instruction));
+            return Optional.of(flag);
         }
 
         return Optional.empty();
@@ -139,5 +186,102 @@ public class SignPostCheck extends BaseCheck<String>
     protected List<String> getFallbackInstructions()
     {
         return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * Given a final {@link Edge}, hops back and finds the first edge that was forming the ramp.
+     *
+     * @param finalEdge
+     *            {@link Edge} that is the last/final piece of the ramp
+     * @return {@link Edge} that possibly is the first {@link Edge} forming the ramp
+     */
+    private Edge findFirstRampEdge(final Edge finalEdge)
+    {
+        int count = 0;
+
+        // Go back and collect edges
+        Edge nextEdge = finalEdge;
+        while (count < MAX_EDGE_COUNT_FOR_RAMP)
+        {
+            count++;
+
+            // Break if edge has no heading
+            final Optional<Heading> initialHeading = nextEdge.asPolyLine().initialHeading();
+            if (!initialHeading.isPresent())
+            {
+                break;
+            }
+
+            // Collect in edges and make sure there is not more than one
+            final Set<Edge> inEdges = nextEdge.inEdges();
+            if (inEdges.isEmpty() || inEdges.size() > 1)
+            {
+                break;
+            }
+
+            // Find the edge that precedes nextEdge
+            final HighwayTag highwayTag = nextEdge.highwayTag();
+            final Edge precedingEdge = inEdges.iterator().next();
+
+            // Ignore if edge has a different classification
+            if (!highwayTag.isIdenticalClassification(precedingEdge.highwayTag()))
+            {
+                break;
+            }
+
+            // Break if given edge has no heading
+            final Optional<Heading> finalHeading = precedingEdge.asPolyLine().finalHeading();
+            if (!finalHeading.isPresent() || initialHeading.get().asPositiveAngle()
+                    .difference(finalHeading.get().asPositiveAngle())
+                    .isGreaterThan(this.rampAngleDifference))
+            {
+                break;
+            }
+
+            nextEdge = precedingEdge;
+        }
+
+        return nextEdge;
+    }
+
+    /**
+     * Returns if given a connected {@link Edge} is possibly a ramp entering or leaving source
+     * {@link Edge}.
+     *
+     * @param sourceEdge
+     *            Source {@link Edge}
+     * @param sourceHighwayTag
+     *            {@link HighwayTag} of the source {@link Edge}
+     * @param connectedEdge
+     *            Connected {@link Edge} to source {@link Edge}
+     * @return true if connected {@link Edge} is a ramp
+     */
+    private boolean isPossiblyRamp(final Edge sourceEdge, final HighwayTag sourceHighwayTag,
+            final Edge connectedEdge)
+    {
+        // Ignore if edge is failing to pass ramp filter and also ignore if it is short
+        if (!this.rampEdgeFilter.test(connectedEdge)
+                || !connectedEdge.length().isGreaterThan(this.minimumLinkLength))
+        {
+            return false;
+        }
+
+        // Different classification is a good indication for a ramp
+        if (!sourceHighwayTag.isIdenticalClassification(connectedEdge.highwayTag()))
+        {
+            return true;
+        }
+
+        // If ramp differentiator tag is supplied, then use it to differentiate same classification
+        // edges
+        if (this.rampDifferentiatorTag == null)
+        {
+            return true;
+        }
+
+        // Look for certain tag differences if edges have same highway tag
+        final String sourceTag = sourceEdge.tag(this.rampDifferentiatorTag);
+        final String rampTag = connectedEdge.tag(this.rampDifferentiatorTag);
+        return !(sourceTag == null && rampTag == null || Strings.equals(sourceTag, rampTag));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTest.java
@@ -8,7 +8,9 @@ import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.flag.FlaggedObject;
+import org.openstreetmap.atlas.checks.flag.FlaggedPoint;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.geography.Location;
 
 /**
  * Tests for {@link SignPostCheck}
@@ -18,7 +20,11 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 public class SignPostCheckTest
 {
     private static SignPostCheck CHECK = new SignPostCheck(
-            ConfigurationResolver.emptyConfiguration());
+            ConfigurationResolver.inlineConfiguration(
+                    "{" + "\"SignPostCheck.source.filter\": \"highway->motorway,trunk,primary|motorroad->yes\", "
+                            + "\"SignPostCheck.ramp.filter\": \"highway->motorway_link,trunk_link,primary,primary_link&motorroad->!\","
+                            + "\"SignPostCheck.ramp.differentiator.tag\": \"diff\","
+                            + "\"SignPostCheck.ramp.angle.difference.degrees\": 90.0" + "}"));
 
     @Rule
     public SignPostCheckTestRule setup = new SignPostCheckTestRule();
@@ -26,15 +32,12 @@ public class SignPostCheckTest
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
-    private static void verify(final CheckFlag flag, final boolean shouldFlagDestination,
-            final boolean shouldFlagJunction)
+    private static void verify(final CheckFlag flag, final int expectedFlaggedObjectCount,
+            final boolean shouldFlagDestination, final boolean shouldFlagJunction)
     {
-        // Verify that only node is flagged
+        // Verify that node and edge is flagged
         final Set<FlaggedObject> flaggedObjects = flag.getFlaggedObjects();
-        Assert.assertEquals(1, flaggedObjects.size());
-
-        // Verify the node id
-        Assert.assertEquals(SignPostCheckTestRule.JUNCTION_NODE_ID, flag.getIdentifier());
+        Assert.assertEquals(expectedFlaggedObjectCount, flaggedObjects.size());
 
         // Verify the instruction tag keys and values
         Assert.assertTrue(!shouldFlagDestination || flag.getInstructions().contains("destination"));
@@ -43,12 +46,48 @@ public class SignPostCheckTest
     }
 
     @Test
+    public void motorroadPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.motorroadPrimaryLinkMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+    }
+
+    @Test
+    public void motorroadPrimaryMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.motorroadPrimaryMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+    }
+
+    @Test
+    public void motorwayLinkMotorwayMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.motorwayLinkMotorwayMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+
+        // Verify that we flagged starting node of the ramp (formed by single edge)
+        this.verifier.verify(flag ->
+        {
+            final FlaggedObject flaggedPoint = flag.getFlaggedObjects().stream()
+                    .filter(object -> object instanceof FlaggedPoint).findFirst().get();
+            final Location flaggedLocation = flaggedPoint.getGeometry().iterator().next();
+            Assert.assertEquals(Location.forString(SignPostCheckTestRule.LINK_1), flaggedLocation);
+        });
+    }
+
+    @Test
     public void motorwayMotorwayLinkMissingJunctionAndDestinationAtlas()
     {
         this.verifier.actual(this.setup.motorwayMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -65,7 +104,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.motorwayMultipleLinksMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 3, true, true));
     }
 
     @Test
@@ -73,7 +112,8 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.motorwayPrimaryLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
-        this.verifier.verifyEmpty();
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -98,7 +138,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.motorwayTrunkLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -106,25 +146,25 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.motorwayTrunkLinkWithDestinationAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, false, true));
+        this.verifier.verify(flag -> verify(flag, 1, false, true));
     }
 
     @Test
-    public void primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public void primaryLinkTrunkMissingJunctionAndDestinationAtlas()
     {
-        this.verifier.actual(this.setup.primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas(),
+        this.verifier.actual(this.setup.primaryLinkTrunkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
-    }
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
 
-    @Test
-    public void primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas()
-    {
-        this.verifier.actual(this.setup.primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
-        this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        // Verify that we flagged starting node of the ramp (formed by 2 edges)
+        this.verifier.verify(flag ->
+        {
+            final FlaggedObject flaggedPoint = flag.getFlaggedObjects().stream()
+                    .filter(object -> object instanceof FlaggedPoint).findFirst().get();
+            final Location flaggedLocation = flaggedPoint.getGeometry().iterator().next();
+            Assert.assertEquals(Location.forString(SignPostCheckTestRule.LINK_1), flaggedLocation);
+        });
     }
 
     @Test
@@ -133,7 +173,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.primaryMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -142,7 +182,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.primaryTrunkLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -151,7 +191,7 @@ public class SignPostCheckTest
         this.verifier.actual(this.setup.trunkMotorwayLinkMissingJunctionAndDestinationAtlas(),
                 CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
     }
 
     @Test
@@ -159,15 +199,7 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.trunkMotorwayLinkWithJunctionAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, false));
-    }
-
-    @Test
-    public void trunkPrimaryLinkMissingJunctionAndDestinationAtlas()
-    {
-        this.verifier.actual(this.setup.trunkPrimaryLinkMissingJunctionAndDestinationAtlas(),
-                CHECK);
-        this.verifier.verifyEmpty();
+        this.verifier.verify(flag -> verify(flag, 1, true, false));
     }
 
     @Test
@@ -191,6 +223,14 @@ public class SignPostCheckTest
     {
         this.verifier.actual(this.setup.trunkTrunkLinkMissingJunctionAndDestinationAtlas(), CHECK);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> verify(flag, true, true));
+        this.verifier.verify(flag -> verify(flag, 2, true, true));
+    }
+
+    @Test
+    public void unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        this.verifier.actual(this.setup.unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas(),
+                CHECK);
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheckTestRule.java
@@ -20,18 +20,21 @@ public class SignPostCheckTestRule extends CoreTestRule
     private static final String HIGHWAY_4 = "47.641319, -122.322601";
     private static final String HIGHWAY_5 = "47.643585, -122.322487";
 
-    private static final String LINK_1 = "47.639336, -122.322525";
+    private static final String HIGHWAY2_1 = "47.642048, -122.324181";
+    private static final String HIGHWAY2_2 = "47.642769, -122.317772";
+    private static final String HIGHWAY2_3 = "47.643078, -122.314384";
+
+    static final String LINK_1 = "47.639336, -122.322525";
     private static final String LINK_2 = "47.640697, -122.322395";
     private static final String LINK_3 = "47.642033, -122.321556";
     private static final String LINK_4 = "47.642471, -122.319885";
-    private static final String LINK_5 = "47.641216, -122.3218";
 
-    public static final String JUNCTION_NODE_ID = "123456789";
+    private static final String LINK2_1 = "47.641216, -122.3218";
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -47,7 +50,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -63,7 +66,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -79,7 +82,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)) },
             // edges
@@ -95,7 +98,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -113,7 +116,26 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_4)) },
+            // edges
+            edges = { @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
+                    @Loc(value = HIGHWAY_3) }, tags = { "highway=primary", "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary",
+                                    "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
+                            @Loc(value = LINK_2), @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary",
+                                    "diff=treat-me-different" }) })
+    private Atlas motorroadPrimaryMissingJunctionAndDestinationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -131,7 +153,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -149,7 +171,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -167,11 +189,11 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)),
-                    @Node(coordinates = @Loc(value = LINK_5)) },
+                    @Node(coordinates = @Loc(value = LINK2_1)) },
             // edges
             edges = {
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
@@ -183,31 +205,49 @@ public class SignPostCheckTestRule extends CoreTestRule
                             @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
                             @Loc(value = LINK_2),
-                            @Loc(value = LINK_5) }, tags = { "highway=trunk_link" }) })
+                            @Loc(value = LINK2_1) }, tags = { "highway=trunk_link" }) })
     private Atlas motorwayMultipleLinksMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_4)) },
+            // edges
+            edges = { @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
+                    @Loc(value = HIGHWAY_3) }, tags = { "highway=primary", "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
+                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary",
+                                    "motorroad=yes" }),
+                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
+                            @Loc(value = LINK_2), @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=primary_link" }) })
+    private Atlas motorroadPrimaryLinkMissingJunctionAndDestinationAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
             // edges
             edges = {
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
-                            @Loc(value = HIGHWAY_3) }, tags = { "highway=trunk" }),
+                            @Loc(value = HIGHWAY_3) }, tags = { "highway=unclassified" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
-                            @Loc(value = HIGHWAY_5) }, tags = { "highway=trunk" }),
+                            @Loc(value = HIGHWAY_5) }, tags = { "highway=unclassified" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
                             @Loc(value = LINK_2), @Loc(value = LINK_3),
                             @Loc(value = LINK_4) }, tags = { "highway=primary_link" }) })
-    private Atlas trunkPrimaryLinkMissingJunctionAndDestinationAtlas;
+    private Atlas unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -225,7 +265,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -243,25 +283,28 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
-                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_3)),
                     @Node(coordinates = @Loc(value = LINK_1)),
+                    @Node(coordinates = @Loc(value = LINK_3)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
             // edges
             edges = {
+                    @Edge(coordinates = { @Loc(value = LINK_1), @Loc(value = LINK_2),
+                            @Loc(value = LINK_3) }, tags = { "highway=primary_link" }),
+                    @Edge(coordinates = { @Loc(value = LINK_3), @Loc(value = LINK_4) }, tags = {
+                            "highway=primary_link" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
-                            @Loc(value = HIGHWAY_3) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
-                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
-                            @Loc(value = LINK_2), @Loc(value = LINK_3),
-                            @Loc(value = LINK_4) }, tags = { "highway=trunk_link" }) })
-    private Atlas primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas;
+                            @Loc(value = HIGHWAY2_1),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_2),
+                            @Loc(value = HIGHWAY2_3) }, tags = { "highway=motorway" }) })
+    private Atlas primaryLinkTrunkMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -279,25 +322,26 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
-                    @Node(coordinates = @Loc(value = HIGHWAY_5)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_1)),
+                    @Node(coordinates = @Loc(value = HIGHWAY2_3)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
             // edges
             edges = {
+                    @Edge(coordinates = { @Loc(value = LINK_1), @Loc(value = LINK_2),
+                            @Loc(value = LINK_3),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }),
                     @Edge(coordinates = { @Loc(value = HIGHWAY_1), @Loc(value = HIGHWAY_2),
-                            @Loc(value = HIGHWAY_3) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = HIGHWAY_4),
-                            @Loc(value = HIGHWAY_5) }, tags = { "highway=primary_link" }),
-                    @Edge(coordinates = { @Loc(value = HIGHWAY_3), @Loc(value = LINK_1),
-                            @Loc(value = LINK_2), @Loc(value = LINK_3),
-                            @Loc(value = LINK_4) }, tags = { "highway=motorway_link" }) })
-    private Atlas primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas;
+                            @Loc(value = HIGHWAY2_1),
+                            @Loc(value = LINK_4) }, tags = { "highway=motorway" }),
+                    @Edge(coordinates = { @Loc(value = LINK_4), @Loc(value = HIGHWAY2_2),
+                            @Loc(value = HIGHWAY2_3) }, tags = { "highway=motorway" }) })
+    private Atlas motorwayLinkMotorwayMissingJunctionAndDestinationAtlas;
 
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3)),
+                    @Node(coordinates = @Loc(value = HIGHWAY_3)),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
                     @Node(coordinates = @Loc(value = LINK_4)) },
@@ -316,7 +360,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3), tags = {
+                    @Node(coordinates = @Loc(value = HIGHWAY_3), tags = {
                             "highway=motorway_junction" }),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
@@ -335,7 +379,7 @@ public class SignPostCheckTestRule extends CoreTestRule
     @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = HIGHWAY_1)),
-                    @Node(id = JUNCTION_NODE_ID, coordinates = @Loc(value = HIGHWAY_3), tags = {
+                    @Node(coordinates = @Loc(value = HIGHWAY_3), tags = {
                             "highway=motorway_junction" }),
                     @Node(coordinates = @Loc(value = HIGHWAY_5)),
                     @Node(coordinates = @Loc(value = LINK_1)),
@@ -351,6 +395,21 @@ public class SignPostCheckTestRule extends CoreTestRule
                             @Loc(value = LINK_4) }, tags = { "highway=motorway_link",
                                     "destination=somewhere" }) })
     private Atlas motorwayMotorwayLinkWithJunctionAndDestinationAtlas;
+
+    public Atlas motorroadPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        return this.motorroadPrimaryLinkMissingJunctionAndDestinationAtlas;
+    }
+
+    public Atlas motorroadPrimaryMissingJunctionAndDestinationAtlas()
+    {
+        return this.motorroadPrimaryMissingJunctionAndDestinationAtlas;
+    }
+
+    public Atlas motorwayLinkMotorwayMissingJunctionAndDestinationAtlas()
+    {
+        return this.motorwayLinkMotorwayMissingJunctionAndDestinationAtlas;
+    }
 
     public Atlas motorwayMotorwayLinkMissingJunctionAndDestinationAtlas()
     {
@@ -392,14 +451,9 @@ public class SignPostCheckTestRule extends CoreTestRule
         return this.motorwayTrunkLinkWithDestinationAtlas;
     }
 
-    public Atlas primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas()
+    public Atlas primaryLinkTrunkMissingJunctionAndDestinationAtlas()
     {
-        return this.primaryLinkMotorwayLinkMissingJunctionAndDestinationAtlas;
-    }
-
-    public Atlas primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas()
-    {
-        return this.primaryLinkTrunkLinkMissingJunctionAndDestinationAtlas;
+        return this.primaryLinkTrunkMissingJunctionAndDestinationAtlas;
     }
 
     public Atlas primaryMotorwayLinkMissingJunctionAndDestinationAtlas()
@@ -422,11 +476,6 @@ public class SignPostCheckTestRule extends CoreTestRule
         return this.trunkMotorwayLinkWithJunctionAtlas;
     }
 
-    public Atlas trunkPrimaryLinkMissingJunctionAndDestinationAtlas()
-    {
-        return this.trunkPrimaryLinkMissingJunctionAndDestinationAtlas;
-    }
-
     public Atlas trunkShortMotorwayLinkMissingJunctionAndDestinationAtlas()
     {
         return this.trunkShortMotorwayLinkMissingJunctionAndDestinationAtlas;
@@ -440,5 +489,10 @@ public class SignPostCheckTestRule extends CoreTestRule
     public Atlas trunkTrunkLinkMissingJunctionAndDestinationAtlas()
     {
         return this.trunkTrunkLinkMissingJunctionAndDestinationAtlas;
+    }
+
+    public Atlas unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas()
+    {
+        return this.unclassifiedPrimaryLinkMissingJunctionAndDestinationAtlas;
     }
 }


### PR DESCRIPTION
This PR updates `SignPostCheck` for flexibility and easier maintenance. In addition to off ramps, now on ramps are flagged as well. However, on-ramps are treated differently and their start location is found and flagged rather than where they connect to highway.

- Check logic is now driven by configuration. That makes it flexible. Any additional highway types could be added, or existing ones could be ignored without a code change.
- I removed additional `missingTags` and `offendingObjects` sets that were used to track objects and tags. I am now relying on `CheckFlag` class directly. At the end, if instance doesn't have anything flagged, we'll skip flag operation.
- While doing this I hit a bug in `CheckFlag` class. Methods `addObject` and `addObjects` had different behavior. I updated `addObjects` to call `addObject`.