### PR TITLE
Integrity check updates

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -133,8 +133,9 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
      */
     private boolean hasNoConnectedEdges(final Edge edge)
     {
-        // loop through all edges that are connected to the edge you are looking at
-        for (final Edge connectedEdge : edge.connectedEdges())
+        // Loop through all edges that are connected to the edge you are looking at
+        final Iterable<Edge> connectedEdges = edge.connectedEdges();
+        for (final Edge connectedEdge : connectedEdges)
         {
             // if edge is not null (ie. valid) and not the reverse edge then immediately return
             // false, and it can safely assumed that this particular edge is not a floating edge

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
@@ -96,21 +96,17 @@ public class SnakeRoadCheck extends BaseCheck<Long>
         // of whether it's a snake road or not
         this.markAsFlagged(object.getOsmIdentifier());
 
-        // Check the base case - edge must have connected edges
-        if (!edge.connectedEdges().isEmpty())
+        // Instantiate the network walk with the starting edge
+        SnakeRoadNetworkWalk walk = initializeNetworkWalk(edge);
+
+        // Walk the road
+        walk = walkNetwork(edge, walk);
+
+        // If we've found a snake road, create a flag
+        if (networkWalkQualifiesAsSnakeRoad(walk))
         {
-            // Instantiate the network walk with the starting edge
-            SnakeRoadNetworkWalk walk = initializeNetworkWalk(edge);
-
-            // Walk the road
-            walk = walkNetwork(edge, walk);
-
-            // If we've found a snake road, create a flag
-            if (networkWalkQualifiesAsSnakeRoad(walk))
-            {
-                return Optional.of(createFlag(walk.getVisitedEdges(),
-                        this.getLocalizedInstruction(0, object.getOsmIdentifier())));
-            }
+            return Optional.of(createFlag(walk.getVisitedEdges(),
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
 
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateNodeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateNodeCheck.java
@@ -3,15 +3,15 @@ package org.openstreetmap.atlas.checks.validation.points;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.Location;
-import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
-import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * This check looks for two or more {@link Node}s that are in the exact same location.
@@ -22,14 +22,8 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 public class DuplicateNodeCheck extends BaseCheck<Location>
 {
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("Duplicate Node {0,number,#} at {1}");
+            .asList("Nodes {0} are duplicates at {1}.");
     private static final long serialVersionUID = 1055616456230649593L;
-
-    @Override
-    protected List<String> getFallbackInstructions()
-    {
-        return FALLBACK_INSTRUCTIONS;
-    }
 
     /**
      * Default constructor
@@ -45,27 +39,31 @@ public class DuplicateNodeCheck extends BaseCheck<Location>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Node;
+        return object instanceof Node && !this.isFlagged(((Node) object).getLocation());
     }
 
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Node node = (Node) object;
-        if (!this.isFlagged(node.getLocation()))
+        this.markAsFlagged(node.getLocation());
+
+        final List<Node> duplicates = Iterables
+                .asList(object.getAtlas().nodesAt(node.getLocation()));
+        if (duplicates.size() > 1)
         {
-            final Rectangle box = node.getLocation().boxAround(Distance.meters(0));
-            for (final Node dupe : object.getAtlas().nodesWithin(box))
-            {
-                if (object.getIdentifier() != dupe.getIdentifier()
-                        && dupe.getLocation().equals(node.getLocation()))
-                {
-                    this.markAsFlagged(node.getLocation());
-                    return Optional.of(createFlag(object, this.getLocalizedInstruction(0,
-                            object.getOsmIdentifier(), node.getLocation())));
-                }
-            }
+            final List<Long> duplicateIdentifiers = duplicates.stream()
+                    .map(duplicate -> duplicate.getOsmIdentifier()).collect(Collectors.toList());
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, duplicateIdentifiers, node.getLocation())));
         }
+
         return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 }


### PR DESCRIPTION
This PR has minor updates for three checks.
- `Iterable` used in `FloatingEdgeCheck` is cached first before being consumed. Otherwise, `for` loop goes and repeatedly goes over it.
- `!edge.connectedEdges().isEmpty()` condition is removed from `SnakeRoadCheck`, because that is redundant. `SnakeRoadNetworkWalk` already handles edges with no connections (such cases are very rare anyways).
- `DuplicateNodeCheck` was relying on `nodesWithin` call, but there is already `nodesAt` call that could be used to get nodes at a given location. Therefore, `nodesWithin` is replaced with `nodesAt`. Also `isFlagged` check is moved into `validCheckForObject`. Finally, node identifiers are collected and used in the instruction for easier action (there could be more than 1 duplicate).

Changes are tested, verified. Challenges are the same before and after this change.