### PR TITLE
Add checkinCommit to support MR java client to pass in another value

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -60,7 +60,7 @@ public class Challenge implements Serializable
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty, final String tags)
     {
-        this(name, description, blurb, instruction, difficulty, ChallengePriority.NONE, null, null,
+        this(name, description, blurb, instruction, difficulty, ChallengePriority.LOW, null, null,
                 null, tags);
     }
 
@@ -68,7 +68,7 @@ public class Challenge implements Serializable
             final String instruction, final String checkinComment,
             final ChallengeDifficulty difficulty, final String tags)
     {
-        this(name, description, blurb, instruction, difficulty, ChallengePriority.NONE, null, null,
+        this(name, description, blurb, instruction, difficulty, ChallengePriority.LOW, null, null,
                 null, tags);
         this.checkinComment = checkinComment;
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -49,6 +49,7 @@ public class Challenge implements Serializable
     private final String description;
     private final ChallengeDifficulty difficulty;
     private final String instruction;
+    private String checkinComment;
     private String name;
     private final String tags;
     private final ChallengePriority defaultPriority;
@@ -59,8 +60,17 @@ public class Challenge implements Serializable
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty, final String tags)
     {
-        this(name, description, blurb, instruction, difficulty, ChallengePriority.LOW, null, null,
+        this(name, description, blurb, instruction, difficulty, ChallengePriority.NONE, null, null,
                 null, tags);
+    }
+
+    public Challenge(final String name, final String description, final String blurb,
+            final String instruction, final String checkinComment,
+            final ChallengeDifficulty difficulty, final String tags)
+    {
+        this(name, description, blurb, instruction, difficulty, ChallengePriority.NONE, null, null,
+                null, tags);
+        this.checkinComment = checkinComment;
     }
 
     public Challenge(final String name, final String description, final String blurb,
@@ -78,6 +88,17 @@ public class Challenge implements Serializable
         this.mediumPriorityRule = mediumPriorityRule;
         this.lowPriorityRule = lowPriorityRule;
         this.tags = tags;
+        this.checkinComment = "#maproulette";
+    }
+
+    public String getCheckinComment()
+    {
+        return this.checkinComment;
+    }
+
+    public void setCheckinComment(final String checkinComment)
+    {
+        this.checkinComment = checkinComment;
     }
 
     public long getId()

--- a/src/test/java/org/openstreetmap/atlas/checks/base/ChallengeTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/ChallengeTest.java
@@ -29,6 +29,8 @@ public class ChallengeTest
         Assert.assertEquals("description", testCheck.getChallenge().getDescription().toLowerCase());
         Assert.assertEquals("blurb", testCheck.getChallenge().getBlurb().toLowerCase());
         Assert.assertEquals("instruction", testCheck.getChallenge().getInstruction().toLowerCase());
+        Assert.assertEquals("#maproulette",
+                testCheck.getChallenge().getCheckinComment().toLowerCase());
         Assert.assertEquals(ChallengeDifficulty.EASY, testCheck.getChallenge().getDifficulty());
         Assert.assertEquals(ChallengePriority.LOW, testCheck.getChallenge().getDefaultPriority());
 

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
@@ -19,6 +19,7 @@ public class ChallengeSerializationTest
     private static final String DESCRIPTION = "DESCRIPTION";
     private static final String BLURB = "BLURB";
     private static final String INSTRUCTION = "INSTRUCTION";
+    private static final String CHECKIN_COMMENT = "#maproulette";
 
     /**
      * Test if a challange can be deserialized from a test JSON file. The challenge resource json
@@ -32,6 +33,7 @@ public class ChallengeSerializationTest
         Assert.assertEquals(DESCRIPTION, deserializedChallenge.getDescription());
         Assert.assertEquals(BLURB, deserializedChallenge.getBlurb());
         Assert.assertEquals(INSTRUCTION, deserializedChallenge.getInstruction());
+        Assert.assertEquals(CHECKIN_COMMENT, deserializedChallenge.getCheckinComment());
         Assert.assertEquals(ChallengeDifficulty.NORMAL, deserializedChallenge.getDifficulty());
         Assert.assertEquals(ChallengePriority.NONE, deserializedChallenge.getDefaultPriority());
         Assert.assertNull(deserializedChallenge.getHighPriorityRule());
@@ -51,6 +53,7 @@ public class ChallengeSerializationTest
         Assert.assertEquals(DESCRIPTION, deserializedChallenge.getDescription());
         Assert.assertEquals(BLURB, deserializedChallenge.getBlurb());
         Assert.assertEquals(INSTRUCTION, deserializedChallenge.getInstruction());
+        Assert.assertEquals(CHECKIN_COMMENT, deserializedChallenge.getCheckinComment());
         Assert.assertEquals(ChallengeDifficulty.NORMAL, deserializedChallenge.getDifficulty());
         Assert.assertEquals(ChallengePriority.LOW, deserializedChallenge.getDefaultPriority());
         Assert.assertNotNull(deserializedChallenge.getHighPriorityRule());
@@ -105,7 +108,7 @@ public class ChallengeSerializationTest
         Assert.assertEquals(deserializedJson.get("blurb"), rawJson.get("blurb"));
         Assert.assertEquals(deserializedJson.get("instruction"), rawJson.get("instruction"));
     }
-
+    
     /**
      * Tests that a challenge with no defaultPriority specified gets loaded as defaultPriority=LOW.
      */

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
@@ -108,7 +108,7 @@ public class ChallengeSerializationTest
         Assert.assertEquals(deserializedJson.get("blurb"), rawJson.get("blurb"));
         Assert.assertEquals(deserializedJson.get("instruction"), rawJson.get("instruction"));
     }
-    
+
     /**
      * Tests that a challenge with no defaultPriority specified gets loaded as defaultPriority=LOW.
      */


### PR DESCRIPTION
### Description:
Add checkinCommit to support MR java client to pass in another value "", by default it is always "#maproulette".

For more background knowledge, If you manually add a challenge to a project on MR, on the New Challenge page, you are supposed to fill in mandatory fields like name, instructions, and other fields as you like, and there are two radio box indicate that if you want to "Automatically append #maproulette hashtag (highly recommended)" or "Skip hashtag", after debugging, from the http request, we can know that this field is mapped to input parameter checkinCommit with two values as showed below:

![image](https://user-images.githubusercontent.com/12950070/53202966-b1963800-35dc-11e9-9947-d2b3be646d9f.png)


So for MR java client, we want to support uses to choose which value they want to use, that is what this PR is trying to do. By default, we still keep this value to "#maproulette" as before.

### Radar:
rdar://problem/48078543

### Description:Potential Impact:

Should be no impact on downstream, whoever use this MR java client to publish challenge should be as the same as before.

### Unit Test Approach:

Unit test added for this field.

### Other Test:

Build an atlas check dev jar and make our project depends on this dev jar, and run our program with code changes by passing in checkinCommit="" for test challenges, and then check them on MR, you will see Changeset Description box on the page is empty.
![image](https://user-images.githubusercontent.com/12950070/53203011-d4c0e780-35dc-11e9-9900-89c8a18163a1.png)


If I remove this parameter from our program, you will see it becomes below, which is the same as before.
![image](https://user-images.githubusercontent.com/12950070/53203065-f7530080-35dc-11e9-9391-8305ffe9030a.png)