### PR TITLE
Decency resolve for new Spark

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,13 +51,11 @@ configurations
             // Snappy 1.1.1.6 is the one that has the proper .so libs.
             // https://github.com/xerial/snappy-java/issues/6
             force 'org.xerial.snappy:snappy-java:1.1.1.6'
-            force 'org.scala-lang:scala-library:2.10.2'
 
-            // http://stackoverflow.com/questions/31039367/spark-parallelize-could-not-find-creator-property-with-name-id
-            // This is to avoid a JsonMappingException for something named 'id' in org.apache.spark.rdd.RDDOperationScope
-            force 'com.fasterxml.jackson.core:jackson-core:2.4.4'
-            force 'com.fasterxml.jackson.core:jackson-databind:2.4.4'
-            force 'org.slf4j:slf4j-api:1.7.12'
+            // Force the version compatible with the latest version
+            // of Spark brought in by atlas generator 
+            force 'com.fasterxml.jackson.core:jackson-core:2.9.8'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
         }
     }
     shaded


### PR DESCRIPTION
### Description:

Resolve dependency issues introduced by the update of the spark version in atlas-generator.

### Potential Impact:

Should enable running of the integrity checks spark job again. Issue introduced https://github.com/osmlab/atlas-checks/issues/164

### Unit Test Approach:

No unit tests because it is a runtime dependency issue. 
-ran the job before and after to confirm that it was broken as observed and fixed as intended.

### Test Results:

Builds and runs normally. 
