### PR TITLE
Converting all MR Challenge defaultPriority values to integers

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -167,7 +167,7 @@ public class Challenge implements Serializable
             challengeJson.add(KEY_NAME, new JsonPrimitive(challengeName));
         }
 
-        if (this.defaultPriority != null && this.defaultPriority != ChallengePriority.NONE)
+        if (this.defaultPriority != null)
         {
             challengeJson.add(KEY_DEFAULT_PRIORITY,
                     new JsonPrimitive(this.defaultPriority.intValue()));


### PR DESCRIPTION
When creating a Challenge, the `defaultPriority` property in MapRoulette's `POST: /api/challenge` endpoint requires an integer. However, when `defaultPriority` is not defined in each check's challenge configuration, the `ChallengePriority.NONE` default value never gets converted into an integer (-1). Causing the following error:

```
{
    "status": "KO",
    "message": {
        "obj.defaultPriority": [
            {
                "msg": [
                    "error.expected.jsnumber"
                ],
                "args": []
            }
        ]
    }
}
```