### PR TITLE
update atlas to 5.6.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,9 +1,9 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '5.5.6',
+    atlas: '5.6.1',
     commons:'2.6',
-    atlas_generator: '4.2.7',
+    atlas_generator: '4.3.0',
 ]
 
 project.ext.packages = [

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SignPostCheck.java
@@ -3,10 +3,10 @@ package org.openstreetmap.atlas.checks.validation.linear.edges;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.directory.api.util.Strings;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
@@ -282,6 +282,6 @@ public class SignPostCheck extends BaseCheck<String>
         // Look for certain tag differences if edges have same highway tag
         final String sourceTag = sourceEdge.tag(this.rampDifferentiatorTag);
         final String rampTag = connectedEdge.tag(this.rampDifferentiatorTag);
-        return !(sourceTag == null && rampTag == null || Strings.equals(sourceTag, rampTag));
+        return !(Objects.equals(sourceTag, rampTag));
     }
 }


### PR DESCRIPTION
### Description:

- update atlas to 5.6.1 and atlas-generator to 4.3.0.
- fix an error after the upgrade, caused by a removal of a transient dependency.

### Potential Impact:

none as long as there is no breaking change in the new atlas lib.

### Unit Test Approach:

run all existing unit tests

### Test Results:

pass
