### PR TITLE
Update README and gradlew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 **/out/
 /bin/
 **/ignored/
+/data/*.pbf

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ To run Atlas Checks the following is required:
 To start working with Checks follow the steps below:
 1. Clone Atlas Checks project using following command `git clone https://github.com/osmlab/atlas-checks.git`
 2. Switch to newly created directory: `cd atlas-checks`
+3. Download an OSM PBF file and place it in the `/data/` directory.
 3. Execute `gradle run`
 
-This command will build and run Atlas Checks with all the default options against the country Anguilla. GeoJSON output will be be produced that contains all the results found from the run. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
+This command will build and run Atlas Checks with all the default options against OSM PBF that you put in the data directory.. GeoJSON output will be be produced that contains all the results found from the run. Those outputs will be found in `/build/geojson/`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
 
 ## Working with Configuration
 See [configuration docs](docs/configuration.md) for more information about the configuration files that can be used to define specific details around the Atlas Checks application.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To start working with Checks follow the steps below:
 1. Clone Atlas Checks project using following command `git clone https://github.com/osmlab/atlas-checks.git`
 2. Switch to newly created directory: `cd atlas-checks`
 3. Download an OSM PBF file and place it in the `/data/` directory.
-3. Execute `gradle run`
+3. Execute `./gradlew run`
 
 This command will build and run Atlas Checks with all the default options against OSM PBF that you put in the data directory.. GeoJSON output will be be produced that contains all the results found from the run. Those outputs will be found in `/build/geojson/`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -20,13 +20,13 @@ There are a couple of requirements for building and running a new Atlas Check. T
 
 ### Building Check Template
 Building a check template is as easy as running a very basic command using gradle:
-`gradle buildCheck -PCheckName=CheckName`
+`./gradlew buildCheck -PCheckName=CheckName`
 
 The value "CheckName" can and should be changed with whatever represents the check that you are planning to 
 write more clearly. So if you are writing a check to make sure that any areas tagged as pools are not larger 
 than a certain maximum or smaller than a certain minimum, then we might call that check "PoolSizeCheck", 
 and would be done like so:
-`gradle buildCheck -PCheckName=PoolSizeCheck`
+`./gradlew buildCheck -PCheckName=PoolSizeCheck`
 
 This command would be required to be run inside the Atlas-Checks root folder, and would provide the following updates:
 - Creates new file src/main/java/org/openstreetmap/atlas/checks/validation/PoolSizeCheck
@@ -142,7 +142,7 @@ all the configuration values for the system and the checks themselves. For more 
 #### Results
 
 To execute our check(s), we simply need to run the following gradle command:
-`gradle run`
+`./gradlew run`
 
 This will execute our flag using the default configuration. For executing with advanced properties see 
 [Atlas Checks Standalone Application](standalone.md).

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -18,7 +18,7 @@ Gradle will look inside this folder [data/](../data/) for any atlas or PBF files
 Atlas Checks allows you to run the checks against PBF files. If you have downloaded a PBF file you can simply
 place the PBF in the [data/](../data/) directory and execute
 
-`gradle run`
+`./gradlew run`
 
 If you want to supply a location to a remote PBF you can use a project property in Gradle to set the PBF location
 and execute
@@ -33,7 +33,7 @@ area allows Atlas Checks to complete faster, or simply for focus. Like running a
 the PBF file using either a URL location or a local file, but in this case you would include the bounding
 box as well.
 
-`gradle run -Pchecks.local.input=https://download.geofabrik.de/africa/south-africa-latest.osm.pbf -Pchecks.local.pbfBoundingBox=lat,lon:lat,lon`
+`./gradlew run -Pchecks.local.input=https://download.geofabrik.de/africa/south-africa-latest.osm.pbf -Pchecks.local.pbfBoundingBox=lat,lon:lat,lon`
 
 In the above case you would replace lat,lon:lat,lon with the actual bounds of your box.
 
@@ -44,7 +44,7 @@ execute the checks over the Atlas file. Ordinarily the Atlas file will simply be
 then garbage collected once we are finished with it. However it may be useful to save the Atlas for later usage, you
 can do this by adding the `savePbfAtlas` flag to your gradle command, like so:
 
-`gradle run -Pchecks.local.savePbfAtlas=true`
+`./gradlew run -Pchecks.local.savePbfAtlas=true`
 
 #### Output File Formats
 
@@ -60,7 +60,7 @@ GeometryCollection within a GeoJson Feature that has aggregate information withi
 By default, all output formats are enabled. This can be changed by setting the `outputFormat` flag to a comma-separated list'
 of desired formats, like so:
 
-`gradle run -Pchecks.local.outputFormats=geojson,metrics`
+`./gradlew run -Pchecks.local.outputFormats=geojson,metrics`
 
 #### Publish directly to MapRoulette
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 07 14:37:03 PDT 2017
+#Thu May 10 08:52:16 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip


### PR DESCRIPTION
Hey!

I just got atlas checks running on my machine, and I have a small detail in the README that explains that the user does indeed need to put a PBF in the data dir. Also, I updated the gradlew, which pointed to a very old gradle. This way, users can call gradlew and be assured that it will be using the version of gradle we intend.

cc/ @savannahostrowski 