### PR TITLE
Building Road Intersection Check Enhancement

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -36,6 +36,7 @@
     }
   },
   "BuildingRoadIntersectionCheck": {
+    "highway.filter": "highway->motorway_link,primary_link,primary,residential,secondary_link,secondary,service,tertiary_link,tertiary,track,trunk_link,trunk,unclassified,motorway,road",
     "challenge": {
       "description": "Tasks contain buildings which intersect with surrounding roads",
       "blurb": "Intersecting Buildings and Roads",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -36,7 +36,7 @@
     }
   },
   "BuildingRoadIntersectionCheck": {
-    "highway.car.navigable": true,
+    "car.navigable": true,
     "challenge": {
       "description": "Tasks contain buildings which intersect with surrounding roads",
       "blurb": "Intersecting Buildings and Roads",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -36,7 +36,7 @@
     }
   },
   "BuildingRoadIntersectionCheck": {
-    "highway.filter": "highway->motorway_link,primary_link,primary,residential,secondary_link,secondary,service,tertiary_link,tertiary,track,trunk_link,trunk,unclassified,motorway,road",
+    "highway.car.navigable": true,
     "challenge": {
       "description": "Tasks contain buildings which intersect with surrounding roads",
       "blurb": "Intersecting Buildings and Roads",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -89,7 +89,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 // And if the building/edge intersection is not valid
                 && !isValidIntersection(building, edge)
                 // And if the edge has no Access = Private tag
-                && !AccessTag.isPrivate(edge);
+                && !Validators.isOfType(edge, AccessTag.class, AccessTag.PRIVATE);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -37,7 +37,8 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * the intersecting highways will be checked for tags in the enum set "CAR_NAVIGABLE_HIGHWAYS", else
  * checked for tags in "CORE_WAYS" enum set in the {@link HighwayTag} class.
  *
- * @author mgostintsev, sayas01
+ * @author mgostintsev
+ * @author sayas01
  */
 public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
 {
@@ -63,12 +64,9 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                         && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY)
                 || edge.connectedNodes().stream().anyMatch(node -> Validators.isOfType(node,
                         EntranceTag.class, EntranceTag.YES)
-                        || Validators.isOfType(node, AmenityTag.class, AmenityTag.PARKING_ENTRANCE))
-                // Ignore edges with nodes containing Barrier tags
-                || edge.getAtlas()
-                        .nodesWithin(edge.bounds(),
-                                node -> Validators.hasValuesFor(node, BarrierTag.class))
-                        .iterator().hasNext());
+                        || Validators.isOfType(node, AmenityTag.class, AmenityTag.PARKING_ENTRANCE)
+                        // Ignore edges with nodes containing Barrier tags
+                        || Validators.hasValuesFor(node, BarrierTag.class)));
     }
 
     private Predicate<Edge> intersectsCoreWayInvalidly(final Area building)
@@ -184,10 +182,10 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 flag.addObject(edge, this.getLocalizedInstruction(instructionIndex,
                         building.getOsmIdentifier(), edge.getOsmIdentifier()));
                 knownIntersections.add(edge);
-                final Optional<Edge> reverseEdge = edge.reversed();
-                if (reverseEdge.isPresent())
+                final Optional<Edge> reversedEdge = edge.reversed();
+                if (reversedEdge.isPresent())
                 {
-                    knownIntersections.add(reverseEdge.get());
+                    knownIntersections.add(reversedEdge.get());
                 }
             }
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -63,8 +63,9 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                         EntranceTag.class, EntranceTag.YES)
                         || Validators.isOfType(node, AmenityTag.class, AmenityTag.PARKING_ENTRANCE))
                 // Ignore edges with nodes containing Barrier tags
-                || edge.getAtlas().nodesWithin(edge.bounds(),
-                        node -> Validators.isOfType(node, BarrierTag.class, BarrierTag.values()))
+                || edge.getAtlas()
+                        .nodesWithin(edge.bounds(),
+                                node -> Validators.hasValuesFor(node, BarrierTag.class))
                         .iterator().hasNext());
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -47,9 +47,9 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
             .asList(BUILDING_ROAD_INTERSECTION_INSTRUCTION, SERVICE_ROAD_INTERSECTION_INSTRUCTION);
     private static final String INDOOR_KEY = "indoor";
     private static final String YES_VALUE = "yes";
-    private static final Predicate<Edge> highwayServiceTag = edge -> Validators.isOfType(edge,
+    private static final Predicate<Edge> HIGHWAY_SERVICE_TAG = edge -> Validators.isOfType(edge,
             HighwayTag.class, HighwayTag.SERVICE);
-    private final Boolean isCarNavigable;
+    private final Boolean carNavigableEdgesOnly;
     private static final long serialVersionUID = 5986017212661374165L;
 
     private static Predicate<Edge> ignoreTags()
@@ -59,7 +59,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                         TunnelTag.YES)
                 || Validators.isOfType(edge, AreaTag.class, AreaTag.YES)
                 || YES_VALUE.equals(edge.tag(INDOOR_KEY))
-                || highwayServiceTag.test(edge)
+                || HIGHWAY_SERVICE_TAG.test(edge)
                         && Validators.isOfType(edge, ServiceTag.class, ServiceTag.DRIVEWAY)
                 || edge.connectedNodes().stream().anyMatch(node -> Validators.isOfType(node,
                         EntranceTag.class, EntranceTag.YES)
@@ -75,18 +75,14 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
     {
         // An invalid intersection is determined by checking that its highway tag is car navigable
         // or core way based on the configuration value
-        return edge -> (this.isCarNavigable ? HighwayTag.isCarNavigableHighway(edge)
+        return edge -> (this.carNavigableEdgesOnly ? HighwayTag.isCarNavigableHighway(edge)
                 : HighwayTag.isCoreWay(edge))
                 // And if the edge intersects the building polygon
                 && edge.asPolyLine().intersects(building.asPolygon())
                 // And ignore intersections where edge has highway=service and building has
                 // Amenity=fuel
-                && !(highwayServiceTag.test(edge)
+                && !(HIGHWAY_SERVICE_TAG.test(edge)
                         && Validators.isOfType(building, AmenityTag.class, AmenityTag.FUEL))
-                // And ignore intersections where building has points within it with Amenity=fuel
-                && !edge.getAtlas().pointsWithin(building.asPolygon(),
-                        point -> Validators.isOfType(point, AmenityTag.class, AmenityTag.FUEL))
-                        .iterator().hasNext()
                 // And if the layers have the same layer value
                 && LayerTag.getTaggedValue(edge).orElse(0L)
                         .equals(LayerTag.getTaggedValue(building).orElse(0L))
@@ -127,7 +123,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
     public BuildingRoadIntersectionCheck(final Configuration configuration)
     {
         super(configuration);
-        this.isCarNavigable = this.configurationValue(configuration, "car.navigable", true);
+        this.carNavigableEdgesOnly = this.configurationValue(configuration, "car.navigable", true);
     }
 
     @Override
@@ -139,7 +135,11 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
         return object instanceof Area && BuildingTag.isBuilding(object)
                 && !HighwayTag.isHighwayArea(object)
                 && !Validators.isOfType(object, AmenityTag.class, AmenityTag.PARKING)
-                && !Validators.isOfType(object, BuildingTag.class, BuildingTag.ROOF);
+                && !Validators.isOfType(object, BuildingTag.class, BuildingTag.ROOF)
+                // Ignore buildings that have points withing it with Ameniity=Fuel
+                && !object.getAtlas().pointsWithin(((Area) object).asPolygon(),
+                        point -> Validators.isOfType(point, AmenityTag.class, AmenityTag.FUEL))
+                        .iterator().hasNext();
     }
 
     @Override
@@ -147,7 +147,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
     {
         final Area building = (Area) object;
         final Iterable<Edge> intersectingEdges = Iterables.filter(building.getAtlas()
-                .edgesIntersecting(building.bounds(), intersectsCoreWayInvalidly(building)),
+                .edgesIntersecting(building.bounds(), this.intersectsCoreWayInvalidly(building)),
                 ignoreTags());
         final CheckFlag flag = new CheckFlag(getTaskIdentifier(building));
         flag.addObject(building);
@@ -180,7 +180,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
         {
             if (!knownIntersections.contains(edge))
             {
-                final int instructionIndex = highwayServiceTag.test(edge) ? 1 : 0;
+                final int instructionIndex = HIGHWAY_SERVICE_TAG.test(edge) ? 1 : 0;
                 flag.addObject(edge, this.getLocalizedInstruction(instructionIndex,
                         building.getOsmIdentifier(), edge.getOsmIdentifier()));
                 knownIntersections.add(edge);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -83,7 +83,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 // Amenity=fuel
                 && !(highwayServiceTag.test(edge)
                         && Validators.isOfType(building, AmenityTag.class, AmenityTag.FUEL))
-                // And ignore intersections where building has nodes within it with Amenity=fuel
+                // And ignore intersections where building has points within it with Amenity=fuel
                 && !edge.getAtlas().pointsWithin(building.asPolygon(),
                         point -> Validators.isOfType(point, AmenityTag.class, AmenityTag.FUEL))
                         .iterator().hasNext()

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -59,9 +59,9 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 || edge.connectedNodes().stream().anyMatch(node -> Validators.isOfType(node,
                         EntranceTag.class, EntranceTag.YES)
                         || Validators.isOfType(node, AmenityTag.class, AmenityTag.PARKING_ENTRANCE))
-                || (highwayServiceValidator.test(edge) && edge.getAtlas().nodesWithin(edge.bounds(),
+                || edge.getAtlas().nodesWithin(edge.bounds(),
                         node -> Validators.isOfType(node, BarrierTag.class, BarrierTag.values()))
-                        .iterator().next() != null));
+                        .iterator().next() != null);
     }
 
     private static Predicate<Edge> intersectsCoreWayInvalidly(final Area building)
@@ -75,10 +75,9 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 && !(highwayServiceValidator.test(edge)
                         && Validators.isOfType(building, AmenityTag.class, AmenityTag.FUEL))
 
-                && !(highwayServiceValidator.test(edge) && edge
-                        .getAtlas().pointsWithin(building.asPolygon(), point -> Validators
-                                .isOfType(point, AmenityTag.class, AmenityTag.FUEL))
-                        .iterator().hasNext())
+                && !edge.getAtlas().pointsWithin(building.asPolygon(),
+                        point -> Validators.isOfType(point, AmenityTag.class, AmenityTag.FUEL))
+                        .iterator().hasNext()
                 // And if the layers have the same layer value
                 && LayerTag.getTaggedValue(edge).orElse(0L)
                         .equals(LayerTag.getTaggedValue(building).orElse(0L))
@@ -145,13 +144,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
         final CheckFlag flag = new CheckFlag(getTaskIdentifier(building));
         flag.addObject(building);
         this.handleIntersections(intersectingEdges, flag, building);
-
-        if (flag.getPolyLines().size() > 1)
-        {
-            return Optional.of(flag);
-        }
-
-        return Optional.empty();
+        return flag.getPolyLines().size() > 1 ? Optional.of(flag) : Optional.empty();
     }
 
     @Override
@@ -191,5 +184,4 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
             }
         }
     }
-
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -31,9 +31,11 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
  * Flags buildings that intersect/touch centerlines of roads. This doesn't address cases where
- * buildings get really close to roads, but don't overlap them. The highways that need to be tested
- * for intersection can be specified in the "highway.filter" config. By default all highways in the
- * CAR_NAVIGABLE_ENUM_SET of {@link HighwayTag} are checked for intersection.
+ * buildings get really close to roads, but don't overlap them. The configurable value
+ * "car.navigable" can be set to true or false, depending on which the validity of the intersecting
+ * highways will be checked. The default value of "car.navigable" is set to true. If set to true,
+ * the intersecting highways will be checked for tags in the enum set "CAR_NAVIGABLE_HIGHWAYS", else
+ * checked for tags in "CORE_WAYS" enum set in the {@link HighwayTag} class.
  *
  * @author mgostintsev, sayas01
  */
@@ -125,7 +127,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
     public BuildingRoadIntersectionCheck(final Configuration configuration)
     {
         super(configuration);
-        this.isCarNavigable = this.configurationValue(configuration, "highway.car.navigable", true);
+        this.isCarNavigable = this.configurationValue(configuration, "car.navigable", true);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -65,7 +65,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 // Ignore edges with nodes containing Barrier tags
                 || edge.getAtlas().nodesWithin(edge.bounds(),
                         node -> Validators.isOfType(node, BarrierTag.class, BarrierTag.values()))
-                        .iterator().next() != null);
+                        .iterator().hasNext());
     }
 
     private Predicate<Edge> intersectsCoreWayInvalidly(final Area building)
@@ -179,7 +179,6 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
             if (!knownIntersections.contains(edge))
             {
                 final int instructionIndex = highwayServiceValidator.test(edge) ? 1 : 0;
-
                 flag.addObject(edge, this.getLocalizedInstruction(instructionIndex,
                         building.getOsmIdentifier(), edge.getOsmIdentifier()));
                 knownIntersections.add(edge);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -126,7 +126,6 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
     {
         super(configuration);
         this.isCarNavigable = this.configurationValue(configuration, "highway.car.navigable", true);
-
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -80,7 +80,6 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
                 // Amenity=fuel
                 && !(highwayServiceValidator.test(edge)
                         && Validators.isOfType(building, AmenityTag.class, AmenityTag.FUEL))
-
                 // And ignore intersections where building has nodes within it with Amenity=fuel
                 && !edge.getAtlas().pointsWithin(building.asPolygon(),
                         point -> Validators.isOfType(point, AmenityTag.class, AmenityTag.FUEL))

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -19,7 +19,9 @@ public class BuildingRoadIntersectionCheckTest
     private static final BuildingRoadIntersectionCheck spanishCheck = new BuildingRoadIntersectionCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"CheckResourceLoader\": {\"scanUrls\": [\"org.openstreetmap.atlas.checks\"]},\"BuildingRoadIntersectionCheck\":{\"enabled\":true,\"locale\":\"es\",\"flags\":{\"en\":[\"Building (id-{0,number,#}) intersects road (id-{1,number,#})\"],\"es\":[\"Edificio(id-{0,number,#}) cruza calle(id-{1,number,#})\"]}}}"));
-
+    private static final BuildingRoadIntersectionCheck highwayFilterCheck = new BuildingRoadIntersectionCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"BuildingRoadIntersectionCheck\":{\"highway.filter\":\"highway->road\"}}"));
     @Rule
     public BuildingRoadIntersectionTestCaseRule setup = new BuildingRoadIntersectionTestCaseRule();
 
@@ -112,7 +114,14 @@ public class BuildingRoadIntersectionCheckTest
     @Test
     public void testPointsWithinBuilding()
     {
-        this.verifier.actual(this.setup.getNewAtlas(), check);
-        this.verifier.verifyExpectedSize(0);
+        this.verifier.actual(this.setup.getbuildingWithAmenityAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testHighwayFilterConfig()
+    {
+        this.verifier.actual(this.setup.getAtlas(), highwayFilterCheck);
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -21,7 +21,7 @@ public class BuildingRoadIntersectionCheckTest
                     "{\"CheckResourceLoader\": {\"scanUrls\": [\"org.openstreetmap.atlas.checks\"]},\"BuildingRoadIntersectionCheck\":{\"enabled\":true,\"locale\":\"es\",\"flags\":{\"en\":[\"Building (id-{0,number,#}) intersects road (id-{1,number,#})\"],\"es\":[\"Edificio(id-{0,number,#}) cruza calle(id-{1,number,#})\"]}}}"));
     private static final BuildingRoadIntersectionCheck highwayFilterCheck = new BuildingRoadIntersectionCheck(
             ConfigurationResolver.inlineConfiguration(
-                    "{\"BuildingRoadIntersectionCheck\":{\"highway.car.navigable\":false}}"));
+                    "{\"BuildingRoadIntersectionCheck\":{\"car.navigable\":false}}"));
     @Rule
     public BuildingRoadIntersectionTestCaseRule setup = new BuildingRoadIntersectionTestCaseRule();
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -21,7 +21,7 @@ public class BuildingRoadIntersectionCheckTest
                     "{\"CheckResourceLoader\": {\"scanUrls\": [\"org.openstreetmap.atlas.checks\"]},\"BuildingRoadIntersectionCheck\":{\"enabled\":true,\"locale\":\"es\",\"flags\":{\"en\":[\"Building (id-{0,number,#}) intersects road (id-{1,number,#})\"],\"es\":[\"Edificio(id-{0,number,#}) cruza calle(id-{1,number,#})\"]}}}"));
     private static final BuildingRoadIntersectionCheck highwayFilterCheck = new BuildingRoadIntersectionCheck(
             ConfigurationResolver.inlineConfiguration(
-                    "{\"BuildingRoadIntersectionCheck\":{\"highway.filter\":\"highway->road\"}}"));
+                    "{\"BuildingRoadIntersectionCheck\":{\"highway.car.navigable\":false}}"));
     @Rule
     public BuildingRoadIntersectionTestCaseRule setup = new BuildingRoadIntersectionTestCaseRule();
 
@@ -86,7 +86,7 @@ public class BuildingRoadIntersectionCheckTest
     @Test
     public void testLayered()
     {
-        this.verifier.actual(this.setup.getLayeredAtlas(), check);
+        this.verifier.actual(this.setup.getLayeredAtlas(), highwayFilterCheck);
         this.verifier.verifyExpectedSize(0);
     }
 
@@ -115,6 +115,7 @@ public class BuildingRoadIntersectionCheckTest
     public void testIgnoredPointsWithinBuildingAtlas()
     {
         this.verifier.actual(this.setup.getIgnoredPointsWithinBuildingAtlas(), check);
+        this.verifier.verifyExpectedSize(0);
         this.verifier.verifyEmpty();
     }
 
@@ -128,7 +129,7 @@ public class BuildingRoadIntersectionCheckTest
     @Test
     public void testHighwayFilterConfig()
     {
-        this.verifier.actual(this.setup.getAtlas(), highwayFilterCheck);
-        this.verifier.verifyEmpty();
+        this.verifier.actual(this.setup.getCorewayIntersectionAtlas(), highwayFilterCheck);
+        this.verifier.verifyExpectedSize(2);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -9,7 +9,8 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 /**
  * {@link BuildingRoadIntersectionCheck} unit test
  *
- * @author mgostintsev, sayas01
+ * @author mgostintsev
+ * @author sayas01
  */
 public class BuildingRoadIntersectionCheckTest
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -112,9 +112,16 @@ public class BuildingRoadIntersectionCheckTest
     }
 
     @Test
-    public void testPointsWithinBuilding()
+    public void testIgnoredPointsWithinBuildingAtlas()
     {
-        this.verifier.actual(this.setup.getbuildingWithAmenityAtlas(), check);
+        this.verifier.actual(this.setup.getIgnoredPointsWithinBuildingAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testIgnoredNodesWithinEdgeAtlas()
+    {
+        this.verifier.actual(this.setup.getIgnoredNodesWithinEdgeAtlas(), check);
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -108,4 +108,11 @@ public class BuildingRoadIntersectionCheckTest
         this.verifier.actual(this.setup.getEdgeHighWayServiceAtlas(), check);
         this.verifier.verifyExpectedSize(0);
     }
+
+    @Test
+    public void testPointsWithinBuilding()
+    {
+        this.verifier.actual(this.setup.getNewAtlas(), check);
+        this.verifier.verifyExpectedSize(0);
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -9,7 +9,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 /**
  * {@link BuildingRoadIntersectionCheck} unit test
  *
- * @author mgostintsev
+ * @author mgostintsev, sayas01
  */
 public class BuildingRoadIntersectionCheckTest
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheckTest.java
@@ -86,7 +86,7 @@ public class BuildingRoadIntersectionCheckTest
     @Test
     public void testLayered()
     {
-        this.verifier.actual(this.setup.getLayeredAtlas(), highwayFilterCheck);
+        this.verifier.actual(this.setup.getLayeredAtlas(), check);
         this.verifier.verifyExpectedSize(0);
     }
 
@@ -115,7 +115,6 @@ public class BuildingRoadIntersectionCheckTest
     public void testIgnoredPointsWithinBuildingAtlas()
     {
         this.verifier.actual(this.setup.getIgnoredPointsWithinBuildingAtlas(), check);
-        this.verifier.verifyExpectedSize(0);
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -205,16 +205,14 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                     @Loc(value = TEST_20), @Loc(value = TEST_30), @Loc(value = TEST_40),
                     @Loc(value = TEST_50), @Loc(value = TEST_60) }, tags = { "highway=service" }) },
 
-            areas = {
-                    // Regular building - flagged
-                    @Area(id = "3", coordinates = { @Loc(value = TEST_70), @Loc(value = TEST_80),
-                            @Loc(value = TEST_90), @Loc(value = TEST_100), @Loc(value = TEST_40),
-                            @Loc(value = TEST_30) }, tags = { "building=yes" }) })
-    private Atlas newAtlas;
+            areas = { @Area(id = "3", coordinates = { @Loc(value = TEST_70), @Loc(value = TEST_80),
+                    @Loc(value = TEST_90), @Loc(value = TEST_100), @Loc(value = TEST_40),
+                    @Loc(value = TEST_30) }, tags = { "building=yes" }) })
+    private Atlas buildingWithAmenityAtlas;
 
-    public Atlas getNewAtlas()
+    public Atlas getbuildingWithAmenityAtlas()
     {
-        return this.newAtlas;
+        return this.buildingWithAmenityAtlas;
     }
 
     public Atlas getAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -40,14 +40,13 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
     private static final String TEST_80 = "57.2274907, 60.0831821";
     private static final String TEST_90 = "57.2280190, 60.0838174";
     private static final String TEST_100 = "57.2278680, 60.0842460";
-
     private static final String TEST_101 = "57.2277097, 60.0837055";
 
     @TestAtlas(
 
-            nodes = { @Node(coordinates = @Loc(value = TEST_1), tags = { "barrier=*" }),
-                    @Node(coordinates = @Loc(value = TEST_2), tags = { "barrier=*" }),
-                    @Node(coordinates = @Loc(value = TEST_3), tags = { "barrier=*" }) },
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
 
             edges = {
 
@@ -208,11 +207,40 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
             areas = { @Area(id = "3", coordinates = { @Loc(value = TEST_70), @Loc(value = TEST_80),
                     @Loc(value = TEST_90), @Loc(value = TEST_100), @Loc(value = TEST_40),
                     @Loc(value = TEST_30) }, tags = { "building=yes" }) })
-    private Atlas buildingWithAmenityAtlas;
+    private Atlas ignoredPointsWithinBuildingAtlas;
 
-    public Atlas getbuildingWithAmenityAtlas()
+    @TestAtlas(
+
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3), tags = { "barrier=gate" }) },
+
+            edges = {
+
+                    @Edge(id = "292929292929", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=primary" }) },
+
+            areas = {
+                    // Regular building
+                    @Area(id = "323232323232", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "building=yes" }),
+                    // Non-Pedestrian Area
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "highway=primary",
+                                    "building=house" }) })
+    private Atlas ignoredNodesWithinEdgeAtlas;
+
+    public Atlas getIgnoredNodesWithinEdgeAtlas()
     {
-        return this.buildingWithAmenityAtlas;
+        return this.ignoredNodesWithinEdgeAtlas;
+    }
+
+    public Atlas getIgnoredPointsWithinBuildingAtlas()
+    {
+        return this.ignoredPointsWithinBuildingAtlas;
     }
 
     public Atlas getAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -7,6 +7,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
 
 /**
  * {@link BuildingRoadIntersectionCheckTest} test data
@@ -29,11 +30,24 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
     private static final String TEST_4 = "37.332451,-122.028932";
     private static final String TEST_5 = "37.317585,-122.052138";
     private static final String TEST_6 = "37.390535,-122.031007";
+    private static final String TEST_10 = "57.2278740, 60.0846234";
+    private static final String TEST_20 = "57.2279209, 60.0843459";
+    private static final String TEST_30 = "57.2279025, 60.0841482";
+    private static final String TEST_40 = "57.2273807, 60.0834945";
+    private static final String TEST_50 = "57.2272449, 60.0835572";
+    private static final String TEST_60 = "57.2271068, 60.0837054";
+    private static final String TEST_70 = "57.2273397, 60.0836107";
+    private static final String TEST_80 = "57.2274907, 60.0831821";
+    private static final String TEST_90 = "57.2280190, 60.0838174";
+    private static final String TEST_100 = "57.2278680, 60.0842460";
+
+    private static final String TEST_101 = "57.2277097, 60.0837055";
+
     @TestAtlas(
 
-            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
-                    @Node(coordinates = @Loc(value = TEST_2)),
-                    @Node(coordinates = @Loc(value = TEST_3)) },
+            nodes = { @Node(coordinates = @Loc(value = TEST_1), tags = { "barrier=*" }),
+                    @Node(coordinates = @Loc(value = TEST_2), tags = { "barrier=*" }),
+                    @Node(coordinates = @Loc(value = TEST_3), tags = { "barrier=*" }) },
 
             edges = {
 
@@ -169,6 +183,39 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                             @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_1),
                             @Loc(value = TEST_6) }, tags = { "building=yes" }) })
     private Atlas edgeHighWayServiceAtlas;
+
+    @TestAtlas(
+
+            nodes = { @Node(coordinates = @Loc(value = TEST_10)),
+                    @Node(coordinates = @Loc(value = TEST_20)),
+                    @Node(coordinates = @Loc(value = TEST_30)),
+                    @Node(coordinates = @Loc(value = TEST_40)),
+                    @Node(coordinates = @Loc(value = TEST_50)),
+                    @Node(coordinates = @Loc(value = TEST_60)),
+                    @Node(coordinates = @Loc(value = TEST_70)),
+                    @Node(coordinates = @Loc(value = TEST_80)),
+                    @Node(coordinates = @Loc(value = TEST_90)),
+                    @Node(coordinates = @Loc(value = TEST_100)),
+                    @Node(coordinates = @Loc(value = TEST_101), tags = {
+                            "amenity=fuel" }) }, points = {
+                                    @Point(coordinates = @Loc(value = TEST_101), tags = {
+                                            "amenity=fuel" }) },
+
+            edges = { @Edge(id = "292929292929", coordinates = { @Loc(value = TEST_10),
+                    @Loc(value = TEST_20), @Loc(value = TEST_30), @Loc(value = TEST_40),
+                    @Loc(value = TEST_50), @Loc(value = TEST_60) }, tags = { "highway=service" }) },
+
+            areas = {
+                    // Regular building - flagged
+                    @Area(id = "3", coordinates = { @Loc(value = TEST_70), @Loc(value = TEST_80),
+                            @Loc(value = TEST_90), @Loc(value = TEST_100), @Loc(value = TEST_40),
+                            @Loc(value = TEST_30) }, tags = { "building=yes" }) })
+    private Atlas newAtlas;
+
+    public Atlas getNewAtlas()
+    {
+        return this.newAtlas;
+    }
 
     public Atlas getAtlas()
     {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -62,7 +62,7 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                     // Non-Pedestrian Area - flagged
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
-                            @Loc(value = TEST_6) }, tags = { "highway=primary", "building=house" }),
+                            @Loc(value = TEST_6) }, tags = { "highway=steps", "building=house" }),
                     // Pedestrian Area - not flagged
                     @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
                             @Loc(value = TEST_4), @Loc(value = TEST_1),
@@ -232,6 +232,34 @@ public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
                             @Loc(value = TEST_6) }, tags = { "highway=primary",
                                     "building=house" }) })
     private Atlas ignoredNodesWithinEdgeAtlas;
+
+    @TestAtlas(
+
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)) },
+
+            edges = {
+
+                    @Edge(id = "292929292929", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=steps" }) },
+
+            areas = {
+                    // Regular building - flagged
+                    @Area(id = "323232323232", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_2), @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "building=yes" }),
+                    // Non-Pedestrian Area - flagged
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_1),
+                            @Loc(value = TEST_6) }, tags = { "highway=steps", "building=house" }) })
+    private Atlas corewayIntersectionAtlas;
+
+    public Atlas getCorewayIntersectionAtlas()
+    {
+        return this.corewayIntersectionAtlas;
+    }
 
     public Atlas getIgnoredNodesWithinEdgeAtlas()
     {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -12,7 +12,8 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
 /**
  * {@link BuildingRoadIntersectionCheckTest} test data
  *
- * @author mgostintsev, sayas01
+ * @author mgostintsev
+ * @author sayas01
  */
 public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionTestCaseRule.java
@@ -12,7 +12,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
 /**
  * {@link BuildingRoadIntersectionCheckTest} test data
  *
- * @author mgostintsev
+ * @author mgostintsev, sayas01
  */
 public class BuildingRoadIntersectionTestCaseRule extends CoreTestRule
 {


### PR DESCRIPTION
### Description:

This PR adds following enhancements to the BuildingRoadIntersectionCheck:
1. Adds a configurable `car.navigable` to specify valid highway tags for intersection. The default value of "car.navigable" is set to true. If set to true, the intersecting highways will be checked for tags in the "CAR_NAVIGABLE_HIGHWAYS" enum set of `HighwayTag` class. If set to false, it will be checked for tags in "CORE_WAYS" enum set.
2. Ignores intersections with intersecting highway containing nodes with BarrierTag as these are valid intersections.
3. Ignores intersections with intersecting building containing points with `amenity=fuel` tag. Previously, buildings with `amenity=fuel` was ignored. There are cases where nodes within buildings, which are ingested into Atlas as points, have `amenity=fuel` tag. These are valid intersections and should not be flagged. The enhancement also captures this case.

### Potential Impact:

The enhancements will reduce a large number of false positives for this check.

### Unit Test Approach:

Added three test cases to test the enhancements.

### Test Results:

NA

