### PR TITLE
Small refactor of MapRouletteCommand to add DisplayName parameter

### DIFF
--- a/gradle/execute.gradle
+++ b/gradle/execute.gradle
@@ -1,7 +1,7 @@
 task downloadPbf {
     doLast {
         mkdir "${buildDir}/example/data/pbfSource/"
-        ant.get(src: "https://apple.box.com/shared/static/1wj4fiuwg88dczgkwxrva8udbbqjn6y5.pbf",
+        ant.get(src: "https://dl.dropboxusercontent.com/s/ddvpimpnbv6o43t/belize-geofabrik-2019-03-13T21-14-02Z.osm.pbf",
             dest: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
             skipexisting: 'true')
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.Project;
+import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
 import org.openstreetmap.atlas.checks.maproulette.data.Task;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.utilities.tuples.Tuple;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
  * Stand-alone MapRoulette client
  *
  * @author mgostintsev
+ * @author nachtm
  */
 public class MapRouletteClient implements Serializable
 {
@@ -81,21 +83,22 @@ public class MapRouletteClient implements Serializable
 
     public synchronized void addTask(final Challenge challenge, final Task task)
     {
-        String projectName;
+        ProjectConfiguration projectConfiguration;
         if (this.configuration != null)
         {
-            projectName = this.configuration.getProjectName();
-            if (StringUtils.isEmpty(projectName) && StringUtils.isNotEmpty(task.getProjectName()))
+            projectConfiguration = this.configuration.getProjectConfiguration();
+            if (StringUtils.isEmpty(projectConfiguration.getName())
+                    && StringUtils.isNotEmpty(task.getProjectName()))
             {
-                projectName = task.getProjectName();
+                projectConfiguration = new ProjectConfiguration(task.getProjectName());
             }
         }
         else
         {
-            projectName = task.getProjectName();
+            projectConfiguration = new ProjectConfiguration(task.getProjectName());
         }
 
-        this.addTask(projectName, challenge, task);
+        this.addTask(projectConfiguration, challenge, task);
     }
 
     /**
@@ -111,9 +114,15 @@ public class MapRouletteClient implements Serializable
     public synchronized void addTask(final String projectName, final Challenge challenge,
             final Task task)
     {
-        task.setProjectName(projectName);
+        this.addTask(new ProjectConfiguration(projectName), challenge, task);
+    }
+
+    public synchronized void addTask(final ProjectConfiguration projectConfiguration,
+            final Challenge challenge, final Task task)
+    {
+        task.setProjectName(projectConfiguration.getName());
         task.setChallengeName(challenge.getName());
-        updateChallengeTaskList(challenge, task);
+        updateChallengeTaskList(challenge, task, projectConfiguration);
     }
 
     public int getCurrentBatchSize()
@@ -154,10 +163,12 @@ public class MapRouletteClient implements Serializable
         return Optional.of(challenge);
     }
 
-    private Project createProject(final String projectName)
+    private Project createProject(final ProjectConfiguration projectConfiguration)
             throws UnsupportedEncodingException, URISyntaxException
     {
-        final Project project = this.projects.getOrDefault(projectName, new Project(projectName));
+        final String projectName = projectConfiguration.getName();
+        final Project project = this.projects.getOrDefault(projectName,
+                projectConfiguration.buildProject());
         if (project.getId() == -1)
         {
             project.setId(this.connection.createProject(project));
@@ -166,8 +177,8 @@ public class MapRouletteClient implements Serializable
         return project;
     }
 
-    private void updateChallengeTaskList(final Challenge challenge, final Task task)
-            throws CoreException
+    private void updateChallengeTaskList(final Challenge challenge, final Task task,
+            final ProjectConfiguration projectConfiguration) throws CoreException
     {
         final Tuple<String, String> taskKey = new Tuple<>(task.getProjectName(),
                 challenge.getName());
@@ -192,7 +203,7 @@ public class MapRouletteClient implements Serializable
             this.batch.put(taskKey, challengeTaskList);
             try
             {
-                this.createChallenge(this.createProject(task.getProjectName()), challenge);
+                this.createChallenge(this.createProject(projectConfiguration), challenge);
             }
             catch (final Exception e)
             {

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
@@ -74,11 +74,16 @@ public class MapRouletteClient implements Serializable
      */
     public MapRouletteClient(final MapRouletteConfiguration configuration)
     {
+        this(configuration, new MapRouletteConnection(configuration));
+    }
+
+    MapRouletteClient(final MapRouletteConfiguration configuration, final TaskLoader taskLoader)
+    {
         this.batch = new ConcurrentHashMap<>();
         this.projects = new ConcurrentHashMap<>();
         this.challenges = new ConcurrentHashMap<>();
         this.configuration = configuration;
-        this.connection = new MapRouletteConnection(configuration);
+        this.connection = taskLoader;
     }
 
     public synchronized void addTask(final Challenge challenge, final Task task)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -25,21 +25,9 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
 {
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteCommand.class);
 
-    // We take in Map Roulette connection information in one of two ways:
-    // either -maproulette=HOST:PORT:PROJECT:API_KEY,
-    // or -maprouletteConnection=HOST:PORT:API_KEY -projectName=NAME
-    // The second way gives more flexibility as far as defining other project parameters that we
-    // might want to pass in addition
     private static final Switch<MapRouletteConfiguration> MAP_ROULETTE = new Switch<>("maproulette",
             "Map roulette server information, format <host>:<port>:<project>:<api_key>",
             MapRouletteConfiguration::parse);
-    private static final Switch<String> MAP_ROULETTE_NO_PROJECT = new Switch<>(
-            "maprouletteConnection",
-            "Map roulette server information without a project name, format <host>:<port>:<api_key>",
-            StringConverter.IDENTITY);
-    private static final Switch<String> PROJECT_NAME = new Switch<>("projectName",
-            "Name of the project under which all of the tasks will be submitted",
-            StringConverter.IDENTITY);
     private static final Switch<String> PROJECT_DISPLAY_NAME = new Switch<>("projectDisplayName",
             "Display name of the project under which all of the tasks will be submitted",
             StringConverter.IDENTITY);
@@ -126,15 +114,15 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
     {
         final MapRouletteConfiguration mapRoulette = (MapRouletteConfiguration) commandMap
                 .get(MAP_ROULETTE);
-        final String mapRouletteNoProject = (String) commandMap.get(MAP_ROULETTE_NO_PROJECT);
-        final String projectName = (String) commandMap.get(PROJECT_NAME);
         final String projectDisplayName = (String) commandMap.get(PROJECT_DISPLAY_NAME);
 
-        if (mapRoulette != null)
+        if (projectDisplayName == null)
         {
             return mapRoulette;
         }
-        return MapRouletteConfiguration.parseWithProject(mapRouletteNoProject,
-                new ProjectConfiguration(projectName, projectName, projectDisplayName));
+        final ProjectConfiguration project = new ProjectConfiguration(mapRoulette.getProjectName(),
+                mapRoulette.getProjectName(), projectDisplayName);
+        return new MapRouletteConfiguration(mapRoulette.getServer(), mapRoulette.getPort(), project,
+                mapRoulette.getApiKey());
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 public abstract class MapRouletteCommand extends AtlasLoadingCommand
 {
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteCommand.class);
-
+    private static final boolean DEFAULT_ENABLED = true;
     private static final Switch<MapRouletteConfiguration> MAP_ROULETTE = new Switch<>("maproulette",
             "Map roulette server information, format <host>:<port>:<project>:<api_key>",
             MapRouletteConfiguration::parse);
@@ -121,7 +121,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
             return mapRoulette;
         }
         final ProjectConfiguration project = new ProjectConfiguration(mapRoulette.getProjectName(),
-                mapRoulette.getProjectName(), projectDisplayName);
+                mapRoulette.getProjectName(), projectDisplayName, DEFAULT_ENABLED);
         return new MapRouletteConfiguration(mapRoulette.getServer(), mapRoulette.getPort(), project,
                 mapRoulette.getApiKey());
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -29,7 +29,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
             "Map roulette server information, format <host>:<port>:<project>:<api_key>",
             MapRouletteConfiguration::parse);
     private static final Switch<String> PROJECT_DISPLAY_NAME = new Switch<>("projectDisplayName",
-            "Display name of the project under which all of the tasks will be submitted",
+            "Display name of the project under which all of the challenges will be submitted",
             StringConverter.IDENTITY);
     private MapRouletteClient mapRouletteClient;
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -1,14 +1,19 @@
 package org.openstreetmap.atlas.checks.maproulette;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * @author cuthbertm
  * @author mgostintsev
+ * @author nachtm
  */
 public class MapRouletteConfiguration implements Serializable
 {
@@ -19,10 +24,11 @@ public class MapRouletteConfiguration implements Serializable
     private static final int SERVER_INDEX = 0;
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteConfiguration.class);
     private static final long serialVersionUID = -1060265212173405828L;
+    private static final String DELIMITER = ":";
     private final String apiKey;
     private final int port;
-    private final String projectName;
     private final String server;
+    private final ProjectConfiguration projectConfiguration;
 
     /**
      * Parses a map roulette configuration object from a string that follows the structure
@@ -37,12 +43,13 @@ public class MapRouletteConfiguration implements Serializable
     {
         if (StringUtils.isNotEmpty(configuration))
         {
-            final String[] components = configuration.split(":");
-            if (components.length == NUMBER_OF_COMPONENTS)
+            final List<String> components = new LinkedList<>(Arrays.asList(configuration.split(DELIMITER)));
+            if (components.size() == NUMBER_OF_COMPONENTS)
             {
-                return new MapRouletteConfiguration(components[SERVER_INDEX],
-                        Integer.parseInt(components[PORT_INDEX]), components[PROJECT_NAME_INDEX],
-                        components[API_KEY_INDEX]);
+                final ProjectConfiguration projectConfiguration = new ProjectConfiguration(
+                        components.get(PROJECT_NAME_INDEX));
+                components.remove(PROJECT_NAME_INDEX);
+                return MapRouletteConfiguration.parseWithProject(components, projectConfiguration);
             }
         }
         logger.debug(
@@ -51,12 +58,72 @@ public class MapRouletteConfiguration implements Serializable
         return null;
     }
 
+    /**
+     * Parses a map roulette configuration object from a string that follows the structure
+     * [SERVER]:[PORT]:[API_KEY], taking information about the particular project from
+     * projectConfiguration.
+     * 
+     * @param configuration
+     *            The configuration string to parse
+     * @param projectConfiguration
+     *            The details of the project to which we will be uploading.
+     * @return A valid Map Roulette Configuration object, null returned if the configuration string
+     *         is not valid.
+     */
+    public static MapRouletteConfiguration parseWithProject(final String configuration,
+            final ProjectConfiguration projectConfiguration)
+    {
+        if (StringUtils.isNotEmpty(configuration))
+        {
+            final List<String> components = Arrays.asList(configuration.split(DELIMITER));
+            return MapRouletteConfiguration.parseWithProject(components, projectConfiguration);
+        }
+        logger.debug("Map Roulette configuration not set, empty configuration string.");
+        return null;
+    }
+
+    /**
+     * After some pre-processing has been performed, initialize a Map Roulette Configuration object
+     * from some network information and a project configuration.
+     *
+     * @param components
+     *            An ordered list of components defining a connection to Map Roulette. Requires that
+     *            server is at SERVER_INDEX, port is at PORT_INDEX, and the api key is at
+     *            API_KEY_INDEX - 1.
+     * @param configuration
+     *            A ProjectConfiguration defining the project that this connection will connect to
+     *            on Map Roulette
+     * @return A valid Map Roulette Configuration object, null returned if the configuration string
+     *         is not valid.
+     */
+    private static MapRouletteConfiguration parseWithProject(final List<String> components,
+            final ProjectConfiguration configuration)
+    {
+        // TODO clean up indexing/length comparison
+        if (components.size() == NUMBER_OF_COMPONENTS - 1)
+        {
+            return new MapRouletteConfiguration(components.get(SERVER_INDEX),
+                    Integer.parseInt(components.get(PORT_INDEX)), configuration,
+                    components.get(API_KEY_INDEX - 1));
+        }
+        logger.debug(String.format(
+                "Map Roulette configuration not set, invalid number of arguments. [%s]",
+                String.join(DELIMITER, components)));
+        return null;
+    }
+
     public MapRouletteConfiguration(final String server, final int port, final String projectName,
             final String apiKey)
     {
+        this(server, port, new ProjectConfiguration(projectName), apiKey);
+    }
+
+    public MapRouletteConfiguration(final String server, final int port,
+            final ProjectConfiguration projectConfiguration, final String apiKey)
+    {
         this.server = server;
         this.port = port;
-        this.projectName = projectName;
+        this.projectConfiguration = projectConfiguration;
         this.apiKey = apiKey;
     }
 
@@ -72,7 +139,7 @@ public class MapRouletteConfiguration implements Serializable
 
     public String getProjectName()
     {
-        return this.projectName;
+        return this.projectConfiguration.getName();
     }
 
     public String getServer()
@@ -80,9 +147,15 @@ public class MapRouletteConfiguration implements Serializable
         return this.server;
     }
 
+    public ProjectConfiguration getProjectConfiguration()
+    {
+        return this.projectConfiguration;
+    }
+
     @Override
     public String toString()
     {
-        return String.format("%s:%d:%s:%s", this.server, this.port, this.projectName, this.apiKey);
+        return String.format("%s:%d:%s:%s", this.server, this.port,
+                this.projectConfiguration.getName(), this.apiKey);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -44,19 +44,9 @@ public class MapRouletteConfiguration implements Serializable
             final String[] components = configuration.split(DELIMITER);
             if (components.length == NUMBER_OF_COMPONENTS)
             {
-                ProjectConfiguration projectConfiguration = new ProjectConfiguration(
-                        components[PROJECT_NAME_INDEX]);
-                if (!projectConfiguration.getName().equals(components[PROJECT_NAME_INDEX]))
-                {
-                    logger.warn(
-                            "Project name from string ({}) does not equal name from configuration object ({}). Using name from string.",
-                            components[PROJECT_NAME_INDEX], projectConfiguration);
-                    projectConfiguration = new ProjectConfiguration(components[PROJECT_NAME_INDEX],
-                            projectConfiguration.getDescription(),
-                            projectConfiguration.getDisplayName(), PROJECT_DEFAULT_ENABLED);
-                }
                 return new MapRouletteConfiguration(components[SERVER_INDEX],
-                        Integer.parseInt(components[PORT_INDEX]), projectConfiguration,
+                        Integer.parseInt(components[PORT_INDEX]),
+                        new ProjectConfiguration(components[PROJECT_NAME_INDEX]),
                         components[API_KEY_INDEX]);
             }
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -22,6 +22,7 @@ public class MapRouletteConfiguration implements Serializable
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteConfiguration.class);
     private static final long serialVersionUID = -1060265212173405828L;
     private static final String DELIMITER = ":";
+    private static final boolean PROJECT_DEFAULT_ENABLED = true;
     private final String apiKey;
     private final int port;
     private final String server;
@@ -108,7 +109,7 @@ public class MapRouletteConfiguration implements Serializable
                         "Project name from string ({}) does not equal name from configuration object ({}). Using name from string.",
                         components[PROJECT_NAME_INDEX], configurationToUse);
                 configurationToUse = new ProjectConfiguration(components[PROJECT_NAME_INDEX],
-                        configurationToUse.getDescription(), configurationToUse.getDisplayName());
+                        configurationToUse.getDescription(), configurationToUse.getDisplayName(), PROJECT_DEFAULT_ENABLED);
             }
             return new MapRouletteConfiguration(components[SERVER_INDEX],
                     Integer.parseInt(components[PORT_INDEX]), configurationToUse,

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -44,81 +44,25 @@ public class MapRouletteConfiguration implements Serializable
             final String[] components = configuration.split(DELIMITER);
             if (components.length == NUMBER_OF_COMPONENTS)
             {
-                final ProjectConfiguration projectConfiguration = new ProjectConfiguration(
+                ProjectConfiguration projectConfiguration = new ProjectConfiguration(
                         components[PROJECT_NAME_INDEX]);
-                return MapRouletteConfiguration.parseWithProject(components, projectConfiguration);
+                if (!projectConfiguration.getName().equals(components[PROJECT_NAME_INDEX]))
+                {
+                    logger.warn(
+                            "Project name from string ({}) does not equal name from configuration object ({}). Using name from string.",
+                            components[PROJECT_NAME_INDEX], projectConfiguration);
+                    projectConfiguration = new ProjectConfiguration(components[PROJECT_NAME_INDEX],
+                            projectConfiguration.getDescription(),
+                            projectConfiguration.getDisplayName(), PROJECT_DEFAULT_ENABLED);
+                }
+                return new MapRouletteConfiguration(components[SERVER_INDEX],
+                        Integer.parseInt(components[PORT_INDEX]), projectConfiguration,
+                        components[API_KEY_INDEX]);
             }
         }
         logger.debug(
                 String.format("Map Roulette configuration not set, invalid string passed in. [%s]",
                         configuration));
-        return null;
-    }
-
-    /**
-     * Parses a map roulette configuration object from a string that follows the structure
-     * [SERVER]:[PORT]:[PROJECT_NAME]:[API_KEY] and a project-specific configuration object. Note
-     * that the project configuration object also contains a project name -- if the two differ, a
-     * warning will be logged and the project name from the string will be used.
-     * 
-     * @param configuration
-     *            The configuration string to parse.
-     * @param projectConfiguration
-     *            A ProjectConfiguration defining the project that this connection will connect to
-     *            on map roulette
-     * @return A valid Map Roulette configuration object, null returned if the configuration string
-     *         is not valid.
-     */
-    public static MapRouletteConfiguration parseWithProject(final String configuration,
-            final ProjectConfiguration projectConfiguration)
-    {
-        if (StringUtils.isNotEmpty(configuration))
-        {
-            final String[] components = configuration.split(DELIMITER);
-            return parseWithProject(components, projectConfiguration);
-        }
-        logger.debug("Map Roulette configuration not set, invalid string passed in. [%s]",
-                configuration);
-        return null;
-    }
-
-    /**
-     * After some pre-processing has been performed, initialize a Map Roulette Configuration object
-     * from some network information and a project configuration. Note that the project
-     * configuration object also contains a project name -- if the two differ, a warning will be
-     * logged and the project name from the string array will be used.
-     *
-     * @param components
-     *            An ordered list of components defining a connection to Map Roulette. Expects the
-     *            order to be [SERVER, PORT, PROJECT_NAME, API_KEY].
-     * @param configuration
-     *            A ProjectConfiguration defining the project that this connection will connect to
-     *            on Map Roulette
-     * @return A valid Map Roulette Configuration object, null returned if the configuration string
-     *         is not valid.
-     */
-    private static MapRouletteConfiguration parseWithProject(final String[] components,
-            final ProjectConfiguration configuration)
-    {
-        if (components.length == NUMBER_OF_COMPONENTS)
-        {
-            ProjectConfiguration configurationToUse = configuration;
-            if (!configurationToUse.getName().equals(components[PROJECT_NAME_INDEX]))
-            {
-                logger.warn(
-                        "Project name from string ({}) does not equal name from configuration object ({}). Using name from string.",
-                        components[PROJECT_NAME_INDEX], configurationToUse);
-                configurationToUse = new ProjectConfiguration(components[PROJECT_NAME_INDEX],
-                        configurationToUse.getDescription(), configurationToUse.getDisplayName(),
-                        PROJECT_DEFAULT_ENABLED);
-            }
-            return new MapRouletteConfiguration(components[SERVER_INDEX],
-                    Integer.parseInt(components[PORT_INDEX]), configurationToUse,
-                    components[API_KEY_INDEX]);
-        }
-        logger.debug(String.format(
-                "Map Roulette configuration not set, invalid number of arguments. [%s]",
-                String.join(DELIMITER, components)));
         return null;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -109,7 +109,8 @@ public class MapRouletteConfiguration implements Serializable
                         "Project name from string ({}) does not equal name from configuration object ({}). Using name from string.",
                         components[PROJECT_NAME_INDEX], configurationToUse);
                 configurationToUse = new ProjectConfiguration(components[PROJECT_NAME_INDEX],
-                        configurationToUse.getDescription(), configurationToUse.getDisplayName(), PROJECT_DEFAULT_ENABLED);
+                        configurationToUse.getDescription(), configurationToUse.getDisplayName(),
+                        PROJECT_DEFAULT_ENABLED);
             }
             return new MapRouletteConfiguration(components[SERVER_INDEX],
                     Integer.parseInt(components[PORT_INDEX]), configurationToUse,

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -1,9 +1,6 @@
 package org.openstreetmap.atlas.checks.maproulette;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
@@ -17,14 +14,8 @@ import org.slf4j.LoggerFactory;
  */
 public class MapRouletteConfiguration implements Serializable
 {
-    // Note that PROJECT_NAME_INDEX == API_KEY_INDEX! This is because we have two forms:
-    // SERVER:PORT:PROJECT:API_KEY and SERVER:PORT:API_KEY. Under the hood, we are converting from
-    // the first to the second before parsing. So, we need PROJECT_NAME_INDEX to refer to 2
-    // (in the first form) and the rest of the indexes to refer to the second form (where
-    // API_KEY_INDEX is 2).
-    private static final int API_KEY_INDEX = 2;
-    private static final int NUMBER_OF_COMPONENTS_WITH_PROJECT = 4;
-    private static final int NUMBER_OF_COMPONENTS = 3;
+    private static final int API_KEY_INDEX = 3;
+    private static final int NUMBER_OF_COMPONENTS = 4;
     private static final int PORT_INDEX = 1;
     private static final int PROJECT_NAME_INDEX = 2;
     private static final int SERVER_INDEX = 0;
@@ -49,13 +40,11 @@ public class MapRouletteConfiguration implements Serializable
     {
         if (StringUtils.isNotEmpty(configuration))
         {
-            final List<String> components = new LinkedList<>(
-                    Arrays.asList(configuration.split(DELIMITER)));
-            if (components.size() == NUMBER_OF_COMPONENTS_WITH_PROJECT)
+            final String[] components = configuration.split(DELIMITER);
+            if (components.length == NUMBER_OF_COMPONENTS)
             {
                 final ProjectConfiguration projectConfiguration = new ProjectConfiguration(
-                        components.get(PROJECT_NAME_INDEX));
-                components.remove(PROJECT_NAME_INDEX);
+                        components[PROJECT_NAME_INDEX]);
                 return MapRouletteConfiguration.parseWithProject(components, projectConfiguration);
             }
         }
@@ -67,14 +56,16 @@ public class MapRouletteConfiguration implements Serializable
 
     /**
      * Parses a map roulette configuration object from a string that follows the structure
-     * [SERVER]:[PORT]:[API_KEY], taking information about the particular project from
-     * projectConfiguration.
+     * [SERVER]:[PORT]:[PROJECT_NAME]:[API_KEY] and a project-specific configuration object. Note
+     * that the project configuration object also contains a project name -- if the two differ, a
+     * warning will be logged and the project name from the string will be used.
      * 
      * @param configuration
-     *            The configuration string to parse
+     *            The configuration string to parse.
      * @param projectConfiguration
-     *            The details of the project to which we will be uploading.
-     * @return A valid Map Roulette Configuration object, null returned if the configuration string
+     *            A ProjectConfiguration defining the project that this connection will connect to
+     *            on map roulette
+     * @return A valid Map Roulette configuration object, null returned if the configuration string
      *         is not valid.
      */
     public static MapRouletteConfiguration parseWithProject(final String configuration,
@@ -82,34 +73,46 @@ public class MapRouletteConfiguration implements Serializable
     {
         if (StringUtils.isNotEmpty(configuration))
         {
-            final List<String> components = Arrays.asList(configuration.split(DELIMITER));
-            return MapRouletteConfiguration.parseWithProject(components, projectConfiguration);
+            final String[] components = configuration.split(DELIMITER);
+            return parseWithProject(components, projectConfiguration);
         }
-        logger.debug("Map Roulette configuration not set, empty configuration string.");
+        logger.debug("Map Roulette configuration not set, invalid string passed in. [%s]",
+                configuration);
         return null;
     }
 
     /**
      * After some pre-processing has been performed, initialize a Map Roulette Configuration object
-     * from some network information and a project configuration.
+     * from some network information and a project configuration. Note that the project
+     * configuration object also contains a project name -- if the two differ, a warning will be
+     * logged and the project name from the string array will be used.
      *
      * @param components
      *            An ordered list of components defining a connection to Map Roulette. Expects the
-     *            order to be [SERVER, PORT, API_KEY].
+     *            order to be [SERVER, PORT, PROJECT_NAME, API_KEY].
      * @param configuration
      *            A ProjectConfiguration defining the project that this connection will connect to
      *            on Map Roulette
      * @return A valid Map Roulette Configuration object, null returned if the configuration string
      *         is not valid.
      */
-    private static MapRouletteConfiguration parseWithProject(final List<String> components,
+    private static MapRouletteConfiguration parseWithProject(final String[] components,
             final ProjectConfiguration configuration)
     {
-        if (components.size() == NUMBER_OF_COMPONENTS)
+        if (components.length == NUMBER_OF_COMPONENTS)
         {
-            return new MapRouletteConfiguration(components.get(SERVER_INDEX),
-                    Integer.parseInt(components.get(PORT_INDEX)), configuration,
-                    components.get(API_KEY_INDEX));
+            ProjectConfiguration configurationToUse = configuration;
+            if (!configurationToUse.getName().equals(components[PROJECT_NAME_INDEX]))
+            {
+                logger.warn(
+                        "Project name from string ({}) does not equal name from configuration object ({}). Using name from string.",
+                        components[PROJECT_NAME_INDEX], configurationToUse);
+                configurationToUse = new ProjectConfiguration(components[PROJECT_NAME_INDEX],
+                        configurationToUse.getDescription(), configurationToUse.getDisplayName());
+            }
+            return new MapRouletteConfiguration(components[SERVER_INDEX],
+                    Integer.parseInt(components[PORT_INDEX]), configurationToUse,
+                    components[API_KEY_INDEX]);
         }
         logger.debug(String.format(
                 "Map Roulette configuration not set, invalid number of arguments. [%s]",

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -17,8 +17,14 @@ import org.slf4j.LoggerFactory;
  */
 public class MapRouletteConfiguration implements Serializable
 {
-    private static final int API_KEY_INDEX = 3;
-    private static final int NUMBER_OF_COMPONENTS = 4;
+    // Note that PROJECT_NAME_INDEX == API_KEY_INDEX! This is because we have two forms:
+    // SERVER:PORT:PROJECT:API_KEY and SERVER:PORT:API_KEY. Under the hood, we are converting from
+    // the first to the second before parsing. So, we need PROJECT_NAME_INDEX to refer to 2
+    // (in the first form) and the rest of the indexes to refer to the second form (where
+    // API_KEY_INDEX is 2).
+    private static final int API_KEY_INDEX = 2;
+    private static final int NUMBER_OF_COMPONENTS_WITH_PROJECT = 4;
+    private static final int NUMBER_OF_COMPONENTS = 3;
     private static final int PORT_INDEX = 1;
     private static final int PROJECT_NAME_INDEX = 2;
     private static final int SERVER_INDEX = 0;
@@ -43,8 +49,9 @@ public class MapRouletteConfiguration implements Serializable
     {
         if (StringUtils.isNotEmpty(configuration))
         {
-            final List<String> components = new LinkedList<>(Arrays.asList(configuration.split(DELIMITER)));
-            if (components.size() == NUMBER_OF_COMPONENTS)
+            final List<String> components = new LinkedList<>(
+                    Arrays.asList(configuration.split(DELIMITER)));
+            if (components.size() == NUMBER_OF_COMPONENTS_WITH_PROJECT)
             {
                 final ProjectConfiguration projectConfiguration = new ProjectConfiguration(
                         components.get(PROJECT_NAME_INDEX));
@@ -87,9 +94,8 @@ public class MapRouletteConfiguration implements Serializable
      * from some network information and a project configuration.
      *
      * @param components
-     *            An ordered list of components defining a connection to Map Roulette. Requires that
-     *            server is at SERVER_INDEX, port is at PORT_INDEX, and the api key is at
-     *            API_KEY_INDEX - 1.
+     *            An ordered list of components defining a connection to Map Roulette. Expects the
+     *            order to be [SERVER, PORT, API_KEY].
      * @param configuration
      *            A ProjectConfiguration defining the project that this connection will connect to
      *            on Map Roulette
@@ -99,12 +105,11 @@ public class MapRouletteConfiguration implements Serializable
     private static MapRouletteConfiguration parseWithProject(final List<String> components,
             final ProjectConfiguration configuration)
     {
-        // TODO clean up indexing/length comparison
-        if (components.size() == NUMBER_OF_COMPONENTS - 1)
+        if (components.size() == NUMBER_OF_COMPONENTS)
         {
             return new MapRouletteConfiguration(components.get(SERVER_INDEX),
                     Integer.parseInt(components.get(PORT_INDEX)), configuration,
-                    components.get(API_KEY_INDEX - 1));
+                    components.get(API_KEY_INDEX));
         }
         logger.debug(String.format(
                 "Map Roulette configuration not set, invalid number of arguments. [%s]",

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
@@ -16,12 +16,14 @@ public class Project
     private final String name;
     private final String description;
     private final String displayName;
+    private final boolean enabled;
 
     public Project(final String name)
     {
         this.name = name;
         this.description = name;
         this.displayName = name;
+        this.enabled = true;
     }
 
     public Project(final String name, final String description)
@@ -29,13 +31,15 @@ public class Project
         this.name = name;
         this.description = description;
         this.displayName = name;
+        this.enabled = true;
     }
 
-    public Project(final String name, final String description, final String displayName)
+    public Project(final String name, final String description, final String displayName, final boolean enabled)
     {
         this.name = name;
         this.description = description;
         this.displayName = displayName;
+        this.enabled = enabled;
     }
 
     public long getId()
@@ -61,6 +65,11 @@ public class Project
     public String getDisplayName()
     {
         return displayName;
+    }
+
+    public boolean isEnabled()
+    {
+        return enabled;
     }
 
     public JsonObject toJson()

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
@@ -34,7 +34,8 @@ public class Project
         this.enabled = true;
     }
 
-    public Project(final String name, final String description, final String displayName, final boolean enabled)
+    public Project(final String name, final String description, final String displayName,
+            final boolean enabled)
     {
         this.name = name;
         this.description = description;

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonObject;
  * Very basic class defining the structure of the MapRoulette Project
  * 
  * @author cuthbertm
+ * @author nachtm
  */
 public class Project
 {
@@ -14,17 +15,27 @@ public class Project
     private long id = -1;
     private final String name;
     private final String description;
+    private final String displayName;
 
     public Project(final String name)
     {
         this.name = name;
         this.description = name;
+        this.displayName = name;
     }
 
     public Project(final String name, final String description)
     {
         this.name = name;
         this.description = description;
+        this.displayName = name;
+    }
+
+    public Project(final String name, final String description, final String displayName)
+    {
+        this.name = name;
+        this.description = description;
+        this.displayName = displayName;
     }
 
     public long getId()
@@ -45,6 +56,11 @@ public class Project
     public String getDescription()
     {
         return description;
+    }
+
+    public String getDisplayName()
+    {
+        return displayName;
     }
 
     public JsonObject toJson()

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
@@ -27,9 +27,13 @@ public class ProjectConfiguration
 
     /**
      * Defines a project and all of its fields.
-     * @param name The name of the project
-     * @param description The description of the project
-     * @param displayName The name displayed on Map Roulette for the project
+     * 
+     * @param name
+     *            The name of the project
+     * @param description
+     *            The description of the project
+     * @param displayName
+     *            The name displayed on Map Roulette for the project
      */
     public ProjectConfiguration(final String name, final String description,
             final String displayName)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
@@ -1,12 +1,14 @@
 package org.openstreetmap.atlas.checks.maproulette.data;
 
+import java.io.Serializable;
+
 /**
  * Helper class to decouple MapRouletteConfiguration from configuring projects. This allows easier
  * updating of code that handles projects without touching general Map Roulette configuration code.
  *
  * @author nachtm
  */
-public class ProjectConfiguration
+public class ProjectConfiguration implements Serializable
 {
     private String name;
     private String description;

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
@@ -10,10 +10,10 @@ import java.io.Serializable;
  */
 public class ProjectConfiguration implements Serializable
 {
-    private String name;
-    private String description;
-    private String displayName;
-    private boolean enabled;
+    private final String name;
+    private final String description;
+    private final String displayName;
+    private final boolean enabled;
 
     /**
      * Defines a basic project, where all optional fields default to name.

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
@@ -1,0 +1,66 @@
+package org.openstreetmap.atlas.checks.maproulette.data;
+
+/**
+ * Helper class to decouple MapRouletteConfiguration from configuring projects. This allows easier
+ * updating of code that handles projects without touching general Map Roulette configuration code.
+ *
+ * @author nachtm
+ */
+public class ProjectConfiguration
+{
+    private String name;
+    private String description;
+    private String displayName;
+
+    /**
+     * Defines a basic project, where all optional fields default to name.
+     * 
+     * @param name
+     *            The name of the project
+     */
+    public ProjectConfiguration(final String name)
+    {
+        this.name = name;
+        this.description = name;
+        this.displayName = name;
+    }
+
+    /**
+     * Defines a project and all of its fields.
+     * @param name The name of the project
+     * @param description The description of the project
+     * @param displayName The name displayed on Map Roulette for the project
+     */
+    public ProjectConfiguration(final String name, final String description,
+            final String displayName)
+    {
+        this.name = name;
+        this.description = description;
+        this.displayName = displayName;
+    }
+
+    /**
+     * Initialize a project defined by this configuration.
+     * 
+     * @return A new project with the parameters held in this configuration.
+     */
+    public Project buildProject()
+    {
+        return new Project(this.name, this.description, this.displayName);
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public String getDescription()
+    {
+        return this.description;
+    }
+
+    public String getDisplayName()
+    {
+        return this.displayName;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
@@ -11,6 +11,7 @@ public class ProjectConfiguration
     private String name;
     private String description;
     private String displayName;
+    private boolean enabled;
 
     /**
      * Defines a basic project, where all optional fields default to name.
@@ -23,6 +24,7 @@ public class ProjectConfiguration
         this.name = name;
         this.description = name;
         this.displayName = name;
+        this.enabled = true;
     }
 
     /**
@@ -34,13 +36,16 @@ public class ProjectConfiguration
      *            The description of the project
      * @param displayName
      *            The name displayed on Map Roulette for the project
+     * @param enabled
+     *            Whether the project is enabled or not
      */
     public ProjectConfiguration(final String name, final String description,
-            final String displayName)
+            final String displayName, final boolean enabled)
     {
         this.name = name;
         this.description = description;
         this.displayName = displayName;
+        this.enabled = enabled;
     }
 
     /**
@@ -50,7 +55,7 @@ public class ProjectConfiguration
      */
     public Project buildProject()
     {
-        return new Project(this.name, this.description, this.displayName);
+        return new Project(this.name, this.description, this.displayName, this.enabled);
     }
 
     public String getName()

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClientTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClientTest.java
@@ -1,33 +1,84 @@
 package org.openstreetmap.atlas.checks.maproulette;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
+import org.openstreetmap.atlas.checks.maproulette.data.ChallengeDifficulty;
+import org.openstreetmap.atlas.checks.maproulette.data.Project;
+import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
+import org.openstreetmap.atlas.checks.maproulette.data.Task;
 
-import static org.junit.Assert.*;
-
+/**
+ * Unit tests for MapRouletteClient
+ *
+ * @author nachtm
+ */
 public class MapRouletteClientTest
 {
 
-    @Test public void addTask()
+    private static final String CONFIGURATION = "server:123:project:api_key";
+
+    private static final Challenge TEST_CHALLENGE = new Challenge("a name", "a description",
+            "a blurb", "an instruction", ChallengeDifficulty.EASY, "");
+    private Task testTaskOne;
+    private TestMapRouletteConnection mockConnection;
+    private MapRouletteClient client;
+
+    @Before
+    public void setUp()
     {
+        this.testTaskOne = new Task();
+        this.testTaskOne.setTaskIdentifier("1");
+        this.mockConnection = new TestMapRouletteConnection();
+        this.client = new MapRouletteClient(MapRouletteConfiguration.parse(CONFIGURATION),
+                this.mockConnection);
     }
 
-    @Test public void addTask1()
+    @Test
+    public void testAddAndUploadTask()
     {
+        this.client.addTask(TEST_CHALLENGE, this.testTaskOne);
+        this.client.uploadTasks();
+
+        Assert.assertEquals(1, this.mockConnection.uploadedProjects().size());
+        Assert.assertEquals("project", this.mockConnection.uploadedProjects().stream().findFirst()
+                .map(Project::getName).orElse(""));
     }
 
-    @Test public void addTask2()
+    @Test
+    public void testAddAndUploadTaskToNewProject()
     {
+        this.client.addTask("another project", TEST_CHALLENGE, this.testTaskOne);
+        this.client.uploadTasks();
+
+        Assert.assertEquals(1, this.mockConnection.uploadedProjects().size());
+        Assert.assertEquals("another project", this.mockConnection.uploadedProjects().stream()
+                .findFirst().map(Project::getName).orElse(""));
     }
 
-    @Test public void getCurrentBatchSize()
+    @Test
+    public void testProjectConfiguration()
     {
-    }
+        final String name = "yet another project";
+        final String description = "description";
+        final String displayName = "displayName";
+        final ProjectConfiguration configuration = new ProjectConfiguration(name, description,
+                displayName, false);
+        this.client.addTask(configuration, TEST_CHALLENGE, this.testTaskOne);
+        this.client.uploadTasks();
 
-    @Test public void uploadTasks()
-    {
-    }
-
-    @Test public void uploadTasks1()
-    {
+        Assert.assertEquals(1, this.mockConnection.uploadedProjects().size());
+        final Project uploadedProject = this.mockConnection.uploadedProjects().stream().findFirst()
+                .orElseGet(() ->
+                {
+                    Assert.fail(
+                            "There should be exactly one uploaded project, so this shouldn't fail.");
+                    return new Project("some name");
+                });
+        Assert.assertEquals(name, uploadedProject.getName());
+        Assert.assertEquals(description, uploadedProject.getDescription());
+        Assert.assertEquals(displayName, uploadedProject.getDisplayName());
+        Assert.assertFalse(uploadedProject.isEnabled());
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClientTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClientTest.java
@@ -1,0 +1,33 @@
+package org.openstreetmap.atlas.checks.maproulette;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MapRouletteClientTest
+{
+
+    @Test public void addTask()
+    {
+    }
+
+    @Test public void addTask1()
+    {
+    }
+
+    @Test public void addTask2()
+    {
+    }
+
+    @Test public void getCurrentBatchSize()
+    {
+    }
+
+    @Test public void uploadTasks()
+    {
+    }
+
+    @Test public void uploadTasks1()
+    {
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
@@ -1,0 +1,83 @@
+package org.openstreetmap.atlas.checks.maproulette;
+
+import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
+import org.openstreetmap.atlas.checks.maproulette.data.Project;
+import org.openstreetmap.atlas.checks.maproulette.data.Task;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A stub MapRouletteConnection that doesn't actually connect to anything.
+ *
+ * @author nachtm
+ */
+public class TestMapRouletteConnection implements TaskLoader
+{
+
+    private final Map<Project, Set<Challenge>> projectToChallenges;
+    private final Map<Long, Set<Task>> challengeToTasks;
+
+    public TestMapRouletteConnection()
+    {
+        this.projectToChallenges = new HashMap<>();
+        this.challengeToTasks = new HashMap<>();
+    }
+
+    @Override public String getConnectionInfo()
+    {
+        return "";
+    }
+
+    @Override public boolean uploadBatchTasks(final long challengeId, final Set<Task> tasks)
+            throws UnsupportedEncodingException, URISyntaxException
+    {
+        if (this.challengeToTasks.containsKey(challengeId))
+        {
+            this.challengeToTasks.get(challengeId).addAll(tasks);
+        }
+        else
+        {
+            this.challengeToTasks.put(challengeId, tasks);
+        }
+    }
+
+    @Override public boolean uploadTask(final long challengeId, final Task task)
+            throws UnsupportedEncodingException, URISyntaxException
+    {
+        return false;
+    }
+
+    @Override public long createProject(final Project project)
+            throws UnsupportedEncodingException, URISyntaxException
+    {
+        this.projectToChallenges.put(project, Collections.emptySet());
+        return 0;
+    }
+
+    @Override public long createChallenge(final Project project, final Challenge challenge)
+            throws UnsupportedEncodingException, URISyntaxException
+    {
+        if (this.projectToChallenges.containsKey(project))
+        {
+            this.projectToChallenges.get(project).add(challenge);
+        }
+        else
+        {
+            final Set<Challenge> newSet = new HashSet<>();
+            newSet.add(challenge);
+            this.projectToChallenges.put(project, newSet);
+        }
+        return 0;
+    }
+
+    public Set<Project> uploadedProjects()
+    {
+        return projectToChallenges.keySet();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
@@ -1,16 +1,15 @@
 package org.openstreetmap.atlas.checks.maproulette;
 
-import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
-import org.openstreetmap.atlas.checks.maproulette.data.Project;
-import org.openstreetmap.atlas.checks.maproulette.data.Task;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
+import org.openstreetmap.atlas.checks.maproulette.data.Project;
+import org.openstreetmap.atlas.checks.maproulette.data.Task;
 
 /**
  * A stub MapRouletteConnection that doesn't actually connect to anything.
@@ -29,12 +28,14 @@ public class TestMapRouletteConnection implements TaskLoader
         this.challengeToTasks = new HashMap<>();
     }
 
-    @Override public String getConnectionInfo()
+    @Override
+    public String getConnectionInfo()
     {
         return "";
     }
 
-    @Override public boolean uploadBatchTasks(final long challengeId, final Set<Task> tasks)
+    @Override
+    public boolean uploadBatchTasks(final long challengeId, final Set<Task> tasks)
             throws UnsupportedEncodingException, URISyntaxException
     {
         if (this.challengeToTasks.containsKey(challengeId))
@@ -45,22 +46,26 @@ public class TestMapRouletteConnection implements TaskLoader
         {
             this.challengeToTasks.put(challengeId, tasks);
         }
+        return true;
     }
 
-    @Override public boolean uploadTask(final long challengeId, final Task task)
+    @Override
+    public boolean uploadTask(final long challengeId, final Task task)
             throws UnsupportedEncodingException, URISyntaxException
     {
         return false;
     }
 
-    @Override public long createProject(final Project project)
+    @Override
+    public long createProject(final Project project)
             throws UnsupportedEncodingException, URISyntaxException
     {
-        this.projectToChallenges.put(project, Collections.emptySet());
+        this.projectToChallenges.put(project, new HashSet<>());
         return 0;
     }
 
-    @Override public long createChallenge(final Project project, final Challenge challenge)
+    @Override
+    public long createChallenge(final Project project, final Challenge challenge)
             throws UnsupportedEncodingException, URISyntaxException
     {
         if (this.projectToChallenges.containsKey(project))
@@ -79,5 +84,15 @@ public class TestMapRouletteConnection implements TaskLoader
     public Set<Project> uploadedProjects()
     {
         return projectToChallenges.keySet();
+    }
+
+    public Set<Challenge> challengesForProject(final Project project)
+    {
+        return this.projectToChallenges.get(project);
+    }
+
+    public Set<Task> tasksForChallenge(final Challenge challenge)
+    {
+        return this.challengeToTasks.get(challenge);
     }
 }


### PR DESCRIPTION
### Description:

Currently, subclasses of MapRouletteCommand are able to connect to MapRoulette through a four-part command-line switch of the form `maproulette=SERVER:PORT:PROJECT_NAME:API_KEY`. However, the endpoint in MapRoulette that creates a project also takes in a `displayName` parameter, which gives the project a more human-friendly name (think `Test Upload` instead of `test_upload`).

This allows users to pass in a project display name separately, like `projectDisplayName=DISPLAY_NAME`.

In order to make this happen, I made changes to the following classes:
 - `Project` now has a new `displayName` field, which is automatically serialized by its `toJson` function. There is also now a corresponding constructor and getter for `displayName`. 
 - I added a class `ProjectConfiguration`. Semantically, the distinction between a `ProjectConfiguration` and a `Project` is that a `ProjectConfiguration` defines and initializes `Project`s. So, we can pass around what a project should look like in the future without it actually being initialized. Previously this was not necessary, since the only field we cared about was name. 
 - I updated `MapRouletteConfiguration` to be compatible with `ProjectConfiguration`. 
 - Some private functions in `MapRouletteClient` now take `ProjectConfiguration`s instead of just the project name. I also added a package-private constructor that takes in a `TaskLoader` so I could write tests with a mocked-up `TaskLoader` instead of a full-fledged `MapRouletteConnection`. 
 - Obviously, MapRouletteCommand has been updated to parse and handle the new argument format properly

### Potential Impact:

I worked to maintain backwards compatibility with the old usage of `MapRouletteCommand`s, so there should be no impact, except that MapRouletteCommands can now specify DisplayName!

### Unit Test Approach:

Tried submitting projects with and without -projectDisplayName to MapRoulette.

### Test Results:

Compare the new usage:

Parameters:
![image](https://user-images.githubusercontent.com/12106730/54553028-96fe7700-496e-11e9-9a45-467f2e36bb2c.png)

MapRoulette edit project page:
![image](https://user-images.githubusercontent.com/12106730/54553278-13915580-496f-11e9-929c-1491f665a16a.png)


To the old usage:

Parameters:
![image](https://user-images.githubusercontent.com/12106730/54553177-dcbb3f80-496e-11e9-8dbe-1701bf6e5527.png)

MapRoulette edit project page:
![image](https://user-images.githubusercontent.com/12106730/54553247-ff4d5880-496e-11e9-8cce-ce68f4a52b7e.png)


Also compare their displays in the manage page:
![image](https://user-images.githubusercontent.com/12106730/54553314-23109e80-496f-11e9-8c8b-0e50f0e73486.png)

This can be merged after:
 - [x] I write some unit tests to make sonar happy
