### PR TITLE
Deprecate event service

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/event/Event.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/Event.java
@@ -5,8 +5,11 @@ import java.util.Date;
 /**
  * Useful base class to hold common information for {@link Event} implementations
  *
+ * @deprecated - use {@link org.openstreetmap.atlas.event.Event}.
+ *
  * @author mkalender
  */
+@Deprecated
 public abstract class Event
 {
     private final Date timestamp;

--- a/src/main/java/org/openstreetmap/atlas/checks/event/Event.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/Event.java
@@ -6,7 +6,6 @@ import java.util.Date;
  * Useful base class to hold common information for {@link Event} implementations
  *
  * @deprecated - use {@link org.openstreetmap.atlas.event.Event}.
- *
  * @author mkalender
  */
 @Deprecated

--- a/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
@@ -15,8 +15,11 @@ import com.google.common.eventbus.EventBus;
 /**
  * A simple in-memory publish-subscribe service built on top of {@link EventBus}
  *
+ * @deprecated - use {@link org.openstreetmap.atlas.event.EventService}
+ *
  * @author mkalender
  */
+@Deprecated
 public final class EventService
 {
     private static final Logger logger = LoggerFactory.getLogger(EventService.class);

--- a/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/EventService.java
@@ -16,7 +16,6 @@ import com.google.common.eventbus.EventBus;
  * A simple in-memory publish-subscribe service built on top of {@link EventBus}
  *
  * @deprecated - use {@link org.openstreetmap.atlas.event.EventService}
- *
  * @author mkalender
  */
 @Deprecated

--- a/src/main/java/org/openstreetmap/atlas/checks/event/Processor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/Processor.java
@@ -3,10 +3,13 @@ package org.openstreetmap.atlas.checks.event;
 /**
  * The {@link Processor} interface provides simple hooks for implementations to handle events.
  *
+ * @deprecated - use {@link org.openstreetmap.atlas.event.Processor}
+ *
  * @author mkalender
  * @param <T>
  *            Type that is going to be processed
  */
+@Deprecated
 public interface Processor<T extends Event>
 {
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/event/Processor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/Processor.java
@@ -4,7 +4,6 @@ package org.openstreetmap.atlas.checks.event;
  * The {@link Processor} interface provides simple hooks for implementations to handle events.
  *
  * @deprecated - use {@link org.openstreetmap.atlas.event.Processor}
- *
  * @author mkalender
  * @param <T>
  *            Type that is going to be processed

--- a/src/main/java/org/openstreetmap/atlas/checks/event/ShutdownEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/ShutdownEvent.java
@@ -3,8 +3,11 @@ package org.openstreetmap.atlas.checks.event;
 /**
  * An {@link Event} that is posted when {@link EventService} is shutting down
  *
+ * @deprecated - use {@link org.openstreetmap.atlas.event.ShutdownEvent}
+ *
  * @author mkalender
  */
+@Deprecated
 public class ShutdownEvent extends Event
 {
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/event/ShutdownEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/ShutdownEvent.java
@@ -4,7 +4,6 @@ package org.openstreetmap.atlas.checks.event;
  * An {@link Event} that is posted when {@link EventService} is shutting down
  *
  * @deprecated - use {@link org.openstreetmap.atlas.event.ShutdownEvent}
- *
  * @author mkalender
  */
 @Deprecated


### PR DESCRIPTION
### Description:

The `EventService` was moved to [atlas](https://github.com/osmlab/atlas) as a part of https://github.com/osmlab/atlas/pull/324.

### Potential Impact:

None.

### Unit Test Approach:

NA.

### Test Results:

Existing tests successful.

