### PR TITLE
Sharp Angle Check Enhancement

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -187,7 +187,7 @@
     }
   },
   "SharpAngleCheck": {
-    "threshold.degrees": 149.0,
+    "threshold.degrees": 97.0,
     "challenge": {
       "description": "Each task has edges that have an angle that is too sharp within their polyline. Sharp angles may indicate inaccurate digitization once this threshold is exceeded. There may be other factors in play here such as number of intersections, type of highway, etc. But the main breaking point is any angles that are less than 31.",
       "blurb": "Modify angles that are too acute for possible inaccurate digitization.",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
@@ -20,7 +20,7 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  * Flags edges that have an angle that is too sharp within their {@link PolyLine}. Sharp angles may
  * indicate inaccurate digitization once this threshold is exceeded. There may be other factors in
  * play here, such as number of intersections, type of highway, etc. But the main breaking point is
- * any angles that are less than 31 degrees.
+ * any angles that are less than 83 degrees.
  *
  * @author mgostintsev
  */

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
@@ -26,7 +26,7 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  */
 public class SharpAngleCheck extends BaseCheck<Long>
 {
-    private static final double THRESHOLD_DEGREES_DEFAULT = 149.0;
+    private static final double THRESHOLD_DEGREES_DEFAULT = 97.0;
     private static final String TOO_SHARP_INSTRUCTION_1 = "Highway {0,number,#} has too sharp an angle at {1}";
     private static final String TOO_SHARP_INSTRUCTION_2 = "Highway {0,number,#} has {1} angles that are too sharp";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(TOO_SHARP_INSTRUCTION_1,

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
@@ -1,0 +1,48 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Tests for {@link SharpAngleCheck}
+ *
+ * @author bbreithaupt
+ */
+public class SharpAngleCheckTest
+{
+    @Rule
+    public SharpAngleCheckTestRule setup = new SharpAngleCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final Configuration inlineConfiguration = ConfigurationResolver
+            .inlineConfiguration("{\"SharpAngleCheck\":{\"threshold.degrees\": 97.0}}");
+
+    @Test
+    public void sharpeAngle()
+    {
+        this.verifier.actual(this.setup.sharpeAngle(), new SharpAngleCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void notSharpeAngle()
+    {
+        this.verifier.actual(this.setup.notSharpeAngle(), new SharpAngleCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void sharpeAngles()
+    {
+        this.verifier.actual(this.setup.sharpeAngles(), new SharpAngleCheck(inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert
+                .assertTrue(flag.getInstructions().contains("2 angles that are too sharp")));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
@@ -24,23 +24,26 @@ public class SharpAngleCheckTest
             .inlineConfiguration("{\"SharpAngleCheck\":{\"threshold.degrees\": 97.0}}");
 
     @Test
-    public void sharpeAngle()
+    public void sharpeAngleTest()
     {
-        this.verifier.actual(this.setup.sharpeAngle(), new SharpAngleCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.sharpeAngleAtlas(),
+                new SharpAngleCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void notSharpeAngle()
+    public void notSharpeAngleTest()
     {
-        this.verifier.actual(this.setup.notSharpeAngle(), new SharpAngleCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.notSharpeAngleAtlas(),
+                new SharpAngleCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void sharpeAngles()
+    public void sharpeAnglesTest()
     {
-        this.verifier.actual(this.setup.sharpeAngles(), new SharpAngleCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.sharpeAnglesAtlas(),
+                new SharpAngleCheck(inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert
                 .assertTrue(flag.getInstructions().contains("2 angles that are too sharp")));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTestRule.java
@@ -25,7 +25,7 @@ public class SharpAngleCheckTestRule extends CoreTestRule
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
                     @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }) })
-    private Atlas sharpeAngle;
+    private Atlas sharpeAngleAtlas;
 
     @TestAtlas(
             // nodes
@@ -34,7 +34,7 @@ public class SharpAngleCheckTestRule extends CoreTestRule
             // edges
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_2),
                     @Loc(value = TEST_3), @Loc(value = TEST_1) }, tags = { "highway=motorway" }) })
-    private Atlas notSharpeAngle;
+    private Atlas notSharpeAngleAtlas;
 
     @TestAtlas(
             // nodes
@@ -43,20 +43,20 @@ public class SharpAngleCheckTestRule extends CoreTestRule
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_3),
                     @Loc(value = TEST_2), @Loc(value = TEST_1),
                     @Loc(value = TEST_3) }, tags = { "highway=motorway" }) })
-    private Atlas sharpeAngles;
+    private Atlas sharpeAnglesAtlas;
 
-    public Atlas sharpeAngle()
+    public Atlas sharpeAngleAtlas()
     {
-        return this.sharpeAngle;
+        return this.sharpeAngleAtlas;
     }
 
-    public Atlas notSharpeAngle()
+    public Atlas notSharpeAngleAtlas()
     {
-        return this.notSharpeAngle;
+        return this.notSharpeAngleAtlas;
     }
 
-    public Atlas sharpeAngles()
+    public Atlas sharpeAnglesAtlas()
     {
-        return this.sharpeAngles;
+        return this.sharpeAnglesAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTestRule.java
@@ -1,0 +1,62 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Tests for {@link SharpAngleCheck}
+ *
+ * @author bbreithaupt
+ */
+public class SharpAngleCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "48.040836812424,-122.947197210666";
+    private static final String TEST_2 = "48.0404742717597,-122.946636785158";
+    private static final String TEST_3 = "48.0405764317775,-122.947086805021";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }) })
+    private Atlas sharpeAngle;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_1)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_2),
+                    @Loc(value = TEST_3), @Loc(value = TEST_1) }, tags = { "highway=motorway" }) })
+    private Atlas notSharpeAngle;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_3)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_3),
+                    @Loc(value = TEST_2), @Loc(value = TEST_1),
+                    @Loc(value = TEST_3) }, tags = { "highway=motorway" }) })
+    private Atlas sharpeAngles;
+
+    public Atlas sharpeAngle()
+    {
+        return this.sharpeAngle;
+    }
+
+    public Atlas notSharpeAngle()
+    {
+        return this.notSharpeAngle;
+    }
+
+    public Atlas sharpeAngles()
+    {
+        return this.sharpeAngles;
+    }
+}


### PR DESCRIPTION
This enhancement changes the default threshold.degrees, and adds unit tests.

The default threshold.degrees was changed from 149 to 97. This appears to catch about 3 times more true positive cases, without adding any false positives.