### PR TITLE
IntersectingBuildingsCheck config typo

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -115,7 +115,7 @@
       "tags":"highway"
     }
   },
-  "IntersectingBuildingCheck":
+  "IntersectingBuildingsCheck":
   {
     "intersection.lower.limit": 0.01,
     "challenge": {


### PR DESCRIPTION
This updates a typo in the `IntersectingBuildingsCheck` configuration. 