### PR TITLE
CheckFlagEvent HighwayTag Bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -23,7 +23,7 @@ import com.google.gson.JsonPrimitive;
  * Wraps a {@link CheckFlag} for submission to the {@link EventService} for handling {@link Check}
  * results
  *
- * @author mkalender
+ * @author mkalender, bbreithaupt
  */
 public final class CheckFlagEvent extends Event
 {
@@ -133,11 +133,19 @@ public final class CheckFlagEvent extends Event
         {
             final HighwayTag baslineHighwayTag = highestHighwayTag == null ? HighwayTag.NO
                     : highestHighwayTag;
-            highestHighwayTag = Optional
-                    .ofNullable(((JsonObject) featureProperty).getAsJsonPrimitive(HighwayTag.KEY))
-                    .map(JsonPrimitive::getAsString).map(String::toUpperCase)
-                    .map(HighwayTag::valueOf).filter(baslineHighwayTag::isLessImportantThan)
-                    .orElse(highestHighwayTag);
+            try
+            {
+                highestHighwayTag = Optional
+                        .ofNullable(
+                                ((JsonObject) featureProperty).getAsJsonPrimitive(HighwayTag.KEY))
+                        .map(JsonPrimitive::getAsString).map(String::toUpperCase)
+                        .map(HighwayTag::valueOf).filter(baslineHighwayTag::isLessImportantThan)
+                        .orElse(highestHighwayTag);
+            }
+            catch (final IllegalArgumentException badValue)
+            {
+                return Optional.empty();
+            }
         }
         return Optional.ofNullable(highestHighwayTag)
                 .map(tag -> String.format("%s=%s", HighwayTag.KEY, tag.getTagValue()));

--- a/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessorTestRule.java
@@ -13,7 +13,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 /**
  * {@link CheckFlagGeoJsonProcessorTest} test data
  *
- * @author brian_l_davis
+ * @author brian_l_davis, bbreithaupt
  */
 public class CheckFlagGeoJsonProcessorTestRule extends CoreTestRule
 {
@@ -44,7 +44,8 @@ public class CheckFlagGeoJsonProcessorTestRule extends CoreTestRule
 
                     @Area(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
-                            @Loc(value = TEST_6) }, tags = { "building=yes" }) })
+                            @Loc(value = TEST_6) }, tags = { "building=yes",
+                                    "highway=notanenumvalue" }) })
     private Atlas atlas;
 
     public CheckFlagEvent getCheckFlagEvent()


### PR DESCRIPTION
### Description:

This PR is to fix https://github.com/osmlab/atlas-checks/issues/87. A try catch statement is used to ignore bad highway tag values. 

### Potential Impact:

Stop the exception from stopping the program.

### Unit Test Approach:

A bad highway tag was added to the Area in the test atlas to test for this bug. 

### Test Results:

None

