### PR TITLE
[HACK] Upload artifacts to Sonatype from GCE Travis instances

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -2,13 +2,9 @@
 
 if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ];
 then
-	echo "Sign Archives"
-	./gradlew signArchives
-	echo "Upload Archives"
-	./gradlew uploadArchives
 	if [ "$MANUAL_RELEASE_TRIGGERED" = "true" ];
 	then
-		echo "Promote repository"
-		./gradlew closeAndReleaseRepository
+		echo "Sign, Upload archives to local repo, Upload archives to Sonatype, Close and release repository."
+		./gradlew uploadArchives publishToNexus closeAndReleaseRepository
 	fi
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransfor
 plugins {
 	id 'java'
 	id 'maven'
+	id 'maven-publish'
 	id 'idea'
 	id 'eclipse'
 	id 'signing'
@@ -11,7 +12,7 @@ plugins {
 	id 'jacoco'
 	id "com.diffplug.gradle.spotless" version "3.4.0"
 	id 'org.sonarqube' version '2.6'
-	id "io.codearte.nexus-staging" version "0.8.0"
+	id "io.codearte.nexus-staging" version "0.12.0"
 	id 'com.github.johnrengelman.shadow' version '1.2.4'
 }
 

--- a/gradle/createStagingId.sh
+++ b/gradle/createStagingId.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export ATLAS_PROFILE_ID=1442a4f451744
+export CREATE_STAGING_REPO_RESPONSE=$(curl -X POST -d @nexus_description.xml -u $1:$2 -H Content-Type:application/xml -v https://oss.sonatype.org/service/local/staging/profiles/$ATLAS_PROFILE_ID/start)
+# Response looks like this:
+# <promoteResponse>  <data>    <stagedRepositoryId>orgopenstreetmapatlas-1147</stagedRepositoryId>    <description>Atlas Release</description>  </data></promoteResponse>
+echo $CREATE_STAGING_REPO_RESPONSE | perl -nle 'print "$1" if ($_ =~ /.*<stagedRepositoryId>(.*)<\/stagedRepositoryId>.*/g);' | awk '{$1=$1};1'

--- a/gradle/deployment.gradle
+++ b/gradle/deployment.gradle
@@ -22,6 +22,9 @@ build.dependsOn.remove(signArchives)
 
 uploadArchives
 {
+    doFirst {
+        mkdir "file:/$rootDir/build/deploy"
+    }
     repositories
     {
         mavenDeployer
@@ -31,12 +34,15 @@ uploadArchives
                 MavenDeployment deployment -> signing.signPom(deployment)
             }
 
+            // Hack: Deploy to a local repository first, then upload to Sonatype using scripts.
             repository(url: maven2_url) {
-                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
+                // authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
+                repository(url: "file://localhost/$rootDir/build/deploy")
             }
 
             snapshotRepository(url: snapshot_url) {
-                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
+                // authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
+                repository(url: "file://localhost/$rootDir/build/deploy")
             }
 
             pom.project
@@ -68,5 +74,30 @@ uploadArchives
                 }
             }
         }
+    }
+}
+
+// Scripted hack, inpired from:
+// https://github.com/h2oai/sparkling-water/tree/3f8fcf387a2bcc080343a8fafdc81aebc0d99fa1/gradle/publish
+// and
+// https://github.com/h2oai/sparkling-water/blob/73d2e2bd11ce35c6379f6961188fb2af1a7bc04b/build.gradle#L228
+// Until either this one works for us: https://github.com/marcphilipp/nexus-publish-plugin
+// or this issue is fixed another way:
+// https://github.com/travis-ci/travis-ci/issues/9555
+def createStagingId(def username, def password) {
+    def proc = ['./createStagingId.sh', username, password].execute([], file("${rootDir.toString()}/gradle"))
+    return proc.text
+}
+
+def uploadFiles(def username, def password, def repoDir, def stagingId) {
+    def proc = ['./uploadToNexus.sh', username, password, repoDir, stagingId].execute([], file("${rootDir.toString()}/gradle"))
+    proc.waitFor()
+}
+
+task publishToNexus(dependsOn: 'publish'){
+    doLast {
+        def stagingId = createStagingId(System.getenv('SONATYPE_USERNAME'), System.getenv('SONATYPE_PASSWORD')).replace('\n', '')
+        println("my staging id: " + stagingId)
+        uploadFiles(System.getenv('SONATYPE_USERNAME'), System.getenv('SONATYPE_PASSWORD'), "$rootDir/build/deploy", stagingId)
     }
 }

--- a/gradle/nexus_description.xml
+++ b/gradle/nexus_description.xml
@@ -1,0 +1,5 @@
+<promoteRequest>
+    <data>
+        <description>Atlas Release</description>
+    </data>
+</promoteRequest>

--- a/gradle/uploadToNexus.sh
+++ b/gradle/uploadToNexus.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+name=$1
+password=$2
+repodir=$3
+stagingId=$4
+
+find $repodir -type f | while read f; do
+    suffix=$(echo $f | sed "s%^$repodir/%%")
+    echo "x${stagingId}x"
+    curl -v -u $name:$password -H "Content-type: application/x-rpm" --upload-file $f https://oss.sonatype.org/service/local/staging/deployByRepositoryId/${stagingId}/${suffix} > /dev/null 2>&1
+done


### PR DESCRIPTION
### Description:

This is a hack that allows us to upload artifacts to Sonatype even from GCE.

It is using the maven `uploadArchives` task to upload to a local nexus repo, then uses a script to open a staging repository, get its ID, and specifically uploads each artifact in the repository to the same staging repository in Sonatype. Inspiration comes from [here](https://github.com/h2oai/sparkling-water/blob/73d2e2bd11ce35c6379f6961188fb2af1a7bc04b/build.gradle#L228) and [here](https://github.com/h2oai/sparkling-water/tree/3f8fcf387a2bcc080343a8fafdc81aebc0d99fa1/gradle/publish).

Reference issue: https://github.com/travis-ci/travis-ci/issues/9555

Special thanks to @lucaspcram who helped me with [this bash line](https://github.com/osmlab/atlas-checks/pull/105/files#diff-666bc478d90b3e6e45b5d0fad9e3a94aR7)!

### Potential Impact:

Travis builds for deployment should succeed.

### Unit Test Approach:

N/A

### Test Results:

Tested the upload locally.