### PR TITLE
Expose Check specific and Global Polygon filters

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -63,7 +63,9 @@ public abstract class BaseCheck<T> implements Check, Serializable
     private final Set<T> flaggedIdentifiers = ConcurrentHashMap.newKeySet();
     private final Locale locale;
     private final String name = this.getClass().getSimpleName();
+    // geo filter specific to this check
     private final AtlasEntityPolygonsFilter checkPolygonFilter;
+    // geo filter for all checks
     private final AtlasEntityPolygonsFilter globalPolygonFilter;
     private TaggableFilter tagFilter = null;
 

--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -176,6 +176,16 @@ public abstract class BaseCheck<T> implements Check, Serializable
         return this.name;
     }
 
+    public AtlasEntityPolygonsFilter getCheckPolygonFilter()
+    {
+        return this.checkPolygonFilter;
+    }
+
+    public AtlasEntityPolygonsFilter getGlobalPolygonFilter()
+    {
+        return this.globalPolygonFilter;
+    }
+
     /**
      * Gets the whitelisted countries for this check. If an empty list is returned it safe to assume
      * this check applies to all countries.


### PR DESCRIPTION
### Description:

Expose The filters being used by the check under the hood to filter out objects to flag by area. 

### Potential Impact:

None, getter methods only. No dependencies.

