### PR TITLE
Building Road Intersection Enhancements

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.0.14',
+    atlas: '5.0.15',
     commons:'2.6',
     atlas_generator: '4.0.4',
 ]

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 project.ext.versions = [
     checkstyle: '7.6.1',
-    atlas: '5.0.12',
+    atlas: '5.0.14',
     commons:'2.6',
     atlas_generator: '4.0.4',
 ]

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -18,6 +18,7 @@ import org.openstreetmap.atlas.tags.AmenityTag;
 import org.openstreetmap.atlas.tags.AreaTag;
 import org.openstreetmap.atlas.tags.BuildingTag;
 import org.openstreetmap.atlas.tags.CoveredTag;
+import org.openstreetmap.atlas.tags.EntranceTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
 import org.openstreetmap.atlas.tags.ServiceTag;
@@ -47,8 +48,8 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                         TunnelTag.YES)
                 || Validators.isOfType(edge, AreaTag.class, AreaTag.YES)
                 || YES_VALUE.equals(edge.tag(INDOOR_KEY))
-                || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
-                        && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY))
+                || Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
+                        && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY)
                 || edge.connectedNodes().stream().anyMatch(
                         node -> Validators.isOfType(node, EntranceTag.class, EntranceTag.YES)
                                 || Validators.isOfType(node, AmenityTag.class,

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -46,7 +46,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 || Validators.isOfType(edge, TunnelTag.class, TunnelTag.BUILDING_PASSAGE,
                         TunnelTag.YES)
                 || Validators.isOfType(edge, AreaTag.class, AreaTag.YES)
-                || (edge.getTag(INDOOR_KEY).isPresent() && edge.tag(INDOOR_KEY).equals(YES_VALUE))
+                || YES_VALUE.equals(edge.tag(INDOOR_KEY))
                 || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
                         && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY))
                 || edge.connectedNodes().stream().anyMatch(
@@ -88,17 +88,10 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
         final Node edgeStart = edge.start();
         final Node edgeEnd = edge.end();
         final Set<Location> intersections = building.asPolygon().intersections(edge.asPolyLine());
-        if (intersections.size() == 1
-                && !building.asPolygon().fullyGeometricallyEncloses(edge.asPolyLine()))
-        {
-            if (intersections.contains(edgeStart.getLocation())
-                    || intersections.contains(edgeEnd.getLocation()))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return intersections.size() == 1
+                && !building.asPolygon().fullyGeometricallyEncloses(edge.asPolyLine())
+                && (intersections.contains(edgeStart.getLocation())
+                        || intersections.contains(edgeEnd.getLocation()));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -47,13 +47,13 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 || Validators.isOfType(edge, TunnelTag.class, TunnelTag.BUILDING_PASSAGE,
                         TunnelTag.YES)
                 || Validators.isOfType(edge, AreaTag.class, AreaTag.YES)
-                || (edge.getTag(INDOOR_KEY).isPresent()
-                        && edge.tag(INDOOR_KEY).equals(YES_VALUE))
+                || (edge.getTag(INDOOR_KEY).isPresent() && edge.tag(INDOOR_KEY).equals(YES_VALUE))
                 || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
                         && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY))
                 || Validators.isOfType(edge, BuildingTag.class, BuildingTag.APARTMENTS)
                 || edge.connectedNodes().stream()
-                        .anyMatch(node -> node.getTag(ENTRANCE_KEY).isPresent()));
+                        .anyMatch(node -> node.getTag(ENTRANCE_KEY).isPresent() || Validators
+                                .isOfType(node, AmenityTag.class, AmenityTag.PARKING_ENTRANCE)));
     }
 
     private static Predicate<Edge> intersectsCoreWayInvalidly(final Area building)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -36,7 +36,6 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
 {
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
             .asList("Building (id-{0,number,#}) intersects road (id-{1,number,#})");
-    private static final String ENTRANCE_KEY = "entrance";
     private static final String INDOOR_KEY = "indoor";
     private static final String YES_VALUE = "yes";
     private static final long serialVersionUID = 5986017212661374165L;
@@ -51,9 +50,10 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
                         && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY))
                 || Validators.isOfType(edge, BuildingTag.class, BuildingTag.APARTMENTS)
-                || edge.connectedNodes().stream()
-                        .anyMatch(node -> node.getTag(ENTRANCE_KEY).isPresent() || Validators
-                                .isOfType(node, AmenityTag.class, AmenityTag.PARKING_ENTRANCE)));
+                || edge.connectedNodes().stream().anyMatch(
+                        node -> Validators.isOfType(node, EntranceTag.class, EntranceTag.YES)
+                                || Validators.isOfType(node, AmenityTag.class,
+                                        AmenityTag.PARKING_ENTRANCE)));
     }
 
     private static Predicate<Edge> intersectsCoreWayInvalidly(final Area building)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -49,7 +49,6 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 || (edge.getTag(INDOOR_KEY).isPresent() && edge.tag(INDOOR_KEY).equals(YES_VALUE))
                 || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
                         && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY))
-                || Validators.isOfType(edge, BuildingTag.class, BuildingTag.APARTMENTS)
                 || edge.connectedNodes().stream().anyMatch(
                         node -> Validators.isOfType(node, EntranceTag.class, EntranceTag.YES)
                                 || Validators.isOfType(node, AmenityTag.class,

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -87,4 +87,25 @@ public class BuildingRoadIntersectionCheckTest
         this.verifier.actual(this.setup.getLayeredAtlas(), check);
         this.verifier.verifyExpectedSize(0);
     }
+
+    @Test
+    public void testEdgeAreaYesAtlas()
+    {
+        this.verifier.actual(this.setup.getEdgeAreaYesAtlas(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testEdgeIndoorYesAtlas()
+    {
+        this.verifier.actual(this.setup.getEdgeIndoorYesAtlas(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testEdgeHighWayServiceAtlas()
+    {
+        this.verifier.actual(this.setup.getEdgeHighWayServiceAtlas(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -58,7 +58,11 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                     // Another variation of a Pedestrian Area - not flagged
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
-                            @Loc(value = TEST_6) }, tags = { "highway=pedestrian", "area=yes" }) })
+                            @Loc(value = TEST_6) }, tags = { "highway=pedestrian", "area=yes" }),
+                    // Parking area - not flagged
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "parking=yes" }) })
     private Atlas atlas;
     @TestAtlas(loadFromTextResource = "covered.atlas")
     private Atlas coveredAtlas;
@@ -110,6 +114,62 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                                     "building=house" }) })
     private Atlas layered;
 
+    @TestAtlas(
+
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+
+                    @Edge(id = "292929292929", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "area=yes" }) },
+
+            areas = {
+                    // Regular building - flagged
+                    @Area(id = "323232323232", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "building=yes" }) })
+    private Atlas edgeAreaYesAtlas;
+
+    @TestAtlas(
+
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+
+                    @Edge(id = "292929292929", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "indoor=yes" }) },
+
+            areas = {
+                    // Regular building - flagged
+                    @Area(id = "323232323232", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "building=yes" }) })
+    private Atlas edgeIndoorYesAtlas;
+
+    @TestAtlas(
+
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+
+                    @Edge(id = "292929292929", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                                    "highway=service", "service=driveway" }) },
+
+            areas = {
+                    // Regular building - flagged
+                    @Area(id = "323232323232", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "building=yes" }) })
+    private Atlas edgeHighWayServiceAtlas;
+
     public Atlas getAtlas()
     {
         return this.atlas;
@@ -128,5 +188,20 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
     public Atlas getLayeredAtlas()
     {
         return this.layered;
+    }
+
+    public Atlas getEdgeAreaYesAtlas()
+    {
+        return this.edgeAreaYesAtlas;
+    }
+
+    public Atlas getEdgeIndoorYesAtlas()
+    {
+        return this.edgeIndoorYesAtlas;
+    }
+
+    public Atlas getEdgeHighWayServiceAtlas()
+    {
+        return this.edgeHighWayServiceAtlas;
     }
 }


### PR DESCRIPTION
The Building Road Intersection (BRI) integrity check is meant to analyze overlap between roads and buildings. Barring exceptions for certain scenarios, the geometry for a road and that for a building’s boundary are not supposed to intersect each other.

This PR depends on Atlas PR [#110](https://github.com/osmlab/atlas/pull/110) for the AmenityTag.PARKING_ENTRANCE enum, and Atlas PR [#121](https://github.com/osmlab/atlas/pull/121) for the EntranceTag.java functionality.

**Added functionality:**
- Ignore tag amenity=parking
- Ignore roads/buildings who intersect at a Node which is labeled Parking Garage Entrance/Exit or entrance=yes
- Ignore tag area=yes
- Ignore tag indoor=yes
- Ignore tag tunnel=yes
- Ignore tag highway=service when intersecting building with tag amenity=fuel
- Ignore Ways with tags highway=service and service=driveway

**OSM Examples:**
Example 1:
- Building Feature: https://www.openstreetmap.org/way/310947685
- Road Feature: https://www.openstreetmap.org/way/189212967

Example 2:
- Building Feature: https://www.openstreetmap.org/way/108232856
- Road Feature: https://www.openstreetmap.org/way/525007924
