### PR TITLE
MapRouletteUploadCommand Country and Check Filters

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -77,6 +77,11 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         final Gson gson = new GsonBuilder().registerTypeAdapter(Task.class,
                 new TaskDeserializer(configuration.getProjectName())).create();
         final Configuration instructions = this.loadConfiguration(commandMap);
+        // Get the countries filter
+        final List<String> countries = (List<String>) commandMap.get(COUNTRIES);
+        // Get the checks filter
+        final List<String> checks = (List<String>) commandMap.get(CHECKS);
+
         ((File) commandMap.get(INPUT_DIRECTORY)).listFilesRecursively().forEach(logFile ->
         {
             // If this file is something we handle, read and upload the tasks contained within
@@ -89,17 +94,13 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                     {
                         // Get Task from geojson
                         final Task task = gson.fromJson(line, Task.class);
-                        // Get the first country code from the geojson
+                        // Get the first country code from the Task
                         final Optional<String> countryCode = Iterables
                                 .stream(task.getGeoJson().orElse(new JsonArray()))
                                 .map(this::getElementCountryCode).firstMatching(Optional::isPresent)
                                 .get();
                         // Get the challenge name from the Task
                         final String check = task.getChallengeName();
-                        // Get the countries filter
-                        final List<String> countries = (List<String>) commandMap.get(COUNTRIES);
-                        // Get the checks filter
-                        final List<String> checks = (List<String>) commandMap.get(CHECKS);
                         // If the country filter and country code exist, check that the country code
                         // is in the filter.
                         if ((countries == null || (countryCode.isPresent()
@@ -110,7 +111,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                         {
                             try
                             {
-                                // try to add the task for upload
+                                // Try to add the task for upload
                                 this.addTask(
                                         this.getChallenge(task.getChallengeName(), instructions),
                                         task);

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -78,9 +78,10 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                 new TaskDeserializer(configuration.getProjectName())).create();
         final Configuration instructions = this.loadConfiguration(commandMap);
         // Get the countries filter
-        final List<String> countries = (List<String>) commandMap.get(COUNTRIES);
+        final Optional<List<String>> countries = (Optional<List<String>>) commandMap
+                .getOption(COUNTRIES);
         // Get the checks filter
-        final List<String> checks = (List<String>) commandMap.get(CHECKS);
+        final Optional<List<String>> checks = (Optional<List<String>>) commandMap.getOption(CHECKS);
 
         ((File) commandMap.get(INPUT_DIRECTORY)).listFilesRecursively().forEach(logFile ->
         {
@@ -103,11 +104,11 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                         final String check = task.getChallengeName();
                         // If the country filter and country code exist, check that the country code
                         // is in the filter.
-                        if ((countries == null || (countryCode.isPresent()
-                                && countries.contains(countryCode.get())))
+                        if ((!countries.isPresent() || (countryCode.isPresent()
+                                && countries.get().contains(countryCode.get())))
                                 // If the checks filter exists, check that the challenge name is in
                                 // the checks filter.
-                                && (checks == null || checks.contains(check)))
+                                && (!checks.isPresent() || checks.get().contains(check)))
                         {
                             try
                             {

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -119,7 +119,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                             }
                             catch (URISyntaxException | UnsupportedEncodingException error)
                             {
-                                logger.error("Error thrown while adding task: ", error);
+                                logger.error("Exception thrown while adding task: ", error);
                             }
                         }
                     });
@@ -127,7 +127,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                 }
                 catch (final IOException error)
                 {
-                    logger.error("Error while reading {}:", logFile, error);
+                    logger.error("Exception while reading {}:", logFile, error);
                 }
             });
         });

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -110,7 +110,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                         {
                             try
                             {
-                                // try to add the task fot upload
+                                // try to add the task for upload
                                 this.addTask(
                                         this.getChallenge(task.getChallengeName(), instructions),
                                         task);

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -42,6 +42,7 @@ import com.google.gson.JsonObject;
  * Given a directory of log files created by atlas-checks, upload those files to MapRoulette.
  *
  * @author nachtm
+ * @author bbreithaupt
  */
 public class MapRouletteUploadCommand extends MapRouletteCommand
 {

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.maproulette;
 
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.PROPERTIES;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -8,8 +10,10 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
@@ -20,6 +24,8 @@ import org.openstreetmap.atlas.checks.maproulette.data.Task;
 import org.openstreetmap.atlas.checks.maproulette.serializer.ChallengeDeserializer;
 import org.openstreetmap.atlas.checks.maproulette.serializer.TaskDeserializer;
 import org.openstreetmap.atlas.streaming.resource.File;
+import org.openstreetmap.atlas.tags.ISOCountryTag;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.configuration.StandardConfiguration;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
@@ -28,6 +34,9 @@ import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 /**
  * Given a directory of log files created by atlas-checks, upload those files to MapRoulette.
@@ -42,6 +51,12 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
     private static final Switch<File> CONFIG_LOCATION = new Switch<>("config",
             "Path to a file containing MapRoulette challenge configuration.", File::new,
             Optionality.OPTIONAL, "config/configuration.json");
+    private static final Switch<List<String>> COUNTRIES = new Switch<>("countries",
+            "A comma separated list of ISO3 country codes to filter flags by.",
+            string -> Arrays.asList(string.split(",")), Optionality.OPTIONAL);
+    private static final Switch<List<String>> CHECKS = new Switch<>("checks",
+            "A comma separated list of check names to filter flags by.",
+            string -> Arrays.asList(string.split(",")), Optionality.OPTIONAL);
     private static final String PARAMETER_CHALLENGE = "challenge";
     private static final String LOG_EXTENSION = "log";
     private static final String ZIPPED_LOG_EXTENSION = ".log.gz";
@@ -71,15 +86,38 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                 {
                     reader.lines().forEach(line ->
                     {
+                        // Get Task from geojson
                         final Task task = gson.fromJson(line, Task.class);
-                        try
+                        // Get the first country code from the geojson
+                        final Optional<String> countryCode = Iterables
+                                .stream(task.getGeoJson().orElse(new JsonArray()))
+                                .map(this::getElementCountryCode)
+                                .firstMatching(iso -> !iso.equals(""));
+                        // Get the challenge name from the Task
+                        final String check = task.getChallengeName();
+                        // Get the countries filter
+                        final List<String> countries = (List<String>) commandMap.get(COUNTRIES);
+                        // Get the checks filter
+                        final List<String> checks = (List<String>) commandMap.get(CHECKS);
+                        // If the country filter and country code exist, check that the country code
+                        // is in the filter.
+                        if ((countries == null || (countryCode.isPresent()
+                                && countries.contains(countryCode.get())))
+                                // If the checks filter exists, check that the challenge name is in
+                                // the checks filter.
+                                && (checks == null || checks.contains(check)))
                         {
-                            this.addTask(this.getChallenge(task.getChallengeName(), instructions),
-                                    task);
-                        }
-                        catch (URISyntaxException | UnsupportedEncodingException error)
-                        {
-                            logger.error("Error thrown while adding task: ", error);
+                            try
+                            {
+                                // try to add the task fot upload
+                                this.addTask(
+                                        this.getChallenge(task.getChallengeName(), instructions),
+                                        task);
+                            }
+                            catch (URISyntaxException | UnsupportedEncodingException error)
+                            {
+                                logger.error("Error thrown while adding task: ", error);
+                            }
                         }
                     });
                     this.uploadTasks();
@@ -200,10 +238,35 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         });
     }
 
+    /**
+     * Gathers the ISO3 country code from a {@link JsonElement}, if it has one.
+     *
+     * @param element
+     *            a {@link JsonElement}
+     * @return a {@link String} containing the ISO3 country code, or an empty string if no code was
+     *         found
+     */
+    private String getElementCountryCode(final JsonElement element)
+    {
+        final JsonObject elementJson = element.getAsJsonObject();
+        // If the element has properties
+        if (elementJson.has(PROPERTIES))
+        {
+            final JsonObject properties = elementJson.get(PROPERTIES).getAsJsonObject();
+            // And the properties have a country code
+            if (properties.has(ISOCountryTag.KEY))
+            {
+                // Get the country code
+                return properties.get(ISOCountryTag.KEY).getAsString();
+            }
+        }
+        return "";
+    }
+
     @Override
     public SwitchList switches()
     {
-        return super.switches().with(INPUT_DIRECTORY, CONFIG_LOCATION);
+        return super.switches().with(INPUT_DIRECTORY, CONFIG_LOCATION, COUNTRIES, CHECKS);
     }
 
     public static void main(final String[] args)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -92,8 +92,8 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                         // Get the first country code from the geojson
                         final Optional<String> countryCode = Iterables
                                 .stream(task.getGeoJson().orElse(new JsonArray()))
-                                .map(this::getElementCountryCode)
-                                .firstMatching(iso -> !iso.equals(""));
+                                .map(this::getElementCountryCode).firstMatching(Optional::isPresent)
+                                .get();
                         // Get the challenge name from the Task
                         final String check = task.getChallengeName();
                         // Get the countries filter
@@ -244,10 +244,9 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
      *
      * @param element
      *            a {@link JsonElement}
-     * @return a {@link String} containing the ISO3 country code, or an empty string if no code was
-     *         found
+     * @return an {@link Optional} {@link String} containing the ISO3 country code
      */
-    private String getElementCountryCode(final JsonElement element)
+    private Optional<String> getElementCountryCode(final JsonElement element)
     {
         final JsonObject elementJson = element.getAsJsonObject();
         // If the element has properties
@@ -258,10 +257,10 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             if (properties.has(ISOCountryTag.KEY))
             {
                 // Get the country code
-                return properties.get(ISOCountryTag.KEY).getAsString();
+                return Optional.of(properties.get(ISOCountryTag.KEY).getAsString());
             }
         }
-        return "";
+        return Optional.empty();
     }
 
     @Override

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -3,7 +3,8 @@ package org.openstreetmap.atlas.checks.maproulette;
 import java.util.Collections;
 import java.util.Set;
 
-import org.junit.After;
+import org.apache.commons.lang.ArrayUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -28,41 +29,63 @@ public class MapRouletteUploadCommandTest
     private static final String MAPROULETTE_CONFIG = "-maproulette=host:2222:project:api";
     private static final File FOLDER = File.temporaryFolder();
 
+    private boolean filesCreated = false;
+
     @Rule
     public final MapRouletteUploadCommandTestRule setup = new MapRouletteUploadCommandTestRule();
 
     @Before
     public void writeFiles()
     {
-        // Create an unzipped file
-        final FileProcessor<CheckFlagEvent> unzippedProcessor = new CheckFlagFileProcessor(
-                new SparkFileHelper(Collections.emptyMap()),
-                FOLDER.child("unzipped.log").toString()).withCompression(false);
-        unzippedProcessor.process(setup.getOneBasicFlag());
-        unzippedProcessor.process(new ShutdownEvent());
+        if (!this.filesCreated)
+        {
+            // Create an unzipped file
+            final FileProcessor<CheckFlagEvent> unzippedProcessor = new CheckFlagFileProcessor(
+                    new SparkFileHelper(Collections.emptyMap()),
+                    FOLDER.child("unzipped.log").toString()).withCompression(false);
+            unzippedProcessor.process(setup.getOneBasicFlag());
+            unzippedProcessor.process(new ShutdownEvent());
 
-        // Create a zipped file
-        final FileProcessor<CheckFlagEvent> zippedProcessor = new CheckFlagFileProcessor(
-                new SparkFileHelper(Collections.emptyMap()),
-                FOLDER.child("zipped.log.gz").toString()).withCompression(true);
-        zippedProcessor.process(setup.getAnotherBasicFlag());
-        zippedProcessor.process(new ShutdownEvent());
+            // Create a zipped file
+            final FileProcessor<CheckFlagEvent> zippedProcessor = new CheckFlagFileProcessor(
+                    new SparkFileHelper(Collections.emptyMap()),
+                    FOLDER.child("zipped.log.gz").toString()).withCompression(true);
+            zippedProcessor.process(setup.getAnotherBasicFlag());
+            zippedProcessor.process(new ShutdownEvent());
+
+            this.filesCreated = true;
+        }
     }
 
-    @After
-    public void cleanup()
+    @AfterClass
+    public static void cleanup()
     {
         new File(FOLDER.getPath()).deleteRecursively();
     }
 
-    @Test
-    public void testExecute()
+    /**
+     * Runs {@link MapRouletteUploadCommand} using a {@link TestMapRouletteConnection}. Tests that
+     * the correct number of projects, challenges, and tasks are created.
+     *
+     * @param additionalArguments
+     *            String[] of extra arguments for {@link MapRouletteUploadCommand}, to add to the
+     *            data i/o locations and server config
+     * @param expectedProjects
+     *            int, number of expected projects
+     * @param expectedChallenges
+     *            int, number of expected challenges per project
+     * @param expectedTasks
+     *            int, number of expected tasks per challenge per project
+     */
+    private void runAndTest(final String[] additionalArguments, final int expectedProjects,
+            final int expectedChallenges, final int expectedTasks)
     {
         // Set up some arguments
         final MapRouletteCommand command = new MapRouletteUploadCommand();
         final String[] arguments = { String.format("-logfiles=%s", FOLDER.getPath()),
                 MAPROULETTE_CONFIG };
-        final CommandMap map = command.getCommandMap(arguments);
+        final CommandMap map = command
+                .getCommandMap((String[]) ArrayUtils.addAll(arguments, additionalArguments));
         final TestMapRouletteConnection connection = new TestMapRouletteConnection();
 
         // Run the command
@@ -70,14 +93,35 @@ public class MapRouletteUploadCommandTest
 
         // Test the results
         final Set<Project> projects = connection.uploadedProjects();
-        Assert.assertEquals(1, projects.size());
+        Assert.assertEquals(expectedProjects, projects.size());
         projects.forEach(project ->
         {
             Assert.assertEquals("project", project.getName());
             final Set<Challenge> challenges = connection.challengesForProject(project);
-            Assert.assertEquals(1, challenges.size());
-            challenges.forEach(challenge -> Assert.assertEquals(2,
+            Assert.assertEquals(expectedChallenges, challenges.size());
+            challenges.forEach(challenge -> Assert.assertEquals(expectedTasks,
                     connection.tasksForChallenge(challenge).size()));
         });
+    }
+
+    @Test
+    public void testExecute()
+    {
+        final String[] additionalArguments = {};
+        this.runAndTest(additionalArguments, 1, 2, 2);
+    }
+
+    @Test
+    public void testCheckFilter()
+    {
+        final String[] additionalArguments = { "-checks=SomeCheck" };
+        this.runAndTest(additionalArguments, 1, 1, 1);
+    }
+
+    @Test
+    public void testCountryFilter()
+    {
+        final String[] additionalArguments = { "-countries=CAN" };
+        this.runAndTest(additionalArguments, 1, 1, 1);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -23,6 +23,7 @@ import org.openstreetmap.atlas.utilities.runtime.CommandMap;
  * Unit tests for MapRouletteUploadCommand.
  *
  * @author nachtm
+ * @author bbreithaupt
  */
 public class MapRouletteUploadCommandTest
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTestRule.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.checks.maproulette;
 import org.openstreetmap.atlas.checks.event.CheckFlagEvent;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
@@ -18,28 +19,33 @@ public class MapRouletteUploadCommandTestRule extends CoreTestRule
     private static final String CENTER = "0,0";
     private static final String IDENTIFIER_1 = "1";
     private static final String IDENTIFIER_2 = "2";
-    private static final String CHALLENGE = "SomeCheck";
+    private static final String CHALLENGE_1 = "SomeCheck";
+    private static final String CHALLENGE_2 = "SomeOtherCheck";
     private static final String INSTRUCTIONS = "Instructions.";
 
-    @TestAtlas(points = { @Point(coordinates = @Loc(value = CENTER), id = "1") })
+    @TestAtlas(points = {
+            @Point(coordinates = @Loc(value = CENTER), id = "1", tags = { "iso_country_code=USA" }),
+            @Point(coordinates = @Loc(value = CENTER), id = "2", tags = {
+                    "iso_country_code=CAN" }) })
     private Atlas basicAtlas;
 
-    private CheckFlagEvent getBasicFlag(final String identifier)
+    private CheckFlagEvent getBasicFlag(final String identifier, final AtlasObject object,
+            final String challenge)
     {
         final CheckFlag flag = new CheckFlag(identifier);
-        flag.addObject(this.basicAtlas.point(1L));
+        flag.addObject(object);
         flag.addInstruction(INSTRUCTIONS);
 
-        return new CheckFlagEvent(CHALLENGE, flag);
+        return new CheckFlagEvent(challenge, flag);
     }
 
     public CheckFlagEvent getOneBasicFlag()
     {
-        return this.getBasicFlag(IDENTIFIER_1);
+        return this.getBasicFlag(IDENTIFIER_1, this.basicAtlas.point(1L), CHALLENGE_1);
     }
 
     public CheckFlagEvent getAnotherBasicFlag()
     {
-        return this.getBasicFlag(IDENTIFIER_2);
+        return this.getBasicFlag(IDENTIFIER_2, this.basicAtlas.point(2L), CHALLENGE_2);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTestRule.java
@@ -13,6 +13,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
  * Data for unit tests for MapRouletteUploadCommand
  *
  * @author nachtm
+ * @author bbreithaupt
  */
 public class MapRouletteUploadCommandTestRule extends CoreTestRule
 {


### PR DESCRIPTION
### Description:

This adds two filter arguments to the MapRouletteUploadCommand. One is a list of ISO3 country codes, the other is a list of names of atlas checks. If either or both filters are provided, only flags that have values that are in the filters will be uploaded. 

### Potential Impact:

No impact, just optional arguments.

### Unit Test Approach:

A unit test for each filter was added. Test rules and log file generation were altered to accommodate this. 

### Test Results:

None