### PR TITLE
Unregister processor on the event service

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
@@ -96,4 +96,17 @@ public final class EventService
     {
         this.eventBus.register(processor);
     }
+
+    /**
+     * Unregisters given {@link Processor}
+     *
+     * @param <T>
+     *            processor event type that is going to be registered
+     * @param processor
+     *            {@link Processor} to unregister
+     */
+    public <T extends Event> void unRegister(final Processor<T> processor)
+    {
+        this.eventBus.unregister(processor);
+    }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
@@ -105,7 +105,7 @@ public final class EventService
      * @param processor
      *            {@link Processor} to unregister
      */
-    public <T extends Event> void unRegister(final Processor<T> processor)
+    public <T extends Event> void unregister(final Processor<T> processor)
     {
         this.eventBus.unregister(processor);
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
@@ -153,7 +153,7 @@ public class EventServiceTest
                 .get("Event service for unregistering processor");
 
         eventService.register(testProcessor);
-        eventService.unRegister(testProcessor);
+        eventService.unregister(testProcessor);
         eventService.post(new TestEvent("TESTING"));
 
         eventService.complete();

--- a/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
@@ -147,7 +147,6 @@ public class EventServiceTest
     @Test
     public void testUnregisterProcessor()
     {
-
         final TestProcessor testProcessor = new TestProcessor();
         final EventService eventService = EventService
                 .get("Event service for unregistering processor");

--- a/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
@@ -145,6 +145,24 @@ public class EventServiceTest
     }
 
     @Test
+    public void testUnregisterProcessor()
+    {
+
+        final TestProcessor testProcessor = new TestProcessor();
+        final EventService eventService = EventService
+                .get("Event service for unregistering processor");
+
+        eventService.register(testProcessor);
+        eventService.unRegister(testProcessor);
+        eventService.post(new TestEvent("TESTING"));
+
+        eventService.complete();
+
+        Assert.assertEquals(0, testProcessor.getCompleteCount());
+        Assert.assertEquals(0, testProcessor.getProcessCount());
+    }
+
+    @Test
     public void testZeroComplete()
     {
         testCompleteCount(0);


### PR DESCRIPTION
Allow functionality to unregister processors you no long want on the event bus. 