### PR TITLE
Map Roulette Configuration Full URL Parsing Bug

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -62,10 +62,10 @@ of desired formats, like so:
 The standalone application for Atlas Checks can be published directly to MapRoulette using your personal MapRoulette
 API Key. This can be easily done by including the following parameter during your gradle run.
 
-`gradle run -Pchecks.local.maproulette=maproulette.org:80:HOME_12345:APIKey`
+`gradle run -Pchecks.local.maproulette=http://maproulette.org:80:HOME_12345:APIKey`
 
 The MapRoulette configuration supplied is separated by colons and split into 4 different values which are:
-1. maproulette.org - The hostname for the MapRoulette server that you are connecting too
+1. http://maproulette.org - The hostname for the MapRoulette server that you are connecting too
 2. 80 - The port for the MapRoulette server that you are connecting too
 3. HOME_12345 - This would be the name of the project (any project) that you have access too and wish to store the check results in.
 4. APIKey - Your personal APIKey from MapRoulette to allow access to upload checks.

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -66,7 +66,7 @@ API Key. This can be easily done by including the following parameter during you
 
 The MapRoulette configuration supplied is separated by colons and split into 4 different values which are:
 1. http://maproulette.org - The hostname for the MapRoulette server that you are connecting too
-2. 80 - The port for the MapRoulette server that you are connecting too
+2. 80 - The port for the MapRoulette server that you are connecting to
 3. HOME_12345 - This would be the name of the project (any project) that you have access too and wish to store the check results in.
 4. APIKey - Your personal APIKey from MapRoulette to allow access to upload checks.
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -65,9 +65,9 @@ API Key. This can be easily done by including the following parameter during you
 `gradle run -Pchecks.local.maproulette=http://maproulette.org:80:HOME_12345:APIKey`
 
 The MapRoulette configuration supplied is separated by colons and split into 4 different values which are:
-1. http://maproulette.org - The hostname for the MapRoulette server that you are connecting too
+1. http://maproulette.org - The hostname for the MapRoulette server that you are connecting to
 2. 80 - The port for the MapRoulette server that you are connecting to
-3. HOME_12345 - This would be the name of the project (any project) that you have access too and wish to store the check results in.
+3. HOME_12345 - This would be the name of the project (any project) that you have access to and wish to store the check results in.
 4. APIKey - Your personal APIKey from MapRoulette to allow access to upload checks.
 
 #### Creating Compressed Output Files

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -127,7 +127,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
         }
         final ProjectConfiguration project = new ProjectConfiguration(mapRoulette.getProjectName(),
                 mapRoulette.getProjectName(), projectDisplayName, DEFAULT_ENABLED);
-        return new MapRouletteConfiguration(mapRoulette.getServer(), mapRoulette.getPort(), project,
-                mapRoulette.getApiKey());
+        return new MapRouletteConfiguration(mapRoulette.getScheme(), mapRoulette.getServer(),
+                mapRoulette.getPort(), project, mapRoulette.getApiKey());
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -127,7 +127,7 @@ public class MapRouletteConfiguration implements Serializable
     @Override
     public String toString()
     {
-        return String.format("%s:%d:%s:%s", this.server, this.port,
+        return String.format("%s://%s:%d:%s:%s", this.scheme, this.server, this.port,
                 this.projectConfiguration.getName(), this.apiKey);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -6,8 +6,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
 import org.openstreetmap.atlas.exception.CoreException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author cuthbertm
@@ -22,7 +20,6 @@ public class MapRouletteConfiguration implements Serializable
     private static final int PORT_INDEX = 1;
     private static final int PROJECT_NAME_INDEX = 2;
     private static final int SERVER_INDEX = 0;
-    private static final Logger logger = LoggerFactory.getLogger(MapRouletteConfiguration.class);
     private static final long serialVersionUID = -1060265212173405828L;
     private static final String DELIMITER = "(?<!https|http):";
     private static final String SCHEME_DELIMITER = "://";

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
  * @author cuthbertm
  * @author mgostintsev
  * @author nachtm
+ * @author bbreithaupt
  */
 public class MapRouletteConfiguration implements Serializable
 {
@@ -21,7 +22,7 @@ public class MapRouletteConfiguration implements Serializable
     private static final int SERVER_INDEX = 0;
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteConfiguration.class);
     private static final long serialVersionUID = -1060265212173405828L;
-    private static final String DELIMITER = ":";
+    private static final String DELIMITER = "(?<!https|http):";
     private final String apiKey;
     private final int port;
     private final String server;

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.checks.maproulette;
 import java.io.Serializable;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
 import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,14 +24,16 @@ public class MapRouletteConfiguration implements Serializable
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteConfiguration.class);
     private static final long serialVersionUID = -1060265212173405828L;
     private static final String DELIMITER = "(?<!https|http):";
+    private static final String SCHEME_DELIMITER = "://";
     private final String apiKey;
     private final int port;
+    private final String scheme;
     private final String server;
     private final ProjectConfiguration projectConfiguration;
 
     /**
-     * Parses a map roulette configuration object from a string that follows the structure
-     * [SERVER]:[PORT]:[PROJECT_NAME]:[API_KEY]
+     * Parses a map roulette configuration object from a string that follows one of these structures
+     * [SERVER]:[PORT]:[PROJECT_NAME]:[API_KEY] [SCHEME]://[SERVER]:[PORT]:[PROJECT_NAME]:[API_KEY]
      *
      * @param configuration
      *            The configuration string to parse
@@ -44,27 +47,47 @@ public class MapRouletteConfiguration implements Serializable
             final String[] components = configuration.split(DELIMITER);
             if (components.length == NUMBER_OF_COMPONENTS)
             {
-                return new MapRouletteConfiguration(components[SERVER_INDEX],
+                final String scheme;
+                final String server;
+                final String[] splitServer = components[SERVER_INDEX].split(SCHEME_DELIMITER);
+                if (splitServer.length < 2)
+                {
+                    scheme = HttpHost.DEFAULT_SCHEME_NAME;
+                    server = components[SERVER_INDEX];
+                }
+                else
+                {
+                    scheme = splitServer[0];
+                    server = splitServer[1];
+                }
+                return new MapRouletteConfiguration(scheme, server,
                         Integer.parseInt(components[PORT_INDEX]),
                         new ProjectConfiguration(components[PROJECT_NAME_INDEX]),
                         components[API_KEY_INDEX]);
             }
         }
-        logger.debug(
-                String.format("Map Roulette configuration not set, invalid string passed in. [%s]",
-                        configuration));
+        logger.debug("Map Roulette configuration not set, invalid string passed in. [{}]",
+                configuration);
         return null;
     }
 
     public MapRouletteConfiguration(final String server, final int port, final String projectName,
             final String apiKey)
     {
-        this(server, port, new ProjectConfiguration(projectName), apiKey);
+        this(HttpHost.DEFAULT_SCHEME_NAME, server, port, new ProjectConfiguration(projectName),
+                apiKey);
     }
 
     public MapRouletteConfiguration(final String server, final int port,
             final ProjectConfiguration projectConfiguration, final String apiKey)
     {
+        this(HttpHost.DEFAULT_SCHEME_NAME, server, port, projectConfiguration, apiKey);
+    }
+
+    public MapRouletteConfiguration(final String scheme, final String server, final int port,
+            final ProjectConfiguration projectConfiguration, final String apiKey)
+    {
+        this.scheme = scheme;
         this.server = server;
         this.port = port;
         this.projectConfiguration = projectConfiguration;
@@ -84,6 +107,11 @@ public class MapRouletteConfiguration implements Serializable
     public String getProjectName()
     {
         return this.projectConfiguration.getName();
+    }
+
+    public String getScheme()
+    {
+        return this.scheme;
     }
 
     public String getServer()

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfiguration.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,9 +67,9 @@ public class MapRouletteConfiguration implements Serializable
                         components[API_KEY_INDEX]);
             }
         }
-        logger.debug("Map Roulette configuration not set, invalid string passed in. [{}]",
+        throw new CoreException(
+                "Map Roulette configuration not set, invalid string passed in. [{}]",
                 configuration);
-        return null;
     }
 
     public MapRouletteConfiguration(final String server, final int port, final String projectName,

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -221,7 +221,9 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         return new Retry(DEFAULT_CONNECTION_RETRIES, Duration.seconds(DEFAULT_CONNECTION_WAIT))
                 .run(() ->
                 {
-                    final String serverConnection = "http://" + configuration.getServer() + ":"
+                    final String serverConnection = (configuration.getServer().startsWith("http")
+                            ? ""
+                            : "http://") + configuration.getServer() + ":"
                             + configuration.getPort();
                     final GetResource homepage = new GetResource(serverConnection);
                     final int statusCode = homepage.getStatusCode();

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
@@ -55,7 +54,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
                     "configuration can't be null and must be able to connect to MapRouletteServers to create a connection.");
         }
         this.configuration = configuration;
-        this.uriBuilder = new URIBuilder().setScheme(HttpHost.DEFAULT_SCHEME_NAME)
+        this.uriBuilder = new URIBuilder().setScheme(this.configuration.getScheme())
                 .setHost(this.configuration.getServer()).setPort(this.configuration.getPort());
     }
 
@@ -221,10 +220,8 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         return new Retry(DEFAULT_CONNECTION_RETRIES, Duration.seconds(DEFAULT_CONNECTION_WAIT))
                 .run(() ->
                 {
-                    final String serverConnection = (configuration.getServer().startsWith("http")
-                            ? ""
-                            : "http://") + configuration.getServer() + ":"
-                            + configuration.getPort();
+                    final String serverConnection = configuration.getScheme() + "://"
+                            + configuration.getServer() + ":" + configuration.getPort();
                     final GetResource homepage = new GetResource(serverConnection);
                     final int statusCode = homepage.getStatusCode();
                     if (statusCode != HttpStatus.SC_OK)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -220,8 +220,9 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         return new Retry(DEFAULT_CONNECTION_RETRIES, Duration.seconds(DEFAULT_CONNECTION_WAIT))
                 .run(() ->
                 {
-                    final String serverConnection = configuration.getScheme() + "://"
-                            + configuration.getServer() + ":" + configuration.getPort();
+                    final String serverConnection = String.format("%s://%s:%s",
+                            configuration.getScheme(), configuration.getServer(),
+                            configuration.getPort());
                     final GetResource homepage = new GetResource(serverConnection);
                     final int statusCode = homepage.getStatusCode();
                     if (statusCode != HttpStatus.SC_OK)

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfigurationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfigurationTest.java
@@ -7,14 +7,17 @@ import org.junit.Test;
  * Unit tests for MapRouletteConfiguration
  *
  * @author nachtm
+ * @author bbreithaupt
  */
 public class MapRouletteConfigurationTest
 {
     private static final String SERVER = "server";
+    private static final String SERVER2 = "https://server";
     private static final int PORT = 123;
     private static final String PROJECT_NAME = "project";
     private static final String API_KEY = "key";
     private static final String CONFIG = "server:123:project:key";
+    private static final String CONFIG2 = "https://server:123:project:key";
     private static final String BAD_CONFIG = "server:123:project";
 
     @Test
@@ -23,6 +26,18 @@ public class MapRouletteConfigurationTest
         final MapRouletteConfiguration configuration = MapRouletteConfiguration.parse(CONFIG);
         Assert.assertNotNull(configuration);
         Assert.assertEquals(SERVER, configuration.getServer());
+        Assert.assertEquals(PORT, configuration.getPort());
+        Assert.assertEquals(PROJECT_NAME, configuration.getProjectName());
+        Assert.assertEquals(API_KEY, configuration.getApiKey());
+        Assert.assertEquals(PROJECT_NAME, configuration.getProjectConfiguration().getName());
+    }
+
+    @Test
+    public void testFullURLParse()
+    {
+        final MapRouletteConfiguration configuration = MapRouletteConfiguration.parse(CONFIG2);
+        Assert.assertNotNull(configuration);
+        Assert.assertEquals(SERVER2, configuration.getServer());
         Assert.assertEquals(PORT, configuration.getPort());
         Assert.assertEquals(PROJECT_NAME, configuration.getProjectName());
         Assert.assertEquals(API_KEY, configuration.getApiKey());

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfigurationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfigurationTest.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.checks.maproulette;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openstreetmap.atlas.exception.CoreException;
 
 /**
  * Unit tests for MapRouletteConfiguration
@@ -50,7 +51,17 @@ public class MapRouletteConfigurationTest
     @Test
     public void testBadParse()
     {
-        final MapRouletteConfiguration configuration = MapRouletteConfiguration.parse(BAD_CONFIG);
-        Assert.assertNull(configuration);
+        try
+        {
+            final MapRouletteConfiguration configuration = MapRouletteConfiguration
+                    .parse(BAD_CONFIG);
+        }
+        catch (final Exception exception)
+        {
+            if (!(exception instanceof CoreException))
+            {
+                Assert.fail();
+            }
+        }
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfigurationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConfigurationTest.java
@@ -12,7 +12,8 @@ import org.junit.Test;
 public class MapRouletteConfigurationTest
 {
     private static final String SERVER = "server";
-    private static final String SERVER2 = "https://server";
+    private static final String SCHEME = "http";
+    private static final String SCHEME2 = "https";
     private static final int PORT = 123;
     private static final String PROJECT_NAME = "project";
     private static final String API_KEY = "key";
@@ -25,6 +26,7 @@ public class MapRouletteConfigurationTest
     {
         final MapRouletteConfiguration configuration = MapRouletteConfiguration.parse(CONFIG);
         Assert.assertNotNull(configuration);
+        Assert.assertEquals(SCHEME, configuration.getScheme());
         Assert.assertEquals(SERVER, configuration.getServer());
         Assert.assertEquals(PORT, configuration.getPort());
         Assert.assertEquals(PROJECT_NAME, configuration.getProjectName());
@@ -37,7 +39,8 @@ public class MapRouletteConfigurationTest
     {
         final MapRouletteConfiguration configuration = MapRouletteConfiguration.parse(CONFIG2);
         Assert.assertNotNull(configuration);
-        Assert.assertEquals(SERVER2, configuration.getServer());
+        Assert.assertEquals(SCHEME2, configuration.getScheme());
+        Assert.assertEquals(SERVER, configuration.getServer());
         Assert.assertEquals(PORT, configuration.getPort());
         Assert.assertEquals(PROJECT_NAME, configuration.getProjectName());
         Assert.assertEquals(API_KEY, configuration.getApiKey());


### PR DESCRIPTION
### Description:

This fixes a bug with the MapRouletteConfiguration and MapRouletteConnection. Previously these assumed that all URIs used, but did not include, the `http` scheme (e.g. maproulette.server.mine:42 vs http://maproulette.server.mine:42). This updates MapRouletteConfiguration and its `parse` method to look for and store schemes, or continue to use `http` as a default. MapRouletteConnection has been updated to look for the set scheme and use that in building a URI.
Additionally, MapRouletteConfiguration now throws a CoreException when it fails to parse a configuration string, instead of logging a debug message and trowing a NPE. This is preferable, as debug messages are not written to stdout by default, and this is important information for the user. 

### Potential Impact:

This is generally non-breaking, due to the addition of a backwards compatible constructor and the optional use of the scheme field from MapRouletteConfiguration. However,  it could break at runtime if a server URI using something other than http is entered (e.g. https), and is passed to something other than MapRouletteConnection.

### Unit Test Approach:

Added a unit test that includes a https server URL.
Update a unit test to reflect the change from a null return type to a CoreException. 

### Test Results:

Tested uploading a challenge and changing a project name on https://maproulette.org. This was completely successful when using port 443. 

