### PR TITLE
Fixing GeoJSON creation

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -206,7 +206,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public void addObjects(final Iterable<AtlasObject> objects)
     {
-        Iterables.stream(objects).forEach(this::addObject);
+        objects.forEach(this::addObject);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPoint.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPoint.java
@@ -52,23 +52,22 @@ public class FlaggedPoint extends FlaggedObject
     @Override
     public JsonObject asGeoJsonFeature(final String flagIdentifier)
     {
-        final JsonObject feature;
+        final JsonObject geoJsonGeometry;
         final JsonObject properties;
         if (this.locationItem != null)
         {
-            feature = this.locationItem.asGeoJsonGeometry();
+            geoJsonGeometry = this.locationItem.asGeoJsonGeometry();
             properties = this.locationItem.getGeoJsonProperties();
         }
         else
         {
             properties = new JsonObject();
-            feature = GeoJsonUtils.feature(this.point.asGeoJsonGeometry(), properties);
+            geoJsonGeometry = this.point.asGeoJsonGeometry();
         }
 
         properties.addProperty("flag:id", flagIdentifier);
         properties.addProperty("flag:type", FlaggedPoint.class.getSimpleName());
-        feature.add("properties", properties);
-        return feature;
+        return GeoJsonUtils.feature(geoJsonGeometry, properties);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPolyline.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPolyline.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
+import org.openstreetmap.atlas.geography.geojson.GeoJsonUtils;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
 
 import com.google.gson.JsonObject;
@@ -56,13 +57,11 @@ public class FlaggedPolyline extends FlaggedObject
     @Override
     public JsonObject asGeoJsonFeature(final String flagIdentifier)
     {
-        final JsonObject feature = this.atlasItem.asGeoJsonGeometry();
+        final JsonObject geoJsonGeometry = this.atlasItem.asGeoJsonGeometry();
         final JsonObject jsonProperties = this.atlasItem.getGeoJsonProperties();
-
         jsonProperties.addProperty("flag:id", flagIdentifier);
         jsonProperties.addProperty("flag:type", FlaggedPolyline.class.getSimpleName());
-        feature.add("properties", jsonProperties);
-        return feature;
+        return GeoJsonUtils.feature(geoJsonGeometry, jsonProperties);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -7,6 +7,7 @@ import org.openstreetmap.atlas.geography.Rectangle;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
+import org.openstreetmap.atlas.geography.geojson.GeoJsonUtils;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
@@ -43,12 +44,11 @@ public class FlaggedRelation extends FlaggedObject
     @Override
     public JsonObject asGeoJsonFeature(final String flagIdentifier)
     {
-        final JsonObject feature = this.relation.asGeoJsonGeometry();
+        final JsonObject geoJsonGeometry = this.relation.asGeoJsonGeometry();
         final JsonObject featureProperties = this.relation.getGeoJsonProperties();
         featureProperties.addProperty("flag:id", flagIdentifier);
         featureProperties.addProperty("flag:type", FlaggedRelation.class.getSimpleName());
-        feature.add("properties", featureProperties);
-        return feature;
+        return GeoJsonUtils.feature(geoJsonGeometry, featureProperties);
     }
 
     /**


### PR DESCRIPTION
### Description:

Currently, each flagged object should be able to return a properly formed GeoJSON feature with flag ID information. This got broken with the GeoJSON updates where we are now adding properties find to a geometry object which is not to spec. This constructs the feature for each flagged object in the proper way. 

### Potential Impact:

Flag parsers should work the same way as they did before the breaking update. 

### Unit Test Approach:

All unit tests the same. 


