### PR TITLE
Sink Island Check Enhancement to Filter Pedestrian Navigable Highways

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -231,7 +231,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.start())
                 // Ignore edges that are of type service and is connected to pedestrian navigable
                 // ways
-                || this.isServiceRoad(edge) && this.isConnectedToPedestrian(edge);
+                || this.isServiceRoad(edge) && this.isConnectedToPedestrianNavigableHighway(edge);
     }
 
     /**
@@ -274,7 +274,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
      *            any edge
      * @return true if the edge has connection to pedestrian navigable highways
      */
-    private boolean isConnectedToPedestrian(final Edge edge)
+    private boolean isConnectedToPedestrianNavigableHighway(final Edge edge)
     {
         return edge.connectedEdges().stream().anyMatch(HighwayTag::isPedestrianNavigableHighway);
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -220,7 +220,6 @@ public class SinkIslandCheck extends BaseCheck<Long>
      */
     private boolean edgeCharacteristicsToIgnore(final Edge edge)
     {
-
         // If the edge has already been flagged by another process then we can break out of the
         // loop and assume that whether the check was a flag or not was handled by the other process
         return this.isFlagged(edge.getIdentifier())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -8,13 +8,11 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
-import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
@@ -232,24 +230,27 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // ways
                 || this.isServiceRoad(edge) && this.isConnectedToPedestrian(edge)
                 // Ignore edges that are fully enclosed in areas with amenity values to exclude
-                || this.isWithinBuilding(edge);
+                || this.isServiceRoad(edge) && this.isWithinAreasWithExcludedAmenityTags(edge);
     }
 
     /**
-     * Checks if the edge is fully enclosed within areas that have amenity tags that are in the AMENITY_VALUES_TO_EXCLUDE list
-     * @param edge any edge
+     * Checks if the edge is fully enclosed within areas that have amenity tags that are in the
+     * AMENITY_VALUES_TO_EXCLUDE list
+     *
+     * @param edge
+     *            any edge
      * @return true if the edge is fully enclosed within the area with excluded amenity tag
      */
-    private boolean isWithinBuilding(final Edge edge)
+    private boolean isWithinAreasWithExcludedAmenityTags(final Edge edge)
     {
         return StreamSupport
-                .stream(edge.getAtlas().areasCovering(edge.start().getLocation()).spliterator(),
-                        false)
-                .filter(area -> Validators
-                        .isOfType(area, AmenityTag.class, AMENITY_VALUES_TO_EXCLUDE))
-                .anyMatch(area-> area.asPolygon().fullyGeometricallyEncloses(edge.start()
-                        .getLocation())&& area.asPolygon().fullyGeometricallyEncloses(edge.end().getLocation()));
-
+                .stream(edge.getAtlas()
+                        .areasCovering(edge.start().getLocation(),
+                                area -> Validators.isOfType(area, AmenityTag.class,
+                                        AMENITY_VALUES_TO_EXCLUDE))
+                        .spliterator(), false)
+                .anyMatch(area -> area.asPolygon()
+                        .fullyGeometricallyEncloses(edge.end().getLocation()));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -106,9 +106,11 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 emptyFlag = true;
                 break;
             }
+
             // Retrieve all the valid outgoing edges to explore
             final Set<Edge> outEdges = candidate.outEdges().stream().filter(this::validEdge)
                     .collect(Collectors.toSet());
+
             if (outEdges.isEmpty())
             {
                 // Sink edge. Don't mark the edge explored until we know how big the tree is

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -246,8 +246,9 @@ public class SinkIslandCheck extends BaseCheck<Long>
     {
         return StreamSupport
                 .stream(edge.getAtlas()
-                        .areas(area -> Validators.isOfType(area, AmenityTag.class,
-                                AMENITY_VALUES_TO_EXCLUDE))
+                        .areasIntersecting(edge.bounds(),
+                                area -> Validators.isOfType(area, AmenityTag.class,
+                                        AMENITY_VALUES_TO_EXCLUDE))
                         .spliterator(), false)
                 .anyMatch(area -> area.asPolygon().fullyGeometricallyEncloses(edge.asPolyLine()));
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -19,6 +19,7 @@ import org.openstreetmap.atlas.tags.AerowayTag;
 import org.openstreetmap.atlas.tags.AmenityTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.RouteTag;
+import org.openstreetmap.atlas.tags.ServiceTag;
 import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
@@ -32,6 +33,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * @author gpogulsky
  * @author savannahostrowski
  * @author nachtm
+ * @author sayas01
  */
 public class SinkIslandCheck extends BaseCheck<Long>
 {
@@ -71,7 +73,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return this.validEdge(object) && !this.isFlagged(object.getIdentifier()) && ((Edge) object)
+        return this.validEdge(object) && HighwayTag.isCarNavigableHighway(object) && !RouteTag.isFerry(object)
+                && !this.isFlagged(object.getIdentifier()) && ((Edge) object)
                 .highwayTag().isMoreImportantThanOrEqualTo(this.minimumHighwayType);
     }
 
@@ -104,12 +107,21 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 emptyFlag = true;
                 break;
             }
-
+            final Set<Edge> outEdges = candidate.outEdges().stream().filter(edge-> !RouteTag.isFerry(object) && this.validEdge(edge)).collect(
+                    Collectors.toSet());
+            Set<Edge> filteredOutEdges;
             // Retrieve all the valid outgoing edges to explore
-            final Set<Edge> outEdges = candidate.outEdges().stream().filter(this::validEdge)
-                    .collect(Collectors.toSet());
+            if(this.isServiceRoad(candidate))
+            {
+                // check if out edges is car navigable or pedestrian
+                filteredOutEdges = outEdges.stream().filter(edge->HighwayTag.isCarNavigableHighway(object)||
+                        HighwayTag.isPedestrianNavigableHighway(object)).collect(Collectors.toSet());
 
-            if (outEdges.isEmpty())
+            }
+            else{
+                filteredOutEdges = outEdges.stream().filter(edge->HighwayTag.isCarNavigableHighway(object)).collect(Collectors.toSet());
+            }
+            if (filteredOutEdges.isEmpty())
             {
                 // Sink edge. Don't mark the edge explored until we know how big the tree is
                 terminal.add(candidate);
@@ -122,7 +134,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // From the list of outgoing edges from the current candidate filter out any edges
                 // that have already been explored and add all the rest to the queue of possible
                 // candidates
-                outEdges.stream().filter(outEdge -> !explored.contains(outEdge))
+                filteredOutEdges.stream().filter(outEdge -> !explored.contains(outEdge))
                         .forEach(candidates::add);
 
                 // If the number of available candidates and the size of the currently explored
@@ -180,10 +192,17 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // Ignore any airport taxiways and runways, as these often create a sink island
                 && !Validators.isOfType(object, AerowayTag.class, AerowayTag.TAXIWAY,
                         AerowayTag.RUNWAY)
-                // Only allow car navigable highways and ignore ferries
-                && HighwayTag.isCarNavigableHighway(object) && !RouteTag.isFerry(object)
                 // Ignore any highways tagged as areas
                 && !TagPredicates.IS_AREA.test(object);
+    }
+
+    private boolean hasValidHighwayClassification(final AtlasObject connectedEdge, final AtlasObject candidateEdge)
+    {
+        if(!this.isServiceRoad(candidateEdge))
+        {
+            return HighwayTag.isCarNavigableHighway(connectedEdge) && !RouteTag.isFerry(connectedEdge);
+        }
+        return true;
     }
 
     /**
@@ -223,5 +242,11 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // of creating a false positive due to the sectioning of the way
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.end())
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.start());
+    }
+
+    private boolean isServiceRoad(final AtlasObject edge)
+    {
+        return Validators.isOfType(edge,HighwayTag.class,HighwayTag.SERVICE) && Validators.hasValuesFor(edge,
+                ServiceTag.class);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -225,17 +225,32 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // of creating a false positive due to the sectioning of the way
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.end())
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.start())
-                // Ignore edges that are of type service and has connection to pedestrian navigable
+                // Ignore edges that are of type service and is connected to pedestrian navigable
                 // ways
                 || this.isServiceRoad(edge) && this.isConnectedToPedestrian(edge);
     }
 
-    private boolean isServiceRoad(final AtlasObject edge)
+    /**
+     * Checks if an {@link Edge} is of type service
+     * 
+     * @param edge
+     *            any edge
+     * @return true if the highway classification of the edge is of type service and it has a
+     *         service tag
+     */
+    private boolean isServiceRoad(final Edge edge)
     {
         return Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
                 && Validators.hasValuesFor(edge, ServiceTag.class);
     }
 
+    /**
+     * Checks if an {@link Edge} is connected to any edge that is a pedestrian navigable highway
+     * 
+     * @param edge
+     *            any edge
+     * @return true if the edge has connection to pedestrian navigable highways
+     */
     private boolean isConnectedToPedestrian(final Edge edge)
     {
         return edge.connectedEdges().stream().anyMatch(HighwayTag::isPedestrianNavigableHighway);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -8,10 +8,13 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
@@ -227,7 +230,26 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.start())
                 // Ignore edges that are of type service and is connected to pedestrian navigable
                 // ways
-                || this.isServiceRoad(edge) && this.isConnectedToPedestrian(edge);
+                || this.isServiceRoad(edge) && this.isConnectedToPedestrian(edge)
+                // Ignore edges that are fully enclosed in areas with amenity values to exclude
+                || this.isWithinBuilding(edge);
+    }
+
+    /**
+     * Checks if the edge is fully enclosed within areas that have amenity tags that are in the AMENITY_VALUES_TO_EXCLUDE list
+     * @param edge any edge
+     * @return true if the edge is fully enclosed within the area with excluded amenity tag
+     */
+    private boolean isWithinBuilding(final Edge edge)
+    {
+        return StreamSupport
+                .stream(edge.getAtlas().areasCovering(edge.start().getLocation()).spliterator(),
+                        false)
+                .filter(area -> Validators
+                        .isOfType(area, AmenityTag.class, AMENITY_VALUES_TO_EXCLUDE))
+                .anyMatch(area-> area.asPolygon().fullyGeometricallyEncloses(edge.start()
+                        .getLocation())&& area.asPolygon().fullyGeometricallyEncloses(edge.end().getLocation()));
+
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -107,7 +107,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 break;
             }
             // Retrieve all the valid outgoing edges to explore
-            final Set<Edge> outEdges = candidate.outEdges().stream().filter(this::validEdge).collect(Collectors.toSet());
+            final Set<Edge> outEdges = candidate.outEdges().stream().filter(this::validEdge)
+                    .collect(Collectors.toSet());
             if (outEdges.isEmpty())
             {
                 // Sink edge. Don't mark the edge explored until we know how big the tree is
@@ -222,14 +223,15 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // of creating a false positive due to the sectioning of the way
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.end())
                 || SyntheticBoundaryNodeTag.isBoundaryNode(edge.start())
-                // Ignore edges that are of type service and has connection to pedestrian navigable ways
+                // Ignore edges that are of type service and has connection to pedestrian navigable
+                // ways
                 || this.isServiceRoad(edge) && this.isConnectedToPedestrian(edge);
     }
 
     private boolean isServiceRoad(final AtlasObject edge)
     {
-        return Validators.isOfType(edge,HighwayTag.class,HighwayTag.SERVICE) && Validators.hasValuesFor(edge,
-                ServiceTag.class);
+        return Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
+                && Validators.hasValuesFor(edge, ServiceTag.class);
     }
 
     private boolean isConnectedToPedestrian(final Edge edge)

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -100,6 +100,14 @@ public class SinkIslandCheckTest
     {
         this.verifier.actual(this.setup.getEdgeConnectedToPedestrianNetwork(), new SinkIslandCheck(
                 ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testEdgesWithinAreasWithAmenityTags()
+    {
+        this.verifier.actual(this.setup.getEdgeWithinAreaWithAmenityTag(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -10,6 +10,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * @author matthieun
  * @author gpogulsky
  * @author nachtm
+ * @author sayas01
  */
 public class SinkIslandCheckTest
 {
@@ -92,5 +93,13 @@ public class SinkIslandCheckTest
                 new SinkIslandCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"SinkIslandCheck\": {\"tree.size\": 3, \"minimum.highway.type\": \"RESIDENTIAL\"}}")));
         this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testSingleEdgePartOfPedestrianNetwork()
+    {
+        this.verifier.actual(this.setup.getEdgeConnectedToPedestrianNetwork(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -166,13 +166,13 @@ public class SinkIslandCheckTestRule extends CoreTestRule
         return this.serviceSinkIsland;
     }
 
-    public Atlas getEdgeConnectedToPedestrianNetwork()
-    {
-        return this.pedestrianNetwork;
-    }
-
     public Atlas getInvalidEdges()
     {
         return this.invalidEdges;
+    }
+
+    public Atlas getEdgeConnectedToPedestrianNetwork()
+    {
+        return this.pedestrianNetwork;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -12,6 +12,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
  *
  * @author gpogulsky
  * @author nachtm
+ * @author sayas01
  */
 public class SinkIslandCheckTestRule extends CoreTestRule
 {
@@ -121,6 +122,15 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                             "highway=service" }), })
     private Atlas invalidEdges;
 
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)),
+            @Node(coordinates = @Loc(value = TEST_3)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=service", "service=driveway" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=pedestrian" }) })
+    private Atlas pedestrianNetwork;
+
     public Atlas getSingleEdgeAtlas()
     {
         return this.singleEdgeAtlas;
@@ -154,6 +164,11 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     public Atlas getServiceSinkIsland()
     {
         return this.serviceSinkIsland;
+    }
+
+    public Atlas getEdgeConnectedToPedestrianNetwork()
+    {
+        return this.pedestrianNetwork;
     }
 
     public Atlas getInvalidEdges()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.checks.validation.linear.edges;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
@@ -24,6 +25,12 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     private static final String TEST_6 = "37.325440,-122.033948";
     private static final String TEST_7 = "37.3314171,-122.0304871";
     private static final String TEST_8 = "37.324233,-122.003467";
+    private static final String TEST_9 = "56.3097870, 9.1207824";
+    private static final String TEST_10 = "56.3101021, 9.1213965";
+    private static final String TEST_11 = "56.3095716, 9.1223019";
+    private static final String TEST_12 = "56.3092499, 9.1216749";
+    private static final String TEST_13 = "56.3096026, 9.1211942";
+    private static final String TEST_14 = "56.3098639, 9.1217029";
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_3)),
             @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_6)),
@@ -131,6 +138,17 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                             "highway=pedestrian" }) })
     private Atlas pedestrianNetwork;
 
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_9)),
+            @Node(coordinates = @Loc(value = TEST_10)), @Node(coordinates = @Loc(value = TEST_11)),
+            @Node(coordinates = @Loc(value = TEST_12)), @Node(coordinates = @Loc(value = TEST_13)),
+            @Node(coordinates = @Loc(value = TEST_14)) }, areas = { @Area(coordinates = {
+                    @Loc(value = TEST_9), @Loc(value = TEST_10), @Loc(value = TEST_11),
+                    @Loc(value = TEST_12) }, tags = { "amenity=parking" }) }, edges = {
+                            @Edge(id = "1", coordinates = { @Loc(value = TEST_13),
+                                    @Loc(value = TEST_14) }, tags = { "highway=service",
+                                            "service=parking_aisle" }) })
+    private Atlas edgeWithinAreaWithAmenityTag;
+
     public Atlas getSingleEdgeAtlas()
     {
         return this.singleEdgeAtlas;
@@ -174,5 +192,10 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     public Atlas getEdgeConnectedToPedestrianNetwork()
     {
         return this.pedestrianNetwork;
+    }
+
+    public Atlas getEdgeWithinAreaWithAmenityTag()
+    {
+        return this.edgeWithinAreaWithAmenityTag;
     }
 }


### PR DESCRIPTION
### Description:

This PR adds a small enhancement to the existing SinkIslandCheck to exclude edges that are part of pedestrian navigable ways. Many edges that are of type service( `highway = service` and `service = *`) were flagged as floating, but are actually part of pedestrian highway network. The enhancement will filter out edges that are of type `highway = service` and `service =*` and 
1)  are fully enclosed within areas that have amenity = PARKING, PARKING_SPACE, MOTORCYCLE_PARKING,PARKING_ENTRANCE 
Example:
Edge https://www.openstreetmap.org/way/472780972 is within a parking lot
<img src="https://user-images.githubusercontent.com/42149840/55975918-dc495800-5c3f-11e9-9a23-fe69bfd508c5.png" width="200">

2) are connected to any of the pedestrian navigable ways defined in the Highway class. Example: https://www.openstreetmap.org/way/333824047 way is connected to a pedestrian way
### Potential Impact:

A drop in number of previously flagged items that are service edges connected to pedestrian network.

### Unit Test Approach:

Unit tests were added to test the enhancements. Locally ran the enhancements on DNK and verified the pre enhancement and post enhancement results
### Test Results:

All unit tests are passing and the dropped flags in DNK were verified to be of edges that are part of pedestrian network.

