### PR TITLE
Fix Event Service bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
@@ -62,7 +62,7 @@ public final class EventService
         }
 
         this.eventBus.post(new ShutdownEvent());
-        this.processors.forEach(this::unregister);
+        new HashSet<>(this.processors).forEach(this::unregister);
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/EventServiceTest.java
@@ -205,9 +205,11 @@ public class EventServiceTest
     private void testProcessCount(final int threadCount, final int eventCount)
     {
         final TestProcessor testProcessor = new TestProcessor();
+        final TestProcessor otherProcessor = new TestProcessor();
         final EventService eventService = EventService
                 .get("Test service for " + threadCount + "-" + eventCount);
         eventService.register(testProcessor);
+        eventService.register(otherProcessor);
 
         // Send events
         final Pool threadPool = new Pool(threadCount,


### PR DESCRIPTION
### Description:

Addresses the issue: https://github.com/osmlab/atlas-checks/issues/81  where the processors were getting removed from the collection they were iterating from. This was missed because none of the tests used more than one processors. I duplicated the bug by adding another processor to the common test class method, then fixed by creating anew collection to iterate through upon completion of the EventService. 

### Potential Impact:

No more exception for more than one event service processor. 

### Unit Test Approach:

Add line to common function used in many test classes that exposes bug.

### Test Results:

Fix gets rid of the bug. 
