### PR TITLE
checkFilter flag for IntegritySparkJob 

### DIFF
--- a/gradle/runchecks.gradle
+++ b/gradle/runchecks.gradle
@@ -10,9 +10,23 @@ task runChecks(type: JavaExec, dependsOn: 'assemble', description: 'Executes the
 
     main = project.property("checks.${project.profile}.mainClass")
 
+    // If we're passed -PcountryOverride=XXX, override checks.<profile>.countries with XXX
     if (project.hasProperty('countryOverride')) {
-        project.setProperty("checks.${project.profile}.countries",project.properties["countryOverride"])
-        println project.properties["checks.local.countries"]
+        if (project.hasProperty("checks.${project.profile}.countries")) {
+            project.setProperty("checks.${project.profile}.countries", project.properties["countryOverride"])
+        } else {
+            project.ext["checks.${project.profile}.countries"] = project.properties["countryOverride"]
+        }
+    }
+
+    // If we're passed -PcheckOverride=XXX, override checks.<profile>.checksToRun with XXX
+    if (project.hasProperty("checkOverride")) {
+        println project.properties["checkOverride"]
+        if (project.hasProperty("checks.${project.profile}.checksToRun")) {
+            project.setProperty("checks.${project.profile}.checksToRun", project.properties["checkOverride"])
+        } else {
+            project.ext["checks.${project.profile}.checksToRun"] = project.properties["checkOverride"]
+        }
     }
     // apply arguments defined in the gradle.properties file for this profile
     def flags = project.properties.findAll { property ->

--- a/gradle/runchecks.gradle
+++ b/gradle/runchecks.gradle
@@ -10,24 +10,6 @@ task runChecks(type: JavaExec, dependsOn: 'assemble', description: 'Executes the
 
     main = project.property("checks.${project.profile}.mainClass")
 
-    // If we're passed -PcountryOverride=XXX, override checks.<profile>.countries with XXX
-    if (project.hasProperty('countryOverride')) {
-        if (project.hasProperty("checks.${project.profile}.countries")) {
-            project.setProperty("checks.${project.profile}.countries", project.properties["countryOverride"])
-        } else {
-            project.ext["checks.${project.profile}.countries"] = project.properties["countryOverride"]
-        }
-    }
-
-    // If we're passed -PcheckOverride=XXX, override checks.<profile>.checksToRun with XXX
-    if (project.hasProperty("checkOverride")) {
-        println project.properties["checkOverride"]
-        if (project.hasProperty("checks.${project.profile}.checksToRun")) {
-            project.setProperty("checks.${project.profile}.checksToRun", project.properties["checkOverride"])
-        } else {
-            project.ext["checks.${project.profile}.checksToRun"] = project.properties["checkOverride"]
-        }
-    }
     // apply arguments defined in the gradle.properties file for this profile
     def flags = project.properties.findAll { property ->
         property.toString().startsWith("checks.${project.profile}")

--- a/gradle/runchecks.gradle
+++ b/gradle/runchecks.gradle
@@ -10,6 +10,10 @@ task runChecks(type: JavaExec, dependsOn: 'assemble', description: 'Executes the
 
     main = project.property("checks.${project.profile}.mainClass")
 
+    if (project.hasProperty('countryOverride')) {
+        project.setProperty("checks.${project.profile}.countries",project.properties["countryOverride"])
+        println project.properties["checks.local.countries"]
+    }
     // apply arguments defined in the gradle.properties file for this profile
     def flags = project.properties.findAll { property ->
         property.toString().startsWith("checks.${project.profile}")

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -217,6 +217,17 @@ public class CheckResourceLoader
         return loadChecks(this::isEnabledByConfiguration, this.configuration);
     }
 
+    /**
+     * Loads checks that are enabled by configuration and also match some other filter
+     * @param additionalFilter some predicate that returns true for checks we would like to run
+     * @param <T> check type
+     * @return a {@link Set} of checks.
+     */
+    public <T extends Check> Set<T> loadEnabledChecks(final Predicate<Class> additionalFilter)
+    {
+        return loadChecks(checkClass -> this.isEnabledByConfiguration(checkClass) && additionalFilter.test(checkClass));
+    }
+
     public <T extends Check> Set<T> loadChecksForCountry(final String country)
     {
         return loadChecksForCountry(country, checkClass -> true);

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -43,6 +43,7 @@ import com.google.common.reflect.ClassPath;
  *
  * @author brian_l_davis
  * @author jklamer
+ * @author nachtm
  */
 public class CheckResourceLoader
 {

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -219,9 +219,14 @@ public class CheckResourceLoader
 
     public <T extends Check> Set<T> loadChecksForCountry(final String country)
     {
+        return loadChecksForCountry(country, checkClass -> true);
+    }
+
+    public <T extends Check> Set<T> loadChecksForCountry(final String country, final Predicate<Class> filter)
+    {
         final Configuration countryConfiguration = this.getConfigurationForCountry(country);
         return loadChecks(
-                checkClass -> this.isEnabledByConfiguration(countryConfiguration, checkClass),
+                checkClass -> this.isEnabledByConfiguration(countryConfiguration, checkClass) && filter.test(checkClass),
                 countryConfiguration);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -219,13 +219,17 @@ public class CheckResourceLoader
 
     /**
      * Loads checks that are enabled by configuration and also match some other filter
-     * @param additionalFilter some predicate that returns true for checks we would like to run
-     * @param <T> check type
+     * 
+     * @param additionalFilter
+     *            some predicate that returns true for checks we would like to run
+     * @param <T>
+     *            check type
      * @return a {@link Set} of checks.
      */
     public <T extends Check> Set<T> loadEnabledChecks(final Predicate<Class> additionalFilter)
     {
-        return loadChecks(checkClass -> this.isEnabledByConfiguration(checkClass) && additionalFilter.test(checkClass));
+        return loadChecks(checkClass -> this.isEnabledByConfiguration(checkClass)
+                && additionalFilter.test(checkClass));
     }
 
     public <T extends Check> Set<T> loadChecksForCountry(final String country)

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -222,11 +222,13 @@ public class CheckResourceLoader
         return loadChecksForCountry(country, checkClass -> true);
     }
 
-    public <T extends Check> Set<T> loadChecksForCountry(final String country, final Predicate<Class> filter)
+    public <T extends Check> Set<T> loadChecksForCountry(final String country,
+            final Predicate<Class> filter)
     {
         final Configuration countryConfiguration = this.getConfigurationForCountry(country);
         return loadChecks(
-                checkClass -> this.isEnabledByConfiguration(countryConfiguration, checkClass) && filter.test(checkClass),
+                checkClass -> this.isEnabledByConfiguration(countryConfiguration, checkClass)
+                        && filter.test(checkClass),
                 countryConfiguration);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
@@ -235,11 +235,12 @@ public class IntegrityCheckSparkJob extends SparkJob
         // Predicate to determine whether or not a given check was passed in as a command line argument.
         // If there is not a CHECKS_TO_RUN switch, this predicate always returns true.
         @SuppressWarnings("unchecked")
-        final Predicate<Class> isCheckToRun = checkClass -> ((Optional<Set<String>>) commandMap.getOption(CHECKS_TO_RUN))
+        final Optional<Set<String>> checksToRun = (Optional<Set<String>>) commandMap.getOption(CHECKS_TO_RUN);
+        final Predicate<Class> isCheckToRun = checkClass -> checksToRun
                 .map(checkNames -> checkNames.contains(checkClass.getSimpleName())).orElse(true);
         // check configuration and country list
-        final Set<BaseCheck> preOverriddenChecks = checkLoader
-                .loadChecks(isCheckToRun);
+        final Set<BaseCheck> preOverriddenChecks = checkLoader.loadEnabledChecks(isCheckToRun);
+        preOverriddenChecks.forEach(check -> logger.info(check.getCheckName()));
         if (!isValidInput(countries, preOverriddenChecks))
         {
             logger.error("No countries supplied or checks enabled, exiting!");

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
@@ -232,10 +232,12 @@ public class IntegrityCheckSparkJob extends SparkJob
 
         final Map<String, String> sparkContext = configurationMap();
         final CheckResourceLoader checkLoader = new CheckResourceLoader(checksConfiguration);
-        // Predicate to determine whether or not a given check was passed in as a command line argument.
+        // Predicate to determine whether or not a given check was passed in as a command line
+        // argument.
         // If there is not a CHECKS_TO_RUN switch, this predicate always returns true.
         @SuppressWarnings("unchecked")
-        final Optional<Set<String>> checksToRun = (Optional<Set<String>>) commandMap.getOption(CHECKS_TO_RUN);
+        final Optional<Set<String>> checksToRun = (Optional<Set<String>>) commandMap
+                .getOption(CHECKS_TO_RUN);
         final Predicate<Class> isCheckToRun = checkClass -> checksToRun
                 .map(checkNames -> checkNames.contains(checkClass.getSimpleName())).orElse(true);
         // check configuration and country list
@@ -255,13 +257,13 @@ public class IntegrityCheckSparkJob extends SparkJob
         // Add priority countries first if they are supplied by parameter
         final List<Tuple2<String, Set<BaseCheck>>> countryCheckTuples = new ArrayList<>();
         countries.stream().filter(priorityCountries::contains)
-                .forEach(country -> countryCheckTuples.add(new Tuple2<>(country, checkLoader
-                        .loadChecksForCountry(country, isCheckToRun))));
+                .forEach(country -> countryCheckTuples.add(new Tuple2<>(country,
+                        checkLoader.loadChecksForCountry(country, isCheckToRun))));
 
         // Then add the rest of the countries
         countries.stream().filter(country -> !priorityCountries.contains(country))
-                .forEach(country -> countryCheckTuples.add(new Tuple2<>(country, checkLoader
-                        .loadChecksForCountry(country, isCheckToRun))));
+                .forEach(country -> countryCheckTuples.add(new Tuple2<>(country,
+                        checkLoader.loadChecksForCountry(country, isCheckToRun))));
 
         // Log countries and integrity
         logger.info("Initialized countries: {}", countryCheckTuples.stream().map(tuple -> tuple._1)

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -155,8 +155,14 @@ public class CheckResourceLoaderTest
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
-        Assert.assertEquals(1, checkResourceLoader.loadEnabledChecks(checkClass -> checkClass.getSimpleName().contains("Resource")).size());
-        Assert.assertTrue(checkResourceLoader.loadEnabledChecks(checkClass -> checkClass.getSimpleName().startsWith("Base")).isEmpty());
+        Assert.assertEquals(1,
+                checkResourceLoader
+                        .loadEnabledChecks(
+                                checkClass -> checkClass.getSimpleName().contains("Resource"))
+                        .size());
+        Assert.assertTrue(checkResourceLoader
+                .loadEnabledChecks(checkClass -> checkClass.getSimpleName().startsWith("Base"))
+                .isEmpty());
     }
 
     @Test
@@ -166,10 +172,26 @@ public class CheckResourceLoaderTest
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
-        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("ABC", checkClass -> checkClass.getSimpleName().contains("Resource")).isEmpty());
-        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC", checkClass -> checkClass.getSimpleName().startsWith("Base")).size());
+        Assert.assertTrue(
+                checkResourceLoader
+                        .loadChecksForCountry("ABC",
+                                checkClass -> checkClass.getSimpleName().contains("Resource"))
+                        .isEmpty());
+        Assert.assertEquals(1,
+                checkResourceLoader
+                        .loadChecksForCountry("ABC",
+                                checkClass -> checkClass.getSimpleName().startsWith("Base"))
+                        .size());
 
-        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF", checkClass -> checkClass.getSimpleName().contains("Resource")).size());
-        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("DEF", checkClass -> checkClass.getSimpleName().startsWith("Base")).isEmpty());
+        Assert.assertEquals(1,
+                checkResourceLoader
+                        .loadChecksForCountry("DEF",
+                                checkClass -> checkClass.getSimpleName().contains("Resource"))
+                        .size());
+        Assert.assertTrue(
+                checkResourceLoader
+                        .loadChecksForCountry("DEF",
+                                checkClass -> checkClass.getSimpleName().startsWith("Base"))
+                        .isEmpty());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -147,4 +147,29 @@ public class CheckResourceLoaderTest
         Assert.assertTrue(checkResourceLoader.loadChecksForCountry(country3).isEmpty());
         Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry(country4).size());
     }
+
+    @Test
+    public void testAdditionalFilterGeneral()
+    {
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true}, \"BaseTestCheck\":{\"enabled\": false}}";
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+
+        Assert.assertEquals(1, checkResourceLoader.loadEnabledChecks(checkClass -> checkClass.getSimpleName().contains("Resource")).size());
+        Assert.assertTrue(checkResourceLoader.loadEnabledChecks(checkClass -> checkClass.getSimpleName().startsWith("Base")).isEmpty());
+    }
+
+    @Test
+    public void testAdditionalFilterCountrySpecific()
+    {
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("ABC", checkClass -> checkClass.getSimpleName().contains("Resource")).isEmpty());
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC", checkClass -> checkClass.getSimpleName().startsWith("Base")).size());
+
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF", checkClass -> checkClass.getSimpleName().contains("Resource")).size());
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("DEF", checkClass -> checkClass.getSimpleName().startsWith("Base")).isEmpty());
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -15,6 +15,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * Test the configuration loading based on default parameters for enabling checks.
  * 
  * @author brian_l_davis
+ * @author nachtm
  */
 public class CheckResourceLoaderTest
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -194,4 +194,19 @@ public class CheckResourceLoaderTest
                                 checkClass -> checkClass.getSimpleName().startsWith("Base"))
                         .isEmpty());
     }
+
+    @Test
+    public void testAdditionalFilterNoOp()
+    {
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+
+        Assert.assertEquals(checkResourceLoader.loadChecksForCountry("ABC").size(),
+                checkResourceLoader.loadChecksForCountry("ABC", checkClass -> true).size());
+        Assert.assertEquals(checkResourceLoader.loadChecksForCountry("DEF").size(),
+                checkResourceLoader.loadChecksForCountry("DEF", checkClass -> true).size());
+        Assert.assertEquals(checkResourceLoader.loadChecks().size(),
+                checkResourceLoader.loadEnabledChecks(checkClass -> true).size());
+    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -155,9 +155,9 @@ public class CheckResourceLoaderTest
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
-        Assert.assertEquals(1,
-                checkResourceLoader.loadChecks().size());
-        Assert.assertTrue(checkResourceLoader.loadChecks().stream().noneMatch(check -> check.getCheckName().startsWith("Base")));
+        Assert.assertEquals(1, checkResourceLoader.loadChecks().size());
+        Assert.assertTrue(checkResourceLoader.loadChecks().stream()
+                .noneMatch(check -> check.getCheckName().startsWith("Base")));
     }
 
     @Test
@@ -170,8 +170,10 @@ public class CheckResourceLoaderTest
         // ABC contains nothing, since the whitelist and the enabled countries have no overlap
         Assert.assertTrue(checkResourceLoader.loadChecksForCountry("ABC").isEmpty());
 
-        // DEF contains only CheckResourceLoaderTestCheck, since that is the only overlap between enabled countries and the whitelist
-        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("DEF").stream().allMatch(check -> check.getCheckName().startsWith("CheckResource")));
+        // DEF contains only CheckResourceLoaderTestCheck, since that is the only overlap between
+        // enabled countries and the whitelist
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("DEF").stream()
+                .allMatch(check -> check.getCheckName().startsWith("CheckResource")));
     }
 
     @Test
@@ -183,10 +185,14 @@ public class CheckResourceLoaderTest
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
         Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").size());
-        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").stream().map(Check::getCheckName).filter(name -> name.startsWith("Base")).distinct().count());
+        Assert.assertEquals(1,
+                checkResourceLoader.loadChecksForCountry("ABC").stream().map(Check::getCheckName)
+                        .filter(name -> name.startsWith("Base")).distinct().count());
 
         Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").size());
-        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").stream().map(Check::getCheckName).filter(name -> name.startsWith("CheckResource")).distinct().count());
+        Assert.assertEquals(1,
+                checkResourceLoader.loadChecksForCountry("DEF").stream().map(Check::getCheckName)
+                        .filter(name -> name.startsWith("CheckResource")).distinct().count());
     }
 
     @Test
@@ -209,8 +215,10 @@ public class CheckResourceLoaderTest
         // ABC contains nothing, since the whitelist and the enabled countries have no overlap
         Assert.assertTrue(checkResourceLoader.loadChecksForCountry("DEF").isEmpty());
 
-        // DEF contains only CheckResourceLoaderTestCheck, since that is the only overlap between enabled countries and the whitelist
-        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("ABC").stream().allMatch(check -> check.getCheckName().startsWith("Base")));
+        // DEF contains only CheckResourceLoaderTestCheck, since that is the only overlap between
+        // enabled countries and the whitelist
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("ABC").stream()
+                .allMatch(check -> check.getCheckName().startsWith("Base")));
     }
 
     @Test
@@ -222,9 +230,13 @@ public class CheckResourceLoaderTest
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
         Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").size());
-        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").stream().map(Check::getCheckName).filter(name -> name.startsWith("Base")).distinct().count());
+        Assert.assertEquals(1,
+                checkResourceLoader.loadChecksForCountry("ABC").stream().map(Check::getCheckName)
+                        .filter(name -> name.startsWith("Base")).distinct().count());
 
         Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").size());
-        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").stream().map(Check::getCheckName).filter(name -> name.startsWith("CheckResource")).distinct().count());
+        Assert.assertEquals(1,
+                checkResourceLoader.loadChecksForCountry("DEF").stream().map(Check::getCheckName)
+                        .filter(name -> name.startsWith("CheckResource")).distinct().count());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -180,7 +180,7 @@ public class CheckResourceLoaderTest
     public void testWhitelistNoOp()
     {
         // A whitelist containing all checks shouldn't impact the behavior
-        final String configSource = "{\"CheckResourceLoader.checks.blacklist\": [\"CheckResourceLoaderTestCheck\",\"BaseTestCheck\"], \"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
+        final String configSource = "{\"CheckResourceLoader.checks.whitelist\": [\"CheckResourceLoaderTestCheck\",\"BaseTestCheck\"], \"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 

--- a/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/CheckResourceLoaderTest.java
@@ -149,64 +149,82 @@ public class CheckResourceLoaderTest
     }
 
     @Test
-    public void testAdditionalFilterGeneral()
+    public void testWhitelistGeneral()
     {
-        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true}, \"BaseTestCheck\":{\"enabled\": false}}";
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"], \"CheckResourceLoader.checks.whitelist\": [\"CheckResourceLoaderTestCheck\"], \"CheckResourceLoaderTestCheck\":{\"enabled\": true}, \"BaseTestCheck\":{\"enabled\": false}}";
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
         Assert.assertEquals(1,
-                checkResourceLoader
-                        .loadEnabledChecks(
-                                checkClass -> checkClass.getSimpleName().contains("Resource"))
-                        .size());
-        Assert.assertTrue(checkResourceLoader
-                .loadEnabledChecks(checkClass -> checkClass.getSimpleName().startsWith("Base"))
-                .isEmpty());
+                checkResourceLoader.loadChecks().size());
+        Assert.assertTrue(checkResourceLoader.loadChecks().stream().noneMatch(check -> check.getCheckName().startsWith("Base")));
     }
 
     @Test
-    public void testAdditionalFilterCountrySpecific()
+    public void testWhitelistCountrySpecific()
     {
-        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
+        final String configSource = "{\"CheckResourceLoader.checks.whitelist\": [\"CheckResourceLoaderTestCheck\"], \"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
-        Assert.assertTrue(
-                checkResourceLoader
-                        .loadChecksForCountry("ABC",
-                                checkClass -> checkClass.getSimpleName().contains("Resource"))
-                        .isEmpty());
-        Assert.assertEquals(1,
-                checkResourceLoader
-                        .loadChecksForCountry("ABC",
-                                checkClass -> checkClass.getSimpleName().startsWith("Base"))
-                        .size());
+        // ABC contains nothing, since the whitelist and the enabled countries have no overlap
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("ABC").isEmpty());
 
-        Assert.assertEquals(1,
-                checkResourceLoader
-                        .loadChecksForCountry("DEF",
-                                checkClass -> checkClass.getSimpleName().contains("Resource"))
-                        .size());
-        Assert.assertTrue(
-                checkResourceLoader
-                        .loadChecksForCountry("DEF",
-                                checkClass -> checkClass.getSimpleName().startsWith("Base"))
-                        .isEmpty());
+        // DEF contains only CheckResourceLoaderTestCheck, since that is the only overlap between enabled countries and the whitelist
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("DEF").stream().allMatch(check -> check.getCheckName().startsWith("CheckResource")));
     }
 
     @Test
-    public void testAdditionalFilterNoOp()
+    public void testWhitelistNoOp()
     {
-        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
+        // A whitelist containing all checks shouldn't impact the behavior
+        final String configSource = "{\"CheckResourceLoader.checks.blacklist\": [\"CheckResourceLoaderTestCheck\",\"BaseTestCheck\"], \"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
         final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
 
-        Assert.assertEquals(checkResourceLoader.loadChecksForCountry("ABC").size(),
-                checkResourceLoader.loadChecksForCountry("ABC", checkClass -> true).size());
-        Assert.assertEquals(checkResourceLoader.loadChecksForCountry("DEF").size(),
-                checkResourceLoader.loadChecksForCountry("DEF", checkClass -> true).size());
-        Assert.assertEquals(checkResourceLoader.loadChecks().size(),
-                checkResourceLoader.loadEnabledChecks(checkClass -> true).size());
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").size());
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").stream().map(Check::getCheckName).filter(name -> name.startsWith("Base")).distinct().count());
+
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").size());
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").stream().map(Check::getCheckName).filter(name -> name.startsWith("CheckResource")).distinct().count());
+    }
+
+    @Test
+    public void testBlacklistGeneral()
+    {
+        final String configSource = "{\"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"], \"CheckResourceLoader.checks.blacklist\": [\"CheckResourceLoaderTestCheck\"], \"CheckResourceLoaderTestCheck\":{\"enabled\": true}, \"BaseTestCheck\":{\"enabled\": false}}";
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+
+        Assert.assertEquals(0, checkResourceLoader.loadChecks().size());
+    }
+
+    @Test
+    public void testBlacklistCountrySpecific()
+    {
+        final String configSource = "{\"CheckResourceLoader.checks.blacklist\": [\"CheckResourceLoaderTestCheck\"], \"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+
+        // ABC contains nothing, since the whitelist and the enabled countries have no overlap
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("DEF").isEmpty());
+
+        // DEF contains only CheckResourceLoaderTestCheck, since that is the only overlap between enabled countries and the whitelist
+        Assert.assertTrue(checkResourceLoader.loadChecksForCountry("ABC").stream().allMatch(check -> check.getCheckName().startsWith("Base")));
+    }
+
+    @Test
+    public void testBlacklistNoOp()
+    {
+        // A blacklist containing no checks shouldn't impact the behavior
+        final String configSource = "{\"CheckResourceLoader.checks.blacklist\": [], \"CheckResourceLoader.scanUrls\": [\"org.openstreetmap.atlas.checks.base.checks\"],\"CheckResourceLoaderTestCheck\":{\"enabled\": true, \"override.ABC.enabled\": false}, \"BaseTestCheck\":{\"enabled\": false, \"override.ABC.enabled\": true}}";
+        final Configuration configuration = ConfigurationResolver.inlineConfiguration(configSource);
+        final CheckResourceLoader checkResourceLoader = new CheckResourceLoader(configuration);
+
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").size());
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("ABC").stream().map(Check::getCheckName).filter(name -> name.startsWith("Base")).distinct().count());
+
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").size());
+        Assert.assertEquals(1, checkResourceLoader.loadChecksForCountry("DEF").stream().map(Check::getCheckName).filter(name -> name.startsWith("CheckResource")).distinct().count());
     }
 }


### PR DESCRIPTION
### Description:

This PR adds the ability to pass in a `-checkFilter` flag into `IntegritySparkJob`. This lets us quickly run one or two checks. For example, now I can run 
```
./gradlew run -Pchecks.local.checkFilter=PoolSizeCheck
```
 to quickly get the output for just `PoolSizeCheck`, or 
```
./gradlew run -Pchecks.local.checkFilter=PoolSizeCheck,AddressPointMatchCheck
```
to get the output for multiple checks. 

The code changes are as follows:
* ~addition of an overloaded `loadChecksForCountry(final String country, final Predicate<Class> filter)` function to `CheckResourceLoader`.~
* ~addition of a `loadEnabledChecks(final Predicate<Class> additionalFilter)` function, which loads only the default-enabled checks that also pass `additionalFilter`.~
 * addition of a `CheckResourceLoader.checks.whitelist` and `CheckResourceLoader.checks.blacklist` property
 * added a new switch `CHECK_FILTER` which takes in a list of comma-delimited check names. When the checks are run for each country, we now only run a check if:
     * the check is enabled for that country, **and** 
         * its name is included in the `CHECK_FILTER` flag **or** 
         * the `CHECK_FILTER` flag is not present

### Potential Impact:

This only adds functionality, so nothing downstream should be impacted. 

### Unit Test Approach:

No unit tests exist for IntegrityCheckSparkJob. I did manually test a lot of different configurations for this argument, and added some unit tests to CheckResourceLoader to test the new methods.

### Test Results:

All permutations of this command behaved as expected, and all unit tests are passing.