### PR TITLE
Updates to the default gradle run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ To run Atlas Checks the following is required:
 To start working with Atlas Checks follow the steps below:
 1. Clone Atlas Checks project using the following command `git clone https://github.com/osmlab/atlas-checks.git`
 2. Switch to newly created directory: `cd atlas-checks`
-3. Download an OSM PBF file and place it in the `/data/` directory.
 3. Execute `./gradlew run`
 
-This command will build and run Atlas Checks with all the default options against OSM PBF that you put in the data directory. GeoJSON output will be produced that contains all the results found from the run. Those outputs will be found in `/build/geojson/`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
+This command will build and run Atlas Checks with all the default options against a sample OSM PBF of Belize downloaded from [here](https://apple.box.com/s/3k3wcc0lq1fhqgozxr4mdi0llf95byo3). GeoJSON output will be produced that contains all the results found from the run. Those outputs will be found in `atlas-checks/build/examples/data/output`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
 
 ## Working with Configuration
 See [configuration docs](docs/configuration.md) for more information about the configuration files that can be used to define specific details around the Atlas Checks application.

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 apply from: 'dependencies.gradle'
 apply from: 'gradle/quality.gradle'
 apply from: 'gradle/deployment.gradle'
-apply from: 'gradle/runchecks.gradle'
+apply from: 'gradle/execute.gradle'
 
 description = "Atlas Checks"
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,1 +1,0 @@
-Place Atlas or OSM pbf files for processing in this directory

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,24 +1,19 @@
 # Running Atlas Checks as a Standalone Application
 
-For prerequisites for running checks see [dev.md](dev.md). To run the checks only the first two prerequisites are required, Java8 and Gradle. 
+For prerequisites for running checks see [dev.md](dev.md). To run the checks only the first two prerequisites are required, Java8 and Gradle.
 
-Atlas Checks can easily be executed using all the default settings with no additional requirements by simply executing 
+Atlas Checks can easily be executed using all the default settings with no additional requirements by simply executing
 the following statement in the root directory of the cloned Atlas Checks repository:
 
 `gradle run`
 
-This will run Atlas Checks against AIA (Anguilla) found in data/atlas/AIA using the [configuration.json](../config/configuration.json) configuration.
-
-#### Running against new Atlas
-
-Gradle will look inside this folder [data/](../data/) for any atlas or PBF files.  
+This will run Atlas Checks using the [configuration.json](../config/configuration.json) configuration.
 
 #### Running against PBF
 
-Atlas Checks allows you to run the checks against PBF files. If you have downloaded a PBF file you can simply
-place the PBF in the [data/](../data/) directory and execute
+Atlas Checks allows you to run the checks against PBF files.
 
-`./gradlew run`
+`./gradlew run` will download a sample BLZ (Belize) PBF file and run the cheks on it automatically.
 
 If you want to supply a location to a remote PBF you can use a project property in Gradle to set the PBF location
 and execute
@@ -27,7 +22,7 @@ and execute
 
 #### Running against PBF with Bounding Box
 
-Atlas Checks allows you to run checks against a PBF file with a bounding box restriction. This allows you 
+Atlas Checks allows you to run checks against a PBF file with a bounding box restriction. This allows you
 to restrict the checks to a specific area of the map. Either for performance reasons, ie. less geographic
 area allows Atlas Checks to complete faster, or simply for focus. Like running against a PBF, you can include
 the PBF file using either a URL location or a local file, but in this case you would include the bounding
@@ -40,7 +35,7 @@ In the above case you would replace lat,lon:lat,lon with the actual bounds of yo
 #### Saving Intermediate Atlas File
 
 When executing the Atlas Checks against PBF files, the framework will convert the PBF to an Atlas file and then
-execute the checks over the Atlas file. Ordinarily the Atlas file will simply be used as an in-memory object and 
+execute the checks over the Atlas file. Ordinarily the Atlas file will simply be used as an in-memory object and
 then garbage collected once we are finished with it. However it may be useful to save the Atlas for later usage, you
 can do this by adding the `savePbfAtlas` flag to your gradle command, like so:
 
@@ -49,7 +44,7 @@ can do this by adding the `savePbfAtlas` flag to your gradle command, like so:
 #### Output File Formats
 
 Several types of output may be produced by the Atlas Check:
-- Flag Logs (`flags`) - Line delimited GeoJson log files, each line the file representing one Check Flag consisting of a 
+- Flag Logs (`flags`) - Line delimited GeoJson log files, each line the file representing one Check Flag consisting of a
 `FeatureCollection` of features flagged with additional information held within it's properties.
 - Check GeoJson (`geojson`) - Each file contains a `FeatureCollection` containing a `Feature` per Atlas Check. This
 format provides high level view of all geometries flagged by each check, useful for editing and visualization tools like
@@ -77,8 +72,8 @@ The MapRoulette configuration supplied is separated by colons and split into 4 d
 
 #### Creating Compressed Output Files
 
-Flag log and GeoJson files created while running the Atlas Checks are uncompressed by default. Changing this may be 
-important when working with very large data sets. You can change this by adding the `compressOutput` flag to your gradle 
+Flag log and GeoJson files created while running the Atlas Checks are uncompressed by default. Changing this may be
+important when working with very large data sets. You can change this by adding the `compressOutput` flag to your gradle
 command, like so:
 
 `gradle run -Pchecks.local.compressOutput=true`

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,13 +17,13 @@ profile=local
 ## Local (default)
 checks.local.mainClass=org.openstreetmap.atlas.checks.distributed.IntegrityCheckSparkJob
 checks.local.configFiles=file://@ROOTDIR@/config/configuration.json
-checks.local.input=file://@ROOTDIR@/data/
-checks.local.output=file://@BUILDDIR@/
+checks.local.input=file://@BUILDDIR@/example/data/pbfs/
+checks.local.output=file://@BUILDDIR@/example/data/output/
 checks.local.outputFormats=flags,geojson,metrics
 checks.local.countries=UNK
 #checks.local.pbfBoundingBox=
-#checks.local.savePbfAtlas=true
+checks.local.savePbfAtlas=true
 checks.local.compressOutput=false
-checks.local.startedFolder=file://@BUILDDIR@/tmp/
+checks.local.startedFolder=file://@BUILDDIR@/example/tmp/
 checks.local.master=local
 checks.local.sparkOptions=spark.executor.memory->4g,spark.driver.memory->4g,spark.rdd.compress->true

--- a/gradle/execute.gradle
+++ b/gradle/execute.gradle
@@ -1,3 +1,19 @@
+task downloadPbf {
+    doLast {
+        mkdir "${buildDir}/example/data/pbfSource/"
+        ant.get(src: "https://apple.box.com/shared/static/1wj4fiuwg88dczgkwxrva8udbbqjn6y5.pbf",
+            dest: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
+            skipexisting: 'true')
+    }
+}
+
+task copyPbf (dependsOn: 'downloadPbf') {
+    doLast {
+        ant.copy(file: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
+            toFile: "${buildDir}/example/data/pbfs/belize.osm.pbf")
+    }
+}
+
 /**
  * Runs Atlas Checks configured through the gradle.properties file. Multiple run profiles
  * may be defined through project properties. Set the profile project property to switch
@@ -35,7 +51,9 @@ task runChecks(type: JavaExec, dependsOn: 'assemble', description: 'Executes the
 /**
  * Wraps runChecks to perform any task involving setup or teardown
  */
-task run(dependsOn: 'assemble', group: 'application', description: 'Runs the Atlas Check framework configured using profiles defined in gradle.properties.') {
+task run(dependsOn: ['assemble',
+        'downloadPbf',
+        'copyPbf'], group: 'application', description: 'Runs the Atlas Check framework configured using profiles defined in gradle.properties.') {
     doLast {
         runChecks.getCommandLine().each {
             line -> println("$line \\")


### PR DESCRIPTION
### Description:

This allows for automatic downloading of a PBF file for a "zero setup" option. Cloning, then `gradle run` should work out of the box.

- Also fixed the bpf to atlas flow that was not way sectioning for some reason.
- Fixed the following NPE:
```
java.lang.NullPointerException
        at org.openstreetmap.atlas.checks.validation.tag.MixedCaseNameCheck.flag(MixedCaseNameCheck.java:147)
        at org.openstreetmap.atlas.checks.base.BaseCheck.check(BaseCheck.java:126)
        at org.openstreetmap.atlas.checks.distributed.RunnableCheck.lambda$run$0(RunnableCheck.java:57)
        at java.base/java.lang.Iterable.forEach(Iterable.java:75)
        at org.openstreetmap.atlas.checks.distributed.RunnableCheck.run(RunnableCheck.java:55)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

### Potential Impact:

None.

### Unit Test Approach:

No new unit tests.

### Test Results:

N/A
