### PR TITLE
Update InvalidLanesTagCheck Filter

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -139,7 +139,7 @@
     }
   },
   "InvalidLanesTagCheck": {
-    "lanes.filter": "Lanes->1,1.5,2,3,4,5,6,7,8,9,10",
+    "lanes.filter": "lanes->1,1.5,2,3,4,5,6,7,8,9,10",
     "challenge":{
       "description":"Tasks contain invalid values for the lanes tag.",
       "blurb":"Invalid Lanes Tags",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -33,7 +33,7 @@ public class InvalidLanesTagCheck extends BaseCheck
     // Maximum number of connected edges that are checked for toll booth nodes
     private static final int MAX_TOLL_PLAZA_EDGES = 20;
     // Valid values of the lanes OSM key
-    private static final String LANES_FILTER_DEFAULT = "Lanes->1,1.5,2,3,4,5,6,7,8,9,10";
+    private static final String LANES_FILTER_DEFAULT = "lanes->1,1.5,2,3,4,5,6,7,8,9,10";
     private final TaggableFilter lanesFilter;
 
     // Edges that can skip the toll booth test, because they have already been checked.


### PR DESCRIPTION
### Description:

This PR changes the 'L' in 'Lanes' to be lowercase for the `lanesFilter`. This was acceptable before the recent updates the TaggableFilter class in atlas, but no longer gets automatically converted to all lower case. Without this fix, this check is currently flagging every car navigable edge with a lanes tag. 

### Potential Impact:

The check will once again work as intended with default values. 

### Unit Test Approach:

Nothing changed. 

### Test Results:

Ran this on multiple countries before and after. Flag counts dropped back to normal after the fix. 

