### PR TITLE
Hot Fix for Sink Island Check Enhancement Bug 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -76,7 +76,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
     {
         return this.validEdge(object) && !this.isFlagged(object.getIdentifier()) && ((Edge) object)
                 .highwayTag().isMoreImportantThanOrEqualTo(this.minimumHighwayType)
-        // Ignore edges that are fully enclosed in areas with amenity values to exclude
+                // Ignore edges that are fully enclosed in areas with amenity values to exclude
                 && !(this.isServiceRoad((Edge) object)
                         && this.isWithinAreasWithExcludedAmenityTags((Edge) object));
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -74,9 +74,9 @@ public class SinkIslandCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return this.validEdge(object) && !this.isFlagged(object.getIdentifier()) && ((Edge) object)
-                .highwayTag().isMoreImportantThanOrEqualTo(this.minimumHighwayType)
-                // Ignore edges that are fully enclosed in areas with amenity values to exclude
+        return this.validEdge(object) && !this.isFlagged(object.getIdentifier())
+                && ((Edge) object).highwayTag()
+                        .isMoreImportantThanOrEqualTo(this.minimumHighwayType)
                 && !(this.isServiceRoad((Edge) object)
                         && this.isWithinAreasWithExcludedAmenityTags((Edge) object));
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -75,7 +75,10 @@ public class SinkIslandCheck extends BaseCheck<Long>
     public boolean validCheckForObject(final AtlasObject object)
     {
         return this.validEdge(object) && !this.isFlagged(object.getIdentifier()) && ((Edge) object)
-                .highwayTag().isMoreImportantThanOrEqualTo(this.minimumHighwayType);
+                .highwayTag().isMoreImportantThanOrEqualTo(this.minimumHighwayType)
+        // Ignore edges that are fully enclosed in areas with amenity values to exclude
+                && !(this.isServiceRoad((Edge) object)
+                        && this.isWithinAreasWithExcludedAmenityTags((Edge) object));
     }
 
     @Override
@@ -186,10 +189,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
                 // Only allow car navigable highways and ignore ferries
                 && HighwayTag.isCarNavigableHighway(object) && !RouteTag.isFerry(object)
                 // Ignore any highways tagged as areas
-                && !TagPredicates.IS_AREA.test(object)
-                // Ignore edges that are fully enclosed in areas with amenity values to exclude
-                && !(this.isServiceRoad((Edge) object)
-                        && this.isWithinAreasWithExcludedAmenityTags((Edge) object));
+                && !TagPredicates.IS_AREA.test(object);
     }
 
     /**


### PR DESCRIPTION
### Description:

This is a hot fix to fix a bug with the latest enhancement to the SinkIslandCheck. The enhancement added a condition to the `validEdge()` which resulted in some FP which were not caught in the initial analysis. The fix is to extract the condition that checks for service edges that are fully enclosed in amenity areas, from the `validEdge` method to `validCheckForObject` method. Some of the edges that were connected to service roads that were within amenity areas were incorrectly flagged because the out edges (service roads within amenity) of these edges were invalid and so the edges were flagged as floating.
Example:
<img src="https://user-images.githubusercontent.com/42149840/56324645-46706a00-6124-11e9-9dce-848b46ec3a91.png" width="300">

### Potential Impact:

Enhancement would have added some FP flags which are removed with this fix.

### Unit Test Approach:

Ran a pre and post enhancement flag diff to validate the flags dropped.

### Test Results:

All unit tests passing and fixes the additional flags from the enhancement.

