### PR TITLE
 Checkstyle RequireThis changed and update was missed

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,153 +1,153 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+"-//Puppy Crawl//DTD Check Configuration 1.1//EN"
+"http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
-	<module name="NewlineAtEndOfFile" />
-	<module name="TreeWalker">
-		<!-- Checks for Javadoc comments. -->
-		<module name="JavadocMethod">
-			<property name="scope" value="protected" />
-			<property name="excludeScope" value="private" />
-			<property name="allowMissingJavadoc" value="true" />
-			<property name="allowUndeclaredRTE" value="true" />
-		</module>
-		<module name="JavadocType">
-			<property name="authorFormat" value="\S" />
-		</module>
-		<module name="JavadocStyle">
-			<property name="checkFirstSentence" value="false" />
-		</module>
+    <module name="NewlineAtEndOfFile" />
+    <module name="TreeWalker">
+        <!-- Checks for Javadoc comments. -->
+        <module name="JavadocMethod">
+            <property name="scope" value="protected" />
+            <property name="excludeScope" value="private" />
+            <property name="allowMissingJavadoc" value="true" />
+            <property name="allowUndeclaredRTE" value="true" />
+        </module>
+        <module name="JavadocType">
+            <property name="authorFormat" value="\S" />
+        </module>
+        <module name="JavadocStyle">
+            <property name="checkFirstSentence" value="false" />
+        </module>
 
-		<!-- Checks for Naming Conventions. -->
-		<module name="LocalFinalVariableName" >
-			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-			<property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
-		</module>
-		<module name="LocalVariableName" >
-			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-			<property name="allowOneCharVarInForLoop" value="true"/>
-		</module>
-		<module name="MemberName" >
-			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-		</module>
-		<module name="MethodName" >
-			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-		</module>
-		<module name="PackageName" />
-		<module name="ParameterName" >
-			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-		</module>
-		<module name="TypeName" />
+        <!-- Checks for Naming Conventions. -->
+        <module name="LocalFinalVariableName" >
+            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+        </module>
+        <module name="LocalVariableName" >
+            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+        </module>
+        <module name="MemberName" >
+            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+        </module>
+        <module name="MethodName" >
+            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+        </module>
+        <module name="PackageName" />
+        <module name="ParameterName" >
+            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+        </module>
+        <module name="TypeName" />
 
-		<!-- Checks for imports -->
-		<module name="AvoidStarImport" />
-		<module name="CustomImportOrder" />
-		<module name="IllegalImport" />
-		<module name="ImportOrder">
-			<property name="groups" value="java,javax,org,com,*"/>
-			<property name="ordered" value="true"/>
-			<property name="separated" value="true"/>
-			<property name="option" value="top"/>
-		</module>
-		<module name="RedundantImport" />
-		<module name="UnusedImports">
-			<property name="processJavadoc" value="true" />
-		</module>
+        <!-- Checks for imports -->
+        <module name="AvoidStarImport" />
+        <module name="CustomImportOrder" />
+        <module name="IllegalImport" />
+        <module name="ImportOrder">
+            <property name="groups" value="java,javax,org,com,*"/>
+            <property name="ordered" value="true"/>
+            <property name="separated" value="true"/>
+            <property name="option" value="top"/>
+        </module>
+        <module name="RedundantImport" />
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true" />
+        </module>
 
-		<!-- Checks for metrics -->
+        <!-- Checks for metrics -->
 
-		<!-- Checks for Size Violations. -->
+        <!-- Checks for Size Violations. -->
 
-		<!-- Checks for whitespace -->
+        <!-- Checks for whitespace -->
 
-		<!-- Modifier Checks -->
-		<module name="ModifierOrder" />
-		<module name="RedundantModifier" />
+        <!-- Modifier Checks -->
+        <module name="ModifierOrder" />
+        <module name="RedundantModifier" />
 
 
-		<!-- Checks for blocks -->
-		<module name="AvoidNestedBlocks" >
+        <!-- Checks for blocks -->
+        <module name="AvoidNestedBlocks" >
             <property name="allowInSwitchCase" value="true" />
-		</module>
-		<module name="LeftCurly">
-			<property name="option" value="nl" />
-		</module>
-		<module name="EmptyCatchBlock" />
-		<module name="NeedBraces" />
-		<module name="RightCurly">
-			<property name="option" value="alone" />
-		</module>
+        </module>
+        <module name="LeftCurly">
+            <property name="option" value="nl" />
+        </module>
+        <module name="EmptyCatchBlock" />
+        <module name="NeedBraces" />
+        <module name="RightCurly">
+            <property name="option" value="alone" />
+        </module>
 
 
-		<!-- Checks for common coding problems -->
-		<module name="CovariantEquals"/>
-		<module name="DefaultComesLast"/>
-		<module name="EmptyStatement" />
-		<module name="EqualsAvoidNull"/>
-		<module name="EqualsHashCode" />
-		<module name="FallThrough"/>
-		<module name="FinalLocalVariable" >
-			<property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
-			<property name="validateEnhancedForLoopVariable" value="true"/>
-		</module>
-		<module name="IllegalInstantiation" />
-		<module name="IllegalThrows"/>
-		<module name="InnerAssignment"/>
+        <!-- Checks for common coding problems -->
+        <module name="CovariantEquals"/>
+        <module name="DefaultComesLast"/>
+        <module name="EmptyStatement" />
+        <module name="EqualsAvoidNull"/>
+        <module name="EqualsHashCode" />
+        <module name="FallThrough"/>
+        <module name="FinalLocalVariable" >
+            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+            <property name="validateEnhancedForLoopVariable" value="true"/>
+        </module>
+        <module name="IllegalInstantiation" />
+        <module name="IllegalThrows"/>
+        <module name="InnerAssignment"/>
         <module name="MagicNumber" >
-			<property name="ignoreAnnotation" value="true"/>
-		</module>
-		<module name="MissingSwitchDefault" />
-		<module name="ModifiedControlVariable"/>
-		<module name="MultipleStringLiterals" >
+            <property name="ignoreAnnotation" value="true"/>
+        </module>
+        <module name="MissingSwitchDefault" />
+        <module name="ModifiedControlVariable"/>
+        <module name="MultipleStringLiterals" >
             <property name="allowedDuplicates" value="10"/>
         </module>
-		<module name="MultipleVariableDeclarations"/>
-		<module name="NoClone"/>
-		<module name="NoFinalizer"/>
-		<module name="OneStatementPerLine" />
-		<module name="PackageDeclaration"/>
-		<module name="ParameterAssignment"/>
-		<module name="RequireThis">
-    		<property name="checkMethods" value="false"/>
-			<property name="validateOnlyOverlapping" value="false"/>
-		</module>
-		<module name="SimplifyBooleanExpression" />
-		<module name="SimplifyBooleanReturn" />
-		<module name="StringLiteralEquality"/>
-		<module name="UnnecessaryParentheses" />
+        <module name="MultipleVariableDeclarations"/>
+        <module name="NoClone"/>
+        <module name="NoFinalizer"/>
+        <module name="OneStatementPerLine" />
+        <module name="PackageDeclaration"/>
+        <module name="ParameterAssignment"/>
+        <module name="RequireThis">
+            <property name="checkMethods" value="false"/>
+            <property name="validateOnlyOverlapping" value="false"/>
+        </module>
+        <module name="SimplifyBooleanExpression" />
+        <module name="SimplifyBooleanReturn" />
+        <module name="StringLiteralEquality"/>
+        <module name="UnnecessaryParentheses" />
 
-		<!-- Checks for class design -->
-		<module name="FinalClass" />
-		<module name="HideUtilityClassConstructor" />
-		<module name="MutableException"/>
-		<module name="OneTopLevelClass"/>
-		<module name="ThrowsCount"/>
-		<module name="VisibilityModifier" />
+        <!-- Checks for class design -->
+        <module name="FinalClass" />
+        <module name="HideUtilityClassConstructor" />
+        <module name="MutableException"/>
+        <module name="OneTopLevelClass"/>
+        <module name="ThrowsCount"/>
+        <module name="VisibilityModifier" />
 
 
-		<!-- Miscellaneous other checks. -->
-		<module name="ArrayTypeStyle" />
-		<module name="AvoidEscapedUnicodeCharacters">
-			<property name="allowEscapesForControlCharacters" value="true"/>
-		</module>
-		<module name="CommentsIndentation"/>
-		<module name="FinalParameters" />
-		<!-- Skipping indentation until https://github.com/checkstyle/checkstyle/issues/3342 is resolved
-		<module name="Indentation" >
-			<property name="lineWrappingIndentation" value="8"/>
-			<property name="forceStrictCondition" value="false"/>
-		</module> -->
-		<module name="OuterTypeFilename"/>
-		<module name="TrailingComment">
-			<property name="legalComment" value="NOSONAR"/>
- 		</module>
-		<module name="TodoComment" />
-		<module name="UpperEll" />
-	</module>
+        <!-- Miscellaneous other checks. -->
+        <module name="ArrayTypeStyle" />
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+        </module>
+        <module name="CommentsIndentation"/>
+        <module name="FinalParameters" />
+        <!-- Skipping indentation until https://github.com/checkstyle/checkstyle/issues/3342 is resolved
+        <module name="Indentation" >
+        <property name="lineWrappingIndentation" value="8"/>
+        <property name="forceStrictCondition" value="false"/>
+    </module> -->
+    <module name="OuterTypeFilename"/>
+    <module name="TrailingComment">
+        <property name="legalComment" value="NOSONAR"/>
+    </module>
+    <module name="TodoComment" />
+    <module name="UpperEll" />
+</module>
 
-	<module name="SuppressionFilter">
-		<property name="file" value="${config_loc}/suppressions.xml" />
-	</module>
+<module name="SuppressionFilter">
+    <property name="file" value="${config_loc}/suppressions.xml" />
+</module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,153 +1,153 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
+    "-//Puppy Crawl//DTD Check Configuration 1.1//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_1.dtd">
 
 <module name="Checker">
-    <module name="NewlineAtEndOfFile" />
-    <module name="SuppressWarningsFilter" />
-    <module name="TreeWalker">
-        <module name="SuppressWarningsHolder" />
+	<module name="NewlineAtEndOfFile" />
+	<module name="TreeWalker">
+		<!-- Checks for Javadoc comments. -->
+		<module name="JavadocMethod">
+			<property name="scope" value="protected" />
+			<property name="excludeScope" value="private" />
+			<property name="allowMissingJavadoc" value="true" />
+			<property name="allowUndeclaredRTE" value="true" />
+		</module>
+		<module name="JavadocType">
+			<property name="authorFormat" value="\S" />
+		</module>
+		<module name="JavadocStyle">
+			<property name="checkFirstSentence" value="false" />
+		</module>
 
-        <!-- Checks for Javadoc comments. -->
-        <module name="JavadocMethod">
-            <property name="scope" value="protected" />
-            <property name="excludeScope" value="private" />
-            <property name="allowMissingJavadoc" value="true" />
-            <property name="allowUndeclaredRTE" value="true" />
-        </module>
-        <module name="JavadocType">
-            <property name="authorFormat" value="\S" />
-        </module>
-        <module name="JavadocStyle">
-            <property name="checkFirstSentence" value="false" />
-        </module>
+		<!-- Checks for Naming Conventions. -->
+		<module name="LocalFinalVariableName" >
+			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+			<property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+		</module>
+		<module name="LocalVariableName" >
+			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+			<property name="allowOneCharVarInForLoop" value="true"/>
+		</module>
+		<module name="MemberName" >
+			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+		</module>
+		<module name="MethodName" >
+			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+		</module>
+		<module name="PackageName" />
+		<module name="ParameterName" >
+			<property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
+		</module>
+		<module name="TypeName" />
 
-        <!-- Checks for Naming Conventions. -->
-        <module name="LocalFinalVariableName" >
-            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
-        </module>
-        <module name="LocalVariableName" >
-            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-            <property name="allowOneCharVarInForLoop" value="true"/>
-        </module>
-        <module name="MemberName" >
-            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-        </module>
-        <module name="MethodName" >
-            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-        </module>
-        <module name="PackageName" />
-        <module name="ParameterName" >
-            <property name="format" value="^([a-z][a-zA-Z0-9]{2,}$|[e])$"/>
-        </module>
-        <module name="TypeName" />
+		<!-- Checks for imports -->
+		<module name="AvoidStarImport" />
+		<module name="CustomImportOrder" />
+		<module name="IllegalImport" />
+		<module name="ImportOrder">
+			<property name="groups" value="java,javax,org,com,*"/>
+			<property name="ordered" value="true"/>
+			<property name="separated" value="true"/>
+			<property name="option" value="top"/>
+		</module>
+		<module name="RedundantImport" />
+		<module name="UnusedImports">
+			<property name="processJavadoc" value="true" />
+		</module>
 
-        <!-- Checks for imports -->
-        <module name="AvoidStarImport" />
-        <module name="CustomImportOrder" />
-        <module name="IllegalImport" />
-        <module name="ImportOrder">
-            <property name="groups" value="java,javax,org,com,*"/>
-            <property name="ordered" value="true"/>
-            <property name="separated" value="true"/>
-            <property name="option" value="top"/>
-        </module>
-        <module name="RedundantImport" />
-        <module name="UnusedImports">
-            <property name="processJavadoc" value="true" />
-        </module>
+		<!-- Checks for metrics -->
 
-        <!-- Checks for metrics -->
+		<!-- Checks for Size Violations. -->
 
-        <!-- Checks for Size Violations. -->
+		<!-- Checks for whitespace -->
 
-        <!-- Checks for whitespace -->
-
-        <!-- Modifier Checks -->
-        <module name="ModifierOrder" />
-        <module name="RedundantModifier" />
+		<!-- Modifier Checks -->
+		<module name="ModifierOrder" />
+		<module name="RedundantModifier" />
 
 
-        <!-- Checks for blocks -->
-        <module name="AvoidNestedBlocks" >
+		<!-- Checks for blocks -->
+		<module name="AvoidNestedBlocks" >
             <property name="allowInSwitchCase" value="true" />
-        </module>
-        <module name="LeftCurly">
-            <property name="option" value="nl" />
-        </module>
-        <module name="EmptyCatchBlock" />
-        <module name="NeedBraces" />
-        <module name="RightCurly">
-            <property name="option" value="alone" />
-        </module>
+		</module>
+		<module name="LeftCurly">
+			<property name="option" value="nl" />
+		</module>
+		<module name="EmptyCatchBlock" />
+		<module name="NeedBraces" />
+		<module name="RightCurly">
+			<property name="option" value="alone" />
+		</module>
 
 
-        <!-- Checks for common coding problems -->
-        <module name="CovariantEquals"/>
-        <module name="DefaultComesLast"/>
-        <module name="EmptyStatement" />
-        <module name="EqualsAvoidNull"/>
-        <module name="EqualsHashCode" />
-        <module name="FallThrough"/>
-        <module name="FinalLocalVariable" >
-            <property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
-            <property name="validateEnhancedForLoopVariable" value="true"/>
-        </module>
-        <module name="IllegalInstantiation" />
-        <module name="IllegalThrows"/>
-        <module name="InnerAssignment"/>
+		<!-- Checks for common coding problems -->
+		<module name="CovariantEquals"/>
+		<module name="DefaultComesLast"/>
+		<module name="EmptyStatement" />
+		<module name="EqualsAvoidNull"/>
+		<module name="EqualsHashCode" />
+		<module name="FallThrough"/>
+		<module name="FinalLocalVariable" >
+			<property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/>
+			<property name="validateEnhancedForLoopVariable" value="true"/>
+		</module>
+		<module name="IllegalInstantiation" />
+		<module name="IllegalThrows"/>
+		<module name="InnerAssignment"/>
         <module name="MagicNumber" >
-            <property name="ignoreAnnotation" value="true"/>
-        </module>
-        <module name="MissingSwitchDefault" />
-        <module name="ModifiedControlVariable"/>
-        <module name="MultipleStringLiterals" >
+			<property name="ignoreAnnotation" value="true"/>
+		</module>
+		<module name="MissingSwitchDefault" />
+		<module name="ModifiedControlVariable"/>
+		<module name="MultipleStringLiterals" >
             <property name="allowedDuplicates" value="10"/>
         </module>
-        <module name="MultipleVariableDeclarations"/>
-        <module name="NoClone"/>
-        <module name="NoFinalizer"/>
-        <module name="OneStatementPerLine" />
-        <module name="PackageDeclaration"/>
-        <module name="ParameterAssignment"/>
-        <module name="RequireThis">
-            <property name="checkMethods" value="false"/>
-        </module>
-        <module name="SimplifyBooleanExpression" />
-        <module name="SimplifyBooleanReturn" />
-        <module name="StringLiteralEquality"/>
-        <module name="UnnecessaryParentheses" />
+		<module name="MultipleVariableDeclarations"/>
+		<module name="NoClone"/>
+		<module name="NoFinalizer"/>
+		<module name="OneStatementPerLine" />
+		<module name="PackageDeclaration"/>
+		<module name="ParameterAssignment"/>
+		<module name="RequireThis">
+    		<property name="checkMethods" value="false"/>
+			<property name="validateOnlyOverlapping" value="false"/>
+		</module>
+		<module name="SimplifyBooleanExpression" />
+		<module name="SimplifyBooleanReturn" />
+		<module name="StringLiteralEquality"/>
+		<module name="UnnecessaryParentheses" />
 
-        <!-- Checks for class design -->
-        <module name="FinalClass" />
-        <module name="HideUtilityClassConstructor" />
-        <module name="MutableException"/>
-        <module name="OneTopLevelClass"/>
-        <module name="ThrowsCount"/>
-        <module name="VisibilityModifier" />
+		<!-- Checks for class design -->
+		<module name="FinalClass" />
+		<module name="HideUtilityClassConstructor" />
+		<module name="MutableException"/>
+		<module name="OneTopLevelClass"/>
+		<module name="ThrowsCount"/>
+		<module name="VisibilityModifier" />
 
 
-        <!-- Miscellaneous other checks. -->
-        <module name="ArrayTypeStyle" />
-        <module name="AvoidEscapedUnicodeCharacters">
-            <property name="allowEscapesForControlCharacters" value="true"/>
-        </module>
-        <module name="CommentsIndentation"/>
-        <module name="FinalParameters" />
-        <!-- Skipping indentation until https://github.com/checkstyle/checkstyle/issues/3342 is resolved
-        <module name="Indentation" >
-            <property name="lineWrappingIndentation" value="8"/>
-            <property name="forceStrictCondition" value="false"/>
-        </module> -->
-        <module name="OuterTypeFilename"/>
-        <module name="TrailingComment"/>
-        <module name="TodoComment" />
-        <module name="UpperEll" />
-    </module>
+		<!-- Miscellaneous other checks. -->
+		<module name="ArrayTypeStyle" />
+		<module name="AvoidEscapedUnicodeCharacters">
+			<property name="allowEscapesForControlCharacters" value="true"/>
+		</module>
+		<module name="CommentsIndentation"/>
+		<module name="FinalParameters" />
+		<!-- Skipping indentation until https://github.com/checkstyle/checkstyle/issues/3342 is resolved
+		<module name="Indentation" >
+			<property name="lineWrappingIndentation" value="8"/>
+			<property name="forceStrictCondition" value="false"/>
+		</module> -->
+		<module name="OuterTypeFilename"/>
+		<module name="TrailingComment">
+			<property name="legalComment" value="NOSONAR"/>
+ 		</module>
+		<module name="TodoComment" />
+		<module name="UpperEll" />
+	</module>
 
-    <module name="SuppressionFilter">
-        <property name="file" value="${config_loc}/suppressions.xml" />
-    </module>
+	<module name="SuppressionFilter">
+		<property name="file" value="${config_loc}/suppressions.xml" />
+	</module>
 </module>

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -161,11 +161,11 @@ public class CheckResourceLoader
         {
             final ClassPath classPath = ClassPath
                     .from(Thread.currentThread().getContextClassLoader());
-            packages.forEach(packageName -> classPath.getTopLevelClassesRecursive(packageName)
+            this.packages.forEach(packageName -> classPath.getTopLevelClassesRecursive(packageName)
                     .forEach(classInfo ->
                     {
                         final Class<?> checkClass = classInfo.load();
-                        if (checkType.isAssignableFrom(checkClass)
+                        if (this.checkType.isAssignableFrom(checkClass)
                                 && !Modifier.isAbstract(checkClass.getModifiers())
                                 && isEnabled.test(checkClass)
                                 && this.checkWhiteList.map(
@@ -210,10 +210,10 @@ public class CheckResourceLoader
         catch (final IOException oops)
         {
             throw new CoreException("Failed to discover {} classes on classpath",
-                    checkType.getSimpleName());
+                    this.checkType.getSimpleName());
         }
 
-        logger.info("Loaded {} {} in {}", checks.size(), checkType.getSimpleName(),
+        logger.info("Loaded {} {} in {}", checks.size(), this.checkType.getSimpleName(),
                 time.elapsedSince());
         return checks;
     }
@@ -246,7 +246,7 @@ public class CheckResourceLoader
     private boolean isEnabledByConfiguration(final Configuration configuration,
             final Class checkClass)
     {
-        final String key = String.format(enabledKeyTemplate, checkClass.getSimpleName());
-        return configuration.get(key, enabledByDefault).value();
+        final String key = String.format(this.enabledKeyTemplate, checkClass.getSimpleName());
+        return configuration.get(key, this.enabledByDefault).value();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/AtlasFilePathResolver.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/AtlasFilePathResolver.java
@@ -68,8 +68,8 @@ public final class AtlasFilePathResolver implements Serializable
     public String resolvePath(final String basePath, final String country)
     {
         final URI uri = URI.create(basePath);
-        final String template = Optional.ofNullable(uri.getScheme()).map(pathTemplate::get)
-                .orElse(pathTemplate.getOrDefault("default", DEFAULT_PATH_TEMPLATE));
+        final String template = Optional.ofNullable(uri.getScheme()).map(this.pathTemplate::get)
+                .orElse(this.pathTemplate.getOrDefault("default", DEFAULT_PATH_TEMPLATE));
 
         return String.format(template, basePath, country);
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/GeoJsonPathFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/GeoJsonPathFilter.java
@@ -46,6 +46,6 @@ public class GeoJsonPathFilter implements PathFilter
      */
     public String getExtension()
     {
-        return extension;
+        return this.extension;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/LogFilePathFilter.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/LogFilePathFilter.java
@@ -16,7 +16,7 @@ public class LogFilePathFilter implements PathFilter
     private static final String COMPRESSED_FILE_EXTENSION = UNCOMPRESSED_FILE_EXTENSION
             + FileSuffix.GZIP.toString();
 
-    private String extension;
+    private final String extension;
 
     /**
      * Default constructor
@@ -48,6 +48,6 @@ public class LogFilePathFilter implements PathFilter
      */
     public String getExtension()
     {
-        return extension;
+        return this.extension;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/event/FileProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/FileProcessor.java
@@ -59,6 +59,11 @@ public abstract class FileProcessor<T extends Event> implements Processor<T>
         this.counter = new AtomicInteger(0);
     }
 
+    public boolean doesCompressOutput()
+    {
+        return this.compressOutput;
+    }
+
     /**
      * @return the maximum number of events to be batched in a file
      */
@@ -73,11 +78,6 @@ public abstract class FileProcessor<T extends Event> implements Processor<T>
     public final int getCount()
     {
         return this.counter.get();
-    }
-
-    public boolean doesCompressOutput()
-    {
-        return compressOutput;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -43,7 +43,7 @@ public class Challenge implements Serializable
             .create();
 
     @SuppressWarnings("checkstyle:memberName")
-    private long id = -1;
+    private long identifier = -1;
     private long parent = -1;
     private final String blurb;
     private final String description;
@@ -91,39 +91,14 @@ public class Challenge implements Serializable
         this.checkinComment = "#maproulette";
     }
 
-    public String getCheckinComment()
-    {
-        return this.checkinComment;
-    }
-
-    public void setCheckinComment(final String checkinComment)
-    {
-        this.checkinComment = checkinComment;
-    }
-
-    public long getId()
-    {
-        return this.id;
-    }
-
-    public void setId(final long identifier)
-    {
-        this.id = identifier;
-    }
-
-    public long getParentIdentifier()
-    {
-        return this.parent;
-    }
-
-    public void setParentIdentifier(final long identifier)
-    {
-        this.parent = identifier;
-    }
-
     public String getBlurb()
     {
         return this.blurb;
+    }
+
+    public String getCheckinComment()
+    {
+        return this.checkinComment;
     }
 
     public ChallengePriority getDefaultPriority()
@@ -146,6 +121,11 @@ public class Challenge implements Serializable
         return this.highPriorityRule;
     }
 
+    public long getId()
+    {
+        return this.identifier;
+    }
+
     public String getInstruction()
     {
         return this.instruction;
@@ -166,14 +146,34 @@ public class Challenge implements Serializable
         return this.name;
     }
 
+    public long getParentIdentifier()
+    {
+        return this.parent;
+    }
+
+    public String getTags()
+    {
+        return this.tags;
+    }
+
+    public void setCheckinComment(final String checkinComment)
+    {
+        this.checkinComment = checkinComment;
+    }
+
+    public void setId(final long identifier)
+    {
+        this.identifier = identifier;
+    }
+
     public void setName(final String name)
     {
         this.name = name;
     }
 
-    public String getTags()
+    public void setParentIdentifier(final long identifier)
     {
-        return tags;
+        this.parent = identifier;
     }
 
     public JsonObject toJson(final String challengeName)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Project.java
@@ -12,7 +12,7 @@ import com.google.gson.JsonObject;
 public class Project
 {
     @SuppressWarnings("checkstyle:memberName")
-    private long id = -1;
+    private long identifier = -1;
     private final String name;
     private final String description;
     private final String displayName;
@@ -43,34 +43,34 @@ public class Project
         this.enabled = enabled;
     }
 
-    public long getId()
-    {
-        return id;
-    }
-
-    public void setId(final long identifier)
-    {
-        this.id = identifier;
-    }
-
-    public String getName()
-    {
-        return name;
-    }
-
     public String getDescription()
     {
-        return description;
+        return this.description;
     }
 
     public String getDisplayName()
     {
-        return displayName;
+        return this.displayName;
+    }
+
+    public long getId()
+    {
+        return this.identifier;
+    }
+
+    public String getName()
+    {
+        return this.name;
     }
 
     public boolean isEnabled()
     {
-        return enabled;
+        return this.enabled;
+    }
+
+    public void setId(final long identifier)
+    {
+        this.identifier = identifier;
     }
 
     public JsonObject toJson()

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Task.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Task.java
@@ -35,14 +35,14 @@ public class Task
             this.description = description;
         }
 
-        public Location getLocation()
-        {
-            return location;
-        }
-
         public Optional<String> getDescription()
         {
-            return description;
+            return this.description;
+        }
+
+        public Location getLocation()
+        {
+            return this.location;
         }
     }
 
@@ -68,6 +68,11 @@ public class Task
     public Task()
     {
 
+    }
+
+    public void addPoint(final Location point, final String description)
+    {
+        this.points.add(new PointInformation(point, Optional.ofNullable(description)));
     }
 
     /**
@@ -123,7 +128,7 @@ public class Task
 
     public String getProjectName()
     {
-        return projectName;
+        return this.projectName;
     }
 
     public String getTaskIdentifier()
@@ -155,11 +160,6 @@ public class Task
     public void setPoint(final Location point)
     {
         this.points.add(new PointInformation(point, Optional.empty()));
-    }
-
-    public void addPoint(final Location point, final String description)
-    {
-        this.points.add(new PointInformation(point, Optional.ofNullable(description)));
     }
 
     public void setPoints(final Set<Location> points)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -55,136 +55,7 @@ public class MalformedRoundaboutCheck extends BaseCheck
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(WRONG_WAY_INSTRUCTIONS,
             INCOMPLETE_ROUTE_INSTRUCTIONS, ENCLOSED_ROADS_INSTRUCTIONS, BASIC_INSTRUCTION);
 
-    private List<String> leftDrivingCountries;
-
-    /**
-     * An enum of RoundaboutDirections
-     */
-    public enum RoundaboutDirection
-    {
-        CLOCKWISE,
-        COUNTERCLOCKWISE,
-        // Handles the case where we were unable to get any information about the roundabout's
-        // Direction.
-        UNKNOWN
-    }
-
-    @Override
-    protected List<String> getFallbackInstructions()
-    {
-        return FALLBACK_INSTRUCTIONS;
-    }
-
-    public MalformedRoundaboutCheck(final Configuration configuration)
-    {
-        super(configuration);
-        this.leftDrivingCountries = (List<String>) configurationValue(configuration,
-                "traffic.countries.left", LEFT_DRIVING_COUNTRIES_DEFAULT);
-    }
-
-    @Override
-    public boolean validCheckForObject(final AtlasObject object)
-    {
-        // We check that the object is an instance of Edge
-        return object instanceof Edge
-                // Make sure that the object has an iso_country_code
-                && object.getTag(ISOCountryTag.KEY).isPresent()
-                // Make sure that the edges are instances of roundabout
-                && JunctionTag.isRoundabout(object)
-                // And that the Edge has not already been marked as flagged
-                && !this.isFlagged(object.getIdentifier())
-                // Make sure that we are only looking at master edges
-                && ((Edge) object).isMasterEdge()
-                // Check for excluded highway types
-                && !this.isExcludedHighway(object);
-    }
-
-    /**
-     * This is the actual function that will check to see whether the object needs to be flagged.
-     *
-     * @param object
-     *            the atlas object supplied by the Atlas-Checks framework for evaluation
-     * @return an optional {@link CheckFlag} object that
-     */
-    @Override
-    protected Optional<CheckFlag> flag(final AtlasObject object)
-    {
-        final Edge edge = (Edge) object;
-        final String isoCountryCode = edge.tag(ISOCountryTag.KEY).toUpperCase();
-        final Set<String> instructions = new HashSet<>();
-
-        // Get all edges in the roundabout
-        final Set<Edge> roundaboutEdgeSet = new SimpleEdgeWalker(edge, this.isRoundaboutEdge())
-                .collectEdges();
-        roundaboutEdgeSet
-                .forEach(roundaboutEdge -> this.markAsFlagged(roundaboutEdge.getIdentifier()));
-        final Route roundaboutEdges;
-
-        // Try to build a Route from the edges
-        try
-        {
-            roundaboutEdges = Route.fromNonArrangedEdgeSet(roundaboutEdgeSet, false);
-        }
-        // If a Route cannot be formed, flag the edges as an incomplete roundabout.
-        catch (final CoreException badRoundabout)
-        {
-            return Optional.of(this.createFlag(roundaboutEdgeSet, this.getLocalizedInstruction(1)));
-        }
-
-        // Flag if any of the edges are not car navigable or master Edges, or the route does not
-        // form a closed loop.
-        if (roundaboutEdgeSet.stream()
-                .anyMatch(roundaboutEdge -> !HighwayTag.isCarNavigableHighway(roundaboutEdge)
-                        || !roundaboutEdge.isMasterEdge())
-                || !roundaboutEdges.start().inEdges().contains(roundaboutEdges.end()))
-        {
-            instructions.add(this.getLocalizedInstruction(1));
-        }
-
-        // Get the direction of the roundabout
-        final RoundaboutDirection direction = findRoundaboutDirection(roundaboutEdges);
-
-        // Determine if the roundabout is in a left or right driving country
-        final boolean isLeftDriving = leftDrivingCountries.contains(isoCountryCode);
-
-        // If the roundabout traffic is clockwise in a right-driving country, or
-        // If the roundabout traffic is counterclockwise in a left-driving country
-        if (direction.equals(RoundaboutDirection.CLOCKWISE) && !isLeftDriving
-                || direction.equals(RoundaboutDirection.COUNTERCLOCKWISE) && isLeftDriving)
-        {
-            instructions.add(this.getLocalizedInstruction(0));
-        }
-
-        // If there are car navigable edges inside the roundabout flag it, as it is probably
-        // malformed or a throughabout
-        if (roundaboutEdgeSet.stream().noneMatch(this::ignoreBridgeTunnelCrossings)
-                && this.roundaboutEnclosesRoads(roundaboutEdges))
-        {
-            instructions.add(this.getLocalizedInstruction(2));
-        }
-
-        if (!instructions.isEmpty())
-        {
-            final CheckFlag flag = this.createFlag(roundaboutEdgeSet,
-                    this.getLocalizedInstruction(3));
-            instructions.forEach(flag::addInstruction);
-            return Optional.of(flag);
-        }
-        return Optional.empty();
-    }
-
-    /**
-     * Function for {@link SimpleEdgeWalker} that gathers connected edges that are part of a
-     * roundabout.
-     *
-     * @return {@link Function} for {@link SimpleEdgeWalker}
-     */
-    private Function<Edge, Stream<Edge>> isRoundaboutEdge()
-    {
-        return edge -> edge.connectedEdges().stream()
-                .filter(connected -> JunctionTag.isRoundabout(connected)
-                        && !this.isExcludedHighway(connected));
-    }
+    private final List<String> leftDrivingCountries;
 
     /**
      * This method returns a RoundaboutDirection enum which indicates direction of the flow of
@@ -278,6 +149,110 @@ public class MalformedRoundaboutCheck extends BaseCheck
         return (vector1X * vector2Y) - (vector1Y * vector2X);
     }
 
+    public MalformedRoundaboutCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.leftDrivingCountries = (List<String>) configurationValue(configuration,
+                "traffic.countries.left", LEFT_DRIVING_COUNTRIES_DEFAULT);
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        // We check that the object is an instance of Edge
+        return object instanceof Edge
+                // Make sure that the object has an iso_country_code
+                && object.getTag(ISOCountryTag.KEY).isPresent()
+                // Make sure that the edges are instances of roundabout
+                && JunctionTag.isRoundabout(object)
+                // And that the Edge has not already been marked as flagged
+                && !this.isFlagged(object.getIdentifier())
+                // Make sure that we are only looking at master edges
+                && ((Edge) object).isMasterEdge()
+                // Check for excluded highway types
+                && !this.isExcludedHighway(object);
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Edge edge = (Edge) object;
+        final String isoCountryCode = edge.tag(ISOCountryTag.KEY).toUpperCase();
+        final Set<String> instructions = new HashSet<>();
+
+        // Get all edges in the roundabout
+        final Set<Edge> roundaboutEdgeSet = new SimpleEdgeWalker(edge, this.isRoundaboutEdge())
+                .collectEdges();
+        roundaboutEdgeSet
+                .forEach(roundaboutEdge -> this.markAsFlagged(roundaboutEdge.getIdentifier()));
+        final Route roundaboutEdges;
+
+        // Try to build a Route from the edges
+        try
+        {
+            roundaboutEdges = Route.fromNonArrangedEdgeSet(roundaboutEdgeSet, false);
+        }
+        // If a Route cannot be formed, flag the edges as an incomplete roundabout.
+        catch (final CoreException badRoundabout)
+        {
+            return Optional.of(this.createFlag(roundaboutEdgeSet, this.getLocalizedInstruction(1)));
+        }
+
+        // Flag if any of the edges are not car navigable or master Edges, or the route does not
+        // form a closed loop.
+        if (roundaboutEdgeSet.stream()
+                .anyMatch(roundaboutEdge -> !HighwayTag.isCarNavigableHighway(roundaboutEdge)
+                        || !roundaboutEdge.isMasterEdge())
+                || !roundaboutEdges.start().inEdges().contains(roundaboutEdges.end()))
+        {
+            instructions.add(this.getLocalizedInstruction(1));
+        }
+
+        // Get the direction of the roundabout
+        final RoundaboutDirection direction = findRoundaboutDirection(roundaboutEdges);
+
+        // Determine if the roundabout is in a left or right driving country
+        final boolean isLeftDriving = this.leftDrivingCountries.contains(isoCountryCode);
+
+        // If the roundabout traffic is clockwise in a right-driving country, or
+        // If the roundabout traffic is counterclockwise in a left-driving country
+        if (direction.equals(RoundaboutDirection.CLOCKWISE) && !isLeftDriving
+                || direction.equals(RoundaboutDirection.COUNTERCLOCKWISE) && isLeftDriving)
+        {
+            instructions.add(this.getLocalizedInstruction(0));
+        }
+
+        // If there are car navigable edges inside the roundabout flag it, as it is probably
+        // malformed or a throughabout
+        if (roundaboutEdgeSet.stream().noneMatch(this::ignoreBridgeTunnelCrossings)
+                && this.roundaboutEnclosesRoads(roundaboutEdges))
+        {
+            instructions.add(this.getLocalizedInstruction(2));
+        }
+
+        if (!instructions.isEmpty())
+        {
+            final CheckFlag flag = this.createFlag(roundaboutEdgeSet,
+                    this.getLocalizedInstruction(3));
+            instructions.forEach(flag::addInstruction);
+            return Optional.of(flag);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
     /**
      * Checks if an {@link Edge} has values that indicate it is crossable by another edge.
      *
@@ -289,25 +264,6 @@ public class MalformedRoundaboutCheck extends BaseCheck
     {
         return Validators.hasValuesFor(edge, LayerTag.class) || BridgeTag.isBridge(edge)
                 || TunnelTag.isTunnel(edge);
-    }
-
-    /**
-     * Checks for roads that should not be inside a roundabout. Such roads are car navigable, not a
-     * roundabout, bridge, or tunnel, don't have a layer tag, and have geometry inside the
-     * roundabout.
-     *
-     * @param roundabout
-     *            A roundabout as a {@link Route}
-     * @return true if there is a road that is crossing and has geometry enclosed by the roundabout
-     */
-    private boolean roundaboutEnclosesRoads(final Route roundabout)
-    {
-        final Polygon roundaboutPoly = new Polygon(roundabout.asPolyLine());
-        return roundabout.start().getAtlas().edgesIntersecting(roundaboutPoly,
-                edge -> HighwayTag.isCarNavigableHighway(edge) && !JunctionTag.isRoundabout(edge)
-                        && !this.ignoreBridgeTunnelCrossings(edge)
-                        && this.intersectsWithEnclosedGeometry(roundaboutPoly, edge))
-                .iterator().hasNext();
     }
 
     /**
@@ -341,5 +297,49 @@ public class MalformedRoundaboutCheck extends BaseCheck
     {
         return Validators.isOfType(object, HighwayTag.class, HighwayTag.CYCLEWAY,
                 HighwayTag.PEDESTRIAN, HighwayTag.FOOTWAY);
+    }
+
+    /**
+     * Function for {@link SimpleEdgeWalker} that gathers connected edges that are part of a
+     * roundabout.
+     *
+     * @return {@link Function} for {@link SimpleEdgeWalker}
+     */
+    private Function<Edge, Stream<Edge>> isRoundaboutEdge()
+    {
+        return edge -> edge.connectedEdges().stream()
+                .filter(connected -> JunctionTag.isRoundabout(connected)
+                        && !this.isExcludedHighway(connected));
+    }
+
+    /**
+     * Checks for roads that should not be inside a roundabout. Such roads are car navigable, not a
+     * roundabout, bridge, or tunnel, don't have a layer tag, and have geometry inside the
+     * roundabout.
+     *
+     * @param roundabout
+     *            A roundabout as a {@link Route}
+     * @return true if there is a road that is crossing and has geometry enclosed by the roundabout
+     */
+    private boolean roundaboutEnclosesRoads(final Route roundabout)
+    {
+        final Polygon roundaboutPoly = new Polygon(roundabout.asPolyLine());
+        return roundabout.start().getAtlas().edgesIntersecting(roundaboutPoly,
+                edge -> HighwayTag.isCarNavigableHighway(edge) && !JunctionTag.isRoundabout(edge)
+                        && !this.ignoreBridgeTunnelCrossings(edge)
+                        && this.intersectsWithEnclosedGeometry(roundaboutPoly, edge))
+                .iterator().hasNext();
+    }
+
+    /**
+     * An enum of RoundaboutDirections
+     */
+    public enum RoundaboutDirection
+    {
+        CLOCKWISE,
+        COUNTERCLOCKWISE,
+        // Handles the case where we were unable to get any information about the roundabout's
+        // Direction.
+        UNKNOWN
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -34,7 +34,6 @@ import com.google.common.base.Strings;
 
 public class AddressPointMatchCheck extends BaseCheck
 {
-    private static final long serialVersionUID = -756695185133616997L;
     public static final String NO_STREET_NAME_POINT_INSTRUCTIONS = "This Node, {0,number,#}, has "
             + "no street name specified in the address. The street name should likely "
             + "be one of {1}. These names were derived from nearby Nodes.";
@@ -44,6 +43,7 @@ public class AddressPointMatchCheck extends BaseCheck
     public static final String NO_SUGGESTED_NAMES_INSTRUCTIONS = "This node, {0,number,#}, has "
             + "no street name specified in the address. No suggestions names were found as there were no "
             + "nearby Nodes or Ways with street name key tags.";
+    private static final long serialVersionUID = -756695185133616997L;
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
             NO_STREET_NAME_POINT_INSTRUCTIONS, NO_STREET_NAME_EDGE_INSTRUCTIONS,
             NO_SUGGESTED_NAMES_INSTRUCTIONS);
@@ -51,12 +51,6 @@ public class AddressPointMatchCheck extends BaseCheck
     private static final double BOUNDS_SIZE_DEFAULT = 75.0;
 
     private final Distance boundsSize;
-
-    @Override
-    protected List<String> getFallbackInstructions()
-    {
-        return FALLBACK_INSTRUCTIONS;
-    }
 
     public AddressPointMatchCheck(final Configuration configuration)
     {
@@ -92,7 +86,7 @@ public class AddressPointMatchCheck extends BaseCheck
         final Point point = (Point) object;
 
         // Get a bounding box around the Point of interest
-        final Rectangle box = point.getLocation().boxAround(boundsSize);
+        final Rectangle box = point.getLocation().boxAround(this.boundsSize);
 
         // Get all Points in the bounding box, remove Points that have null as their
         // street name or do not have the street name key tag, and get a set of candidate street
@@ -128,6 +122,12 @@ public class AddressPointMatchCheck extends BaseCheck
             return Optional.of(this.createFlag(point,
                     this.getLocalizedInstruction(1, point.getOsmIdentifier(), edges)));
         }
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/base/PierTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/PierTest.java
@@ -35,7 +35,8 @@ public class PierTest
         final String configSource = "{\"PierTestCheck.accept.piers\": true}";
         final PierTestCheck check = new PierTestCheck(
                 ConfigurationResolver.inlineConfiguration(configSource));
-        final Set<CheckFlag> flags = Iterables.stream(check.flags(setup.getAtlas())).collectToSet();
+        final Set<CheckFlag> flags = Iterables.stream(check.flags(this.setup.getAtlas()))
+                .collectToSet();
         Assert.assertEquals(3, flags.size());
     }
 
@@ -49,7 +50,8 @@ public class PierTest
         final String configSource = "{\"PierTestCheck.accept.piers\": false}";
         final PierTestCheck check = new PierTestCheck(
                 ConfigurationResolver.inlineConfiguration(configSource));
-        final Set<CheckFlag> flags = Iterables.stream(check.flags(setup.getAtlas())).collectToSet();
+        final Set<CheckFlag> flags = Iterables.stream(check.flags(this.setup.getAtlas()))
+                .collectToSet();
         Assert.assertEquals(2, flags.size());
         flags.forEach(flag -> Assert.assertNotEquals(100, flag.getIdentifier()));
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/base/TagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/TagTest.java
@@ -27,6 +27,22 @@ public class TagTest
     public BaseTestRule setup = new BaseTestRule();
 
     /**
+     * Test combination tags. In the two cases first, filter by any features that contain the tag
+     * and value "whitelist=true" but does not contain the value "blacklist=false". We specifically
+     * used the filter "!true" even though we could have used "false" to test negation in filters.
+     * Second, Test the OR functionality, process all features that contain "whitelist=true" or
+     * "highway=trunk".
+     */
+    @Test
+    public void testCombinationTags()
+    {
+        final String config = "{\"BaseTestCheck\":{\"tags.filter\":\"whitelist->true&blacklist->!true\"}}";
+        this.testConfiguration(config, 1);
+        final String config2 = "{\"BaseTestCheck\":{\"tags.filter\":\"whitelist->true|highway->trunk\"}}";
+        this.testConfiguration(config2, 5);
+    }
+
+    /**
      * Test that when setting the filter explicitly with no value that it would essentially be
      * ignored.
      */
@@ -53,22 +69,6 @@ public class TagTest
     }
 
     /**
-     * Test combination tags. In the two cases first, filter by any features that contain the tag
-     * and value "whitelist=true" but does not contain the value "blacklist=false". We specifically
-     * used the filter "!true" even though we could have used "false" to test negation in filters.
-     * Second, Test the OR functionality, process all features that contain "whitelist=true" or
-     * "highway=trunk".
-     */
-    @Test
-    public void testCombinationTags()
-    {
-        final String config = "{\"BaseTestCheck\":{\"tags.filter\":\"whitelist->true&blacklist->!true\"}}";
-        this.testConfiguration(config, 1);
-        final String config2 = "{\"BaseTestCheck\":{\"tags.filter\":\"whitelist->true|highway->trunk\"}}";
-        this.testConfiguration(config2, 5);
-    }
-
-    /**
      * Private function used by all test cases to easily test the configuration instead of rewriting
      * the code constantly.
      * 
@@ -79,7 +79,7 @@ public class TagTest
      */
     private void testConfiguration(final String config, final int numberOfFlags)
     {
-        final Atlas atlas = setup.getAtlas();
+        final Atlas atlas = this.setup.getAtlas();
         final Configuration configuration = ConfigurationResolver.inlineConfiguration(config);
         final List<CheckFlag> flags = Iterables
                 .asList(new BaseTestCheck(configuration).flags(atlas));

--- a/src/test/java/org/openstreetmap/atlas/checks/commands/AtlasChecksGeoJSONDiffSubCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/commands/AtlasChecksGeoJSONDiffSubCommandTest.java
@@ -31,15 +31,144 @@ public class AtlasChecksGeoJSONDiffSubCommandTest
     private static final File TARGET_DIRECTORY = File.temporaryFolder();
     private static final File GZ_SOURCE_DIRECTORY = File.temporaryFolder();
     private static final File GZ_TARGET_DIRECTORY = File.temporaryFolder();
-
+    @Rule
+    public final JSONFlagDiffSubCommandTestRule setup = new JSONFlagDiffSubCommandTestRule();
     // Temp Files
     private String sourceFile;
     private String targetFile;
     private String sourceFileGZ;
     private String targetFileGZ;
 
-    @Rule
-    public final JSONFlagDiffSubCommandTestRule setup = new JSONFlagDiffSubCommandTestRule();
+    @AfterClass
+    public static void deleteLogFiles()
+    {
+        SOURCE_DIRECTORY.deleteRecursively();
+        TARGET_DIRECTORY.deleteRecursively();
+        GZ_SOURCE_DIRECTORY.deleteRecursively();
+        GZ_TARGET_DIRECTORY.deleteRecursively();
+    }
+
+    @Test
+    public void fileCreationFromDirectoryTest()
+    {
+        this.populateTestData();
+        final File temp = File.temporaryFolder();
+
+        // Run AtlasJoinerSubCommand
+        final String[] args = { "geojson-diff", String.format("-reference=%s", SOURCE_DIRECTORY),
+                String.format("-input=%s", TARGET_DIRECTORY),
+                String.format("-output=%s", temp.getPath()) };
+        new AtlasChecksCommand(args).runWithoutQuitting(args);
+
+        final List<File> outputFiles = temp.listFilesRecursively();
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("additions-\\d+-2.geojson")));
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("subtractions-\\d+-2.geojson")));
+
+        temp.deleteRecursively();
+    }
+
+    @Test
+    public void fileCreationFromFileTest()
+    {
+        this.populateTestData();
+        final File temp = File.temporaryFolder();
+
+        // Run AtlasJoinerSubCommand
+        final String[] args = { "geojson-diff", String.format("-reference=%s", this.sourceFile),
+                String.format("-input=%s", this.targetFile),
+                String.format("-output=%s", temp.getPath()) };
+        new AtlasChecksCommand(args).runWithoutQuitting(args);
+
+        final List<File> outputFiles = temp.listFilesRecursively();
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("additions-\\d+-1.geojson")));
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("subtractions-\\d+-1.geojson")));
+
+        temp.deleteRecursively();
+    }
+
+    /**
+     * Generate directories of flag files and gather the path to the first file in each.
+     */
+    public void populateTestData()
+    {
+        if (this.sourceFile == null)
+        {
+            this.generateLogFiles(SOURCE_DIRECTORY, TARGET_DIRECTORY, false);
+            this.generateLogFiles(GZ_SOURCE_DIRECTORY, GZ_TARGET_DIRECTORY, true);
+
+            this.sourceFile = this.getFirstGeojsonPath(SOURCE_DIRECTORY);
+            this.targetFile = this.getFirstGeojsonPath(TARGET_DIRECTORY);
+            this.sourceFileGZ = this.getFirstGeojsonPath(GZ_SOURCE_DIRECTORY);
+            this.targetFileGZ = this.getFirstGeojsonPath(GZ_TARGET_DIRECTORY);
+        }
+    }
+
+    @Test
+    public void testFileCreationFromGZippedAndUnZippedFiles()
+    {
+        this.populateTestData();
+        final File temp = File.temporaryFolder();
+
+        // Run AtlasJoinerSubCommand
+        final String[] args = { "geojson-diff", String.format("-reference=%s", this.sourceFileGZ),
+                String.format("-input=%s", this.targetFile),
+                String.format("-output=%s", temp.getPath()) };
+        new AtlasChecksCommand(args).runWithoutQuitting(args);
+
+        final List<File> outputFiles = temp.listFilesRecursively();
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("additions-\\d+-1.geojson")));
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("subtractions-\\d+-1.geojson")));
+
+        temp.deleteRecursively();
+    }
+
+    @Test
+    public void testFileCreationFromGZippedDirectory()
+    {
+        this.populateTestData();
+        final File temp = File.temporaryFolder();
+
+        // Run AtlasJoinerSubCommand
+        final String[] args = { "geojson-diff", String.format("-reference=%s", GZ_SOURCE_DIRECTORY),
+                String.format("-input=%s", GZ_TARGET_DIRECTORY),
+                String.format("-output=%s", temp.getPath()) };
+        new AtlasChecksCommand(args).runWithoutQuitting(args);
+
+        final List<File> outputFiles = temp.listFilesRecursively();
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("additions-\\d+-2.geojson")));
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("subtractions-\\d+-2.geojson")));
+
+        temp.deleteRecursively();
+    }
+
+    @Test
+    public void testFileCreationFromGZippedFile()
+    {
+        this.populateTestData();
+        final File temp = File.temporaryFolder();
+
+        // Run AtlasJoinerSubCommand
+        final String[] args = { "geojson-diff", String.format("-reference=%s", this.sourceFileGZ),
+                String.format("-input=%s", this.targetFileGZ),
+                String.format("-output=%s", temp.getPath()) };
+        new AtlasChecksCommand(args).runWithoutQuitting(args);
+
+        final List<File> outputFiles = temp.listFilesRecursively();
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("additions-\\d+-1.geojson")));
+        Assert.assertTrue(outputFiles.stream()
+                .anyMatch(file -> file.getName().matches("subtractions-\\d+-1.geojson")));
+
+        temp.deleteRecursively();
+    }
 
     /**
      * Generate flag files from {@link CheckFlagEvent}s, into source and target directories. The
@@ -87,136 +216,5 @@ public class AtlasChecksGeoJSONDiffSubCommandTest
                 .filter(file -> file.getName().endsWith(".geojson")
                         || file.getName().endsWith(".geojson.gz"))
                 .sorted().collect(Collectors.toList()).get(0).getPath();
-    }
-
-    /**
-     * Generate directories of flag files and gather the path to the first file in each.
-     */
-    public void populateTestData()
-    {
-        if (sourceFile == null)
-        {
-            this.generateLogFiles(SOURCE_DIRECTORY, TARGET_DIRECTORY, false);
-            this.generateLogFiles(GZ_SOURCE_DIRECTORY, GZ_TARGET_DIRECTORY, true);
-
-            sourceFile = this.getFirstGeojsonPath(SOURCE_DIRECTORY);
-            targetFile = this.getFirstGeojsonPath(TARGET_DIRECTORY);
-            sourceFileGZ = this.getFirstGeojsonPath(GZ_SOURCE_DIRECTORY);
-            targetFileGZ = this.getFirstGeojsonPath(GZ_TARGET_DIRECTORY);
-        }
-    }
-
-    @AfterClass
-    public static void deleteLogFiles()
-    {
-        SOURCE_DIRECTORY.deleteRecursively();
-        TARGET_DIRECTORY.deleteRecursively();
-        GZ_SOURCE_DIRECTORY.deleteRecursively();
-        GZ_TARGET_DIRECTORY.deleteRecursively();
-    }
-
-    @Test
-    public void fileCreationFromFileTest()
-    {
-        this.populateTestData();
-        final File temp = File.temporaryFolder();
-
-        // Run AtlasJoinerSubCommand
-        final String[] args = { "geojson-diff", String.format("-reference=%s", sourceFile),
-                String.format("-input=%s", targetFile),
-                String.format("-output=%s", temp.getPath()) };
-        new AtlasChecksCommand(args).runWithoutQuitting(args);
-
-        final List<File> outputFiles = temp.listFilesRecursively();
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("additions-\\d+-1.geojson")));
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("subtractions-\\d+-1.geojson")));
-
-        temp.deleteRecursively();
-    }
-
-    @Test
-    public void fileCreationFromDirectoryTest()
-    {
-        this.populateTestData();
-        final File temp = File.temporaryFolder();
-
-        // Run AtlasJoinerSubCommand
-        final String[] args = { "geojson-diff", String.format("-reference=%s", SOURCE_DIRECTORY),
-                String.format("-input=%s", TARGET_DIRECTORY),
-                String.format("-output=%s", temp.getPath()) };
-        new AtlasChecksCommand(args).runWithoutQuitting(args);
-
-        final List<File> outputFiles = temp.listFilesRecursively();
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("additions-\\d+-2.geojson")));
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("subtractions-\\d+-2.geojson")));
-
-        temp.deleteRecursively();
-    }
-
-    @Test
-    public void testFileCreationFromGZippedFile()
-    {
-        this.populateTestData();
-        final File temp = File.temporaryFolder();
-
-        // Run AtlasJoinerSubCommand
-        final String[] args = { "geojson-diff", String.format("-reference=%s", sourceFileGZ),
-                String.format("-input=%s", targetFileGZ),
-                String.format("-output=%s", temp.getPath()) };
-        new AtlasChecksCommand(args).runWithoutQuitting(args);
-
-        final List<File> outputFiles = temp.listFilesRecursively();
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("additions-\\d+-1.geojson")));
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("subtractions-\\d+-1.geojson")));
-
-        temp.deleteRecursively();
-    }
-
-    @Test
-    public void testFileCreationFromGZippedAndUnZippedFiles()
-    {
-        this.populateTestData();
-        final File temp = File.temporaryFolder();
-
-        // Run AtlasJoinerSubCommand
-        final String[] args = { "geojson-diff", String.format("-reference=%s", sourceFileGZ),
-                String.format("-input=%s", targetFile),
-                String.format("-output=%s", temp.getPath()) };
-        new AtlasChecksCommand(args).runWithoutQuitting(args);
-
-        final List<File> outputFiles = temp.listFilesRecursively();
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("additions-\\d+-1.geojson")));
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("subtractions-\\d+-1.geojson")));
-
-        temp.deleteRecursively();
-    }
-
-    @Test
-    public void testFileCreationFromGZippedDirectory()
-    {
-        this.populateTestData();
-        final File temp = File.temporaryFolder();
-
-        // Run AtlasJoinerSubCommand
-        final String[] args = { "geojson-diff", String.format("-reference=%s", GZ_SOURCE_DIRECTORY),
-                String.format("-input=%s", GZ_TARGET_DIRECTORY),
-                String.format("-output=%s", temp.getPath()) };
-        new AtlasChecksCommand(args).runWithoutQuitting(args);
-
-        final List<File> outputFiles = temp.listFilesRecursively();
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("additions-\\d+-2.geojson")));
-        Assert.assertTrue(outputFiles.stream()
-                .anyMatch(file -> file.getName().matches("subtractions-\\d+-2.geojson")));
-
-        temp.deleteRecursively();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommandTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommandTestRule.java
@@ -32,7 +32,7 @@ public class FlagStatisticsSubCommandTestRule extends CoreTestRule
      */
     public CheckFlagEvent getOneNodeCheckFlagEvent(final String checkName)
     {
-        final AtlasObject node = atlas.node(1000000L);
+        final AtlasObject node = this.atlas.node(1000000L);
         final CheckFlag flag = new CheckFlag(String.valueOf(node.getIdentifier()));
         flag.addObject(node);
         flag.addInstruction(TEST_INSTRUCTION);

--- a/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessorTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessorTestRule.java
@@ -51,9 +51,9 @@ public class CheckFlagGeoJsonProcessorTestRule extends CoreTestRule
     public CheckFlagEvent getCheckFlagEvent()
     {
         final CheckFlag flag = new CheckFlag("Test check flag");
-        flag.addObject(Iterables.head(atlas.nodes()), "Flagged Node");
-        flag.addObject(Iterables.head(atlas.edges()), "Flagged Edge");
-        flag.addObject(Iterables.head(atlas.areas()), "Flagged Area");
+        flag.addObject(Iterables.head(this.atlas.nodes()), "Flagged Node");
+        flag.addObject(Iterables.head(this.atlas.edges()), "Flagged Edge");
+        flag.addObject(Iterables.head(this.atlas.areas()), "Flagged Area");
 
         final CheckFlagEvent event = new CheckFlagEvent("sample-name", flag);
         event.getCheckFlag().addInstruction("First instruction");

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
@@ -28,10 +28,45 @@ public class TestMapRouletteConnection implements TaskLoader
         this.challengeToTasks = new HashMap<>();
     }
 
+    public Set<Challenge> challengesForProject(final Project project)
+    {
+        return this.projectToChallenges.get(project);
+    }
+
+    @Override
+    public long createChallenge(final Project project, final Challenge challenge)
+            throws UnsupportedEncodingException, URISyntaxException
+    {
+        if (this.projectToChallenges.containsKey(project))
+        {
+            this.projectToChallenges.get(project).add(challenge);
+        }
+        else
+        {
+            final Set<Challenge> newSet = new HashSet<>();
+            newSet.add(challenge);
+            this.projectToChallenges.put(project, newSet);
+        }
+        return 0;
+    }
+
+    @Override
+    public long createProject(final Project project)
+            throws UnsupportedEncodingException, URISyntaxException
+    {
+        this.projectToChallenges.put(project, new HashSet<>());
+        return 0;
+    }
+
     @Override
     public String getConnectionInfo()
     {
         return "";
+    }
+
+    public Set<Task> tasksForChallenge(final Challenge challenge)
+    {
+        return this.challengeToTasks.get(challenge.getId());
     }
 
     @Override
@@ -56,43 +91,8 @@ public class TestMapRouletteConnection implements TaskLoader
         return false;
     }
 
-    @Override
-    public long createProject(final Project project)
-            throws UnsupportedEncodingException, URISyntaxException
-    {
-        this.projectToChallenges.put(project, new HashSet<>());
-        return 0;
-    }
-
-    @Override
-    public long createChallenge(final Project project, final Challenge challenge)
-            throws UnsupportedEncodingException, URISyntaxException
-    {
-        if (this.projectToChallenges.containsKey(project))
-        {
-            this.projectToChallenges.get(project).add(challenge);
-        }
-        else
-        {
-            final Set<Challenge> newSet = new HashSet<>();
-            newSet.add(challenge);
-            this.projectToChallenges.put(project, newSet);
-        }
-        return 0;
-    }
-
     public Set<Project> uploadedProjects()
     {
-        return projectToChallenges.keySet();
-    }
-
-    public Set<Challenge> challengesForProject(final Project project)
-    {
-        return this.projectToChallenges.get(project);
-    }
-
-    public Set<Task> tasksForChallenge(final Challenge challenge)
-    {
-        return this.challengeToTasks.get(challenge.getId());
+        return this.projectToChallenges.keySet();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
@@ -13,48 +13,54 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 public class AreasWithHighwayTagCheckTest
 {
 
+    @Rule
+    public AreasWithHighwayTagCheckTestRule setup = new AreasWithHighwayTagCheckTestRule();
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
     private final AreasWithHighwayTagCheck check = new AreasWithHighwayTagCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"AreasWithHighwayTagCheck\":{\"tags.filter\":\"highway->*&area->yes\"}}"));
 
-    @Rule
-    public AreasWithHighwayTagCheckTestRule setup = new AreasWithHighwayTagCheckTestRule();
-
-    @Rule
-    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
-
     @Test
     public void areaNoHighwayTag()
     {
-        this.verifier.actual(this.setup.areaNoHighwayTagAtlas(), check);
+        this.verifier.actual(this.setup.areaNoHighwayTagAtlas(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
-    public void validHighwayPedestrianTag()
+    public void connectedEdgesBadTags()
     {
-        this.verifier.actual(this.setup.validHighwayPedestrianTagAtlas(), check);
-        this.verifier.verifyEmpty();
-    }
-
-    @Test
-    public void invalidAreaHighwayPrimaryTag()
-    {
-        this.verifier.actual(this.setup.invalidAreaHighwayPrimaryTagAtlas(), check);
-        this.verifier.verifyNotEmpty();
+        this.verifier.actual(this.setup.connectedEdgesBadTags(), this.check);
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test
     public void invalidAreaHighwayFootwayTag()
     {
-        this.verifier.actual(this.setup.invalidAreaHighwayFootwayTagAtlas(), check);
+        this.verifier.actual(this.setup.invalidAreaHighwayFootwayTagAtlas(), this.check);
         this.verifier.verifyNotEmpty();
+    }
+
+    @Test
+    public void invalidAreaHighwayPrimaryTag()
+    {
+        this.verifier.actual(this.setup.invalidAreaHighwayPrimaryTagAtlas(), this.check);
+        this.verifier.verifyNotEmpty();
+    }
+
+    @Test
+    public void invalidEdgeHighwaySecondary()
+    {
+        this.verifier.actual(this.setup.invalidEdgeHighwaySecondary(), this.check);
+        this.verifier.verifyExpectedSize(1);
     }
 
     @Test
     public void invalidHighwayPedestrianNoAreaTag()
     {
-        this.verifier.actual(this.setup.invalidHighwayPedestrianNoAreaTagAtlas(), check);
+        this.verifier.actual(this.setup.invalidHighwayPedestrianNoAreaTagAtlas(), this.check);
         this.verifier.verify(flag -> Assert.assertEquals(flag.getInstructions(),
                 String.format("Area with OSM ID %s is missing area tag.",
                         AreasWithHighwayTagCheckTestRule.INVALID_AREA_ID)));
@@ -63,43 +69,35 @@ public class AreasWithHighwayTagCheckTest
     @Test
     public void validAreaHighwayPlatform()
     {
-        this.verifier.actual(this.setup.validAreaHighwayPlatform(), check);
-        this.verifier.verifyEmpty();
-    }
-
-    @Test
-    public void invalidEdgeHighwaySecondary()
-    {
-        this.verifier.actual(this.setup.invalidEdgeHighwaySecondary(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void validEdgeHighwayService()
-    {
-        this.verifier.actual(this.setup.validEdgeHighwayService(), check);
-        this.verifier.verifyEmpty();
-    }
-
-    @Test
-    public void validEdgeNoAreaTag()
-    {
-        this.verifier.actual(this.setup.validEdgeNoAreaTag(), check);
+        this.verifier.actual(this.setup.validAreaHighwayPlatform(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
     public void validAreaHighwayPrimaryNoAreaTag()
     {
-        this.verifier.actual(this.setup.validAreaHighwayPrimaryNoAreaTag(), check);
+        this.verifier.actual(this.setup.validAreaHighwayPrimaryNoAreaTag(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
-    public void connectedEdgesBadTags()
+    public void validEdgeHighwayService()
     {
-        this.verifier.actual(this.setup.connectedEdgesBadTags(), check);
-        this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.actual(this.setup.validEdgeHighwayService(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void validEdgeNoAreaTag()
+    {
+        this.verifier.actual(this.setup.validEdgeNoAreaTag(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void validHighwayPedestrianTag()
+    {
+        this.verifier.actual(this.setup.validHighwayPedestrianTagAtlas(), this.check);
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTestRule.java
@@ -113,9 +113,14 @@ public class AreasWithHighwayTagCheckTestRule extends CoreTestRule
         return this.areaNoHighwayTagAtlas;
     }
 
-    public Atlas validHighwayPedestrianTagAtlas()
+    public Atlas connectedEdgesBadTags()
     {
-        return this.validHighwayPedestrianTagAtlas;
+        return this.connectedEdgesBadTags;
+    }
+
+    public Atlas invalidAreaHighwayFootwayTagAtlas()
+    {
+        return this.invalidAreaHighwayFootwayTagAtlas;
     }
 
     public Atlas invalidAreaHighwayPrimaryTagAtlas()
@@ -123,9 +128,9 @@ public class AreasWithHighwayTagCheckTestRule extends CoreTestRule
         return this.invalidAreaHighwayPrimaryTagAtlas;
     }
 
-    public Atlas invalidAreaHighwayFootwayTagAtlas()
+    public Atlas invalidEdgeHighwaySecondary()
     {
-        return this.invalidAreaHighwayFootwayTagAtlas;
+        return this.invalidEdgeHighwaySecondary;
     }
 
     public Atlas invalidHighwayPedestrianNoAreaTagAtlas()
@@ -138,29 +143,24 @@ public class AreasWithHighwayTagCheckTestRule extends CoreTestRule
         return this.validAreaHighwayPlatform;
     }
 
-    public Atlas invalidEdgeHighwaySecondary()
+    public Atlas validAreaHighwayPrimaryNoAreaTag()
     {
-        return invalidEdgeHighwaySecondary;
+        return this.validAreaHighwayPrimaryNoAreaTag;
     }
 
     public Atlas validEdgeHighwayService()
     {
-        return validEdgeHighwayService;
+        return this.validEdgeHighwayService;
     }
 
     public Atlas validEdgeNoAreaTag()
     {
-        return validEdgeNoAreaTag;
+        return this.validEdgeNoAreaTag;
     }
 
-    public Atlas validAreaHighwayPrimaryNoAreaTag()
+    public Atlas validHighwayPedestrianTagAtlas()
     {
-        return validAreaHighwayPrimaryNoAreaTag;
-    }
-
-    public Atlas connectedEdgesBadTags()
-    {
-        return connectedEdgesBadTags;
+        return this.validHighwayPedestrianTagAtlas;
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/OverlappingAOIPolygonCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/OverlappingAOIPolygonCheckTest.java
@@ -24,10 +24,10 @@ public class OverlappingAOIPolygonCheckTest
             "{\"OverlappingAOIPolygonCheck\":{\"aoi.tags.filters\": [\"amenity->GRAVE_YARD|landuse->CEMETERY\"],\"intersect.minimum.limit\":0.01}}");
 
     @Test
-    public void sameAOIsNoOverlapTest()
+    public void differentAOIsTest()
     {
-        this.verifier.actual(this.setup.sameAOIsNoOverlapAtlas(),
-                new OverlappingAOIPolygonCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.differentAOIsAtlas(),
+                new OverlappingAOIPolygonCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -35,7 +35,15 @@ public class OverlappingAOIPolygonCheckTest
     public void sameAOIsMinOverlapTest()
     {
         this.verifier.actual(this.setup.sameAOIsMinOverlapAtlas(),
-                new OverlappingAOIPolygonCheck(inlineConfiguration));
+                new OverlappingAOIPolygonCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void sameAOIsNoOverlapTest()
+    {
+        this.verifier.actual(this.setup.sameAOIsNoOverlapAtlas(),
+                new OverlappingAOIPolygonCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -43,7 +51,7 @@ public class OverlappingAOIPolygonCheckTest
     public void sameAOIsTest()
     {
         this.verifier.actual(this.setup.sameAOIsAtlas(),
-                new OverlappingAOIPolygonCheck(inlineConfiguration));
+                new OverlappingAOIPolygonCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
@@ -51,15 +59,7 @@ public class OverlappingAOIPolygonCheckTest
     public void similarAOIsTest()
     {
         this.verifier.actual(this.setup.similarAOIsAtlas(),
-                new OverlappingAOIPolygonCheck(inlineConfiguration));
+                new OverlappingAOIPolygonCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void differentAOIsTest()
-    {
-        this.verifier.actual(this.setup.differentAOIsAtlas(),
-                new OverlappingAOIPolygonCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTest.java
@@ -20,102 +20,104 @@ public class SpikyBuildingCheckTest
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
     @Test
-    public void findsSpikyBuildings()
-    {
-        verifier.actual(setup.getSpikyBuilding(),
-                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void findsSpikyBuildingsRoundNumbers()
-    {
-        verifier.actual(setup.getRoundNumbersSpiky(),
-                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void doesNotFindNormalBuilding()
-    {
-        verifier.actual(setup.getNormalBuilding(),
-                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyEmpty();
-    }
-
-    @Test
-    public void doesNotFindNormalBuildingRound()
-    {
-        verifier.actual(setup.getNormalRound(),
-                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyEmpty();
-    }
-
-    @Test
     public void badCase()
     {
-        verifier.actual(setup.badCase(),
+        this.verifier.actual(this.setup.badCase(),
                 new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyEmpty();
+        this.verifier.verifyEmpty();
     }
 
     @Test
     public void badCase2()
     {
-        verifier.actual(setup.badCase2(),
+        this.verifier.actual(this.setup.badCase2(),
                 new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyEmpty();
+        this.verifier.verifyEmpty();
     }
 
     @Test
     public void circleBuilding()
     {
-        verifier.actual(setup.circleBuilding(),
+        this.verifier.actual(this.setup.circleBuilding(),
                 new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyEmpty();
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void circleBuildingFlaggedWithLargerTotalAngleRequirement()
+    {
+        this.verifier.actual(this.setup.circleBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SpikyBuildingCheck\":{\"curve.degrees.minimum.total_heading_change\":179.0}}")));
+        this.verifier.verifyExpectedSize(3);
     }
 
     @Test
     public void circleBuildingFlaggedWithMorePoints()
     {
-        verifier.actual(setup.circleBuilding(), new SpikyBuildingCheck(ConfigurationResolver
-                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"curve.points.minimum\":10}}")));
-        verifier.verifyExpectedSize(3);
+        this.verifier.actual(this.setup.circleBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SpikyBuildingCheck\":{\"curve.points.minimum\":10}}")));
+        this.verifier.verifyExpectedSize(3);
 
     }
 
     @Test
     public void circleBuildingFlaggedWithStricterAngleThreshold()
     {
-        verifier.actual(setup.circleBuilding(),
+        this.verifier.actual(this.setup.circleBuilding(),
                 new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"SpikyBuildingCheck\":{\"curve.degrees.maximum.single_heading_change\":3.0}}")));
-        verifier.verifyExpectedSize(3);
+        this.verifier.verifyExpectedSize(3);
     }
 
     @Test
-    public void circleBuildingFlaggedWithLargerTotalAngleRequirement()
+    public void doesNotFindNormalBuilding()
     {
-        verifier.actual(setup.circleBuilding(),
-                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"SpikyBuildingCheck\":{\"curve.degrees.minimum.total_heading_change\":179.0}}")));
-        verifier.verifyExpectedSize(3);
+        this.verifier.actual(this.setup.getNormalBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
     }
 
     @Test
-    public void spikyBuildingNotFlaggedSmallThreshold()
+    public void doesNotFindNormalBuildingRound()
     {
-        verifier.actual(setup.getSpikyBuilding(), new SpikyBuildingCheck(ConfigurationResolver
-                .inlineConfiguration("{\"SpikyBuildingCheck\":{\"spiky.angle.maximum\":0.1}}")));
-        verifier.verifyEmpty();
+        this.verifier.actual(this.setup.getNormalRound(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void findsSpikyBuildings()
+    {
+        this.verifier.actual(this.setup.getSpikyBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void findsSpikyBuildingsRoundNumbers()
+    {
+        this.verifier.actual(this.setup.getRoundNumbersSpiky(),
+                new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
     }
 
     @Test
     public void smallConsecutiveCurves()
     {
-        verifier.actual(setup.twoShortConsecutiveCurvesBuilding(),
+        this.verifier.actual(this.setup.twoShortConsecutiveCurvesBuilding(),
                 new SpikyBuildingCheck(ConfigurationResolver.emptyConfiguration()));
-        verifier.verifyExpectedSize(1);
-        verifier.verify(flag -> Assert.assertEquals(2, flag.getPoints().size()));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getPoints().size()));
+    }
+
+    @Test
+    public void spikyBuildingNotFlaggedSmallThreshold()
+    {
+        this.verifier.actual(this.setup.getSpikyBuilding(),
+                new SpikyBuildingCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"SpikyBuildingCheck\":{\"spiky.angle.maximum\":0.1}}")));
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/SpikyBuildingCheckTestRule.java
@@ -97,43 +97,43 @@ public class SpikyBuildingCheckTestRule extends CoreTestRule
             @Loc(value = L), @Loc(value = N) }, tags = "building=yes") })
     private Atlas twoShortConsecutiveCurvesBuilding;
 
-    public Atlas getSpikyBuilding()
-    {
-        return spikyBuilding;
-    }
-
-    public Atlas getNormalBuilding()
-    {
-        return normalBuilding;
-    }
-
-    public Atlas getRoundNumbersSpiky()
-    {
-        return roundNumbersSpiky;
-    }
-
-    public Atlas getNormalRound()
-    {
-        return normalRound;
-    }
-
     public Atlas badCase()
     {
-        return badCase;
+        return this.badCase;
     }
 
     public Atlas badCase2()
     {
-        return badCase2;
+        return this.badCase2;
     }
 
     public Atlas circleBuilding()
     {
-        return circleBuilding;
+        return this.circleBuilding;
+    }
+
+    public Atlas getNormalBuilding()
+    {
+        return this.normalBuilding;
+    }
+
+    public Atlas getNormalRound()
+    {
+        return this.normalRound;
+    }
+
+    public Atlas getRoundNumbersSpiky()
+    {
+        return this.roundNumbersSpiky;
+    }
+
+    public Atlas getSpikyBuilding()
+    {
+        return this.spikyBuilding;
     }
 
     public Atlas twoShortConsecutiveCurvesBuilding()
     {
-        return twoShortConsecutiveCurvesBuilding;
+        return this.twoShortConsecutiveCurvesBuilding;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeTestRule.java
@@ -158,54 +158,54 @@ public class WaterbodyAndIslandSizeTestRule extends CoreTestRule
                             "type=multipolygon", "natural=water" }) })
     private Atlas smallMultiPolygonWaterbodyMemberAtlas;
 
-    public Atlas getLargeIsletAtlas()
+    public Atlas getInvalidMultiPolygonNoNaturalWaterTagRelationAtlas()
     {
-        return largeIsletAtlas;
+        return this.invalidMultiPolygonNoNaturalWaterTagRelationAtlas;
     }
 
-    public Atlas getValidSizeIslandAtlas()
+    public Atlas getLargeIsletAtlas()
     {
-        return validSizeIslandAtlas;
-
+        return this.largeIsletAtlas;
     }
 
     public Atlas getSmallArchipelagoAtlas()
     {
-        return smallArchipelagoAtlas;
-    }
-
-    public Atlas getSmallWaterbodyAtlas()
-    {
-        return smallWaterbodyAtlas;
-    }
-
-    public Atlas getSmallIsletAtlas()
-    {
-        return smallIsletAtlas;
-    }
-
-    public Atlas getSmallMultiPolygonIslandAtlas()
-    {
-        return smallMultiPolygonIslandAtlas;
-    }
-
-    public Atlas getSmallRockMultiPolygonIslandAtlas()
-    {
-        return smallRockMultiPolygonIslandAtlas;
+        return this.smallArchipelagoAtlas;
     }
 
     public Atlas getSmallIslandMultiPolygonDuplicateAtlas()
     {
-        return smallIslandMultiPolygonDuplicateAtlas;
+        return this.smallIslandMultiPolygonDuplicateAtlas;
     }
 
-    public Atlas getInvalidMultiPolygonNoNaturalWaterTagRelationAtlas()
+    public Atlas getSmallIsletAtlas()
     {
-        return invalidMultiPolygonNoNaturalWaterTagRelationAtlas;
+        return this.smallIsletAtlas;
+    }
+
+    public Atlas getSmallMultiPolygonIslandAtlas()
+    {
+        return this.smallMultiPolygonIslandAtlas;
     }
 
     public Atlas getSmallMultiPolygonWaterbodyMemberAtlas()
     {
-        return smallMultiPolygonWaterbodyMemberAtlas;
+        return this.smallMultiPolygonWaterbodyMemberAtlas;
+    }
+
+    public Atlas getSmallRockMultiPolygonIslandAtlas()
+    {
+        return this.smallRockMultiPolygonIslandAtlas;
+    }
+
+    public Atlas getSmallWaterbodyAtlas()
+    {
+        return this.smallWaterbodyAtlas;
+    }
+
+    public Atlas getValidSizeIslandAtlas()
+    {
+        return this.validSizeIslandAtlas;
+
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -59,7 +59,7 @@ public class EdgeCrossingEdgeCheckTest
     public void testInvalidCrossingNonMasterItemsAtlas()
     {
         this.verifier.actual(this.setup.invalidCrossingNonMasterItemsAtlas(),
-                new EdgeCrossingEdgeCheck(configuration));
+                new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.verifyNotEmpty();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolyLineCheckTest.java
@@ -13,6 +13,10 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  */
 public class SelfIntersectingPolyLineCheckTest
 {
+    @Rule
+    public SelfIntersectingPolylineTestCaseRule setup = new SelfIntersectingPolylineTestCaseRule();
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
     private final SelfIntersectingPolylineCheck check = new SelfIntersectingPolylineCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"SelfIntersectingPolylineCheck\":{\"tags.filter\":\"highway->!proposed&highway->!construction&highway->!footway&highway->!path\"}}"));
@@ -20,114 +24,88 @@ public class SelfIntersectingPolyLineCheckTest
             ConfigurationResolver.inlineConfiguration(
                     "{\"SelfIntersectingPolylineCheck\":{\"minimum.highway.type\":\"service\"}}"));
 
-    @Rule
-    public SelfIntersectingPolylineTestCaseRule setup = new SelfIntersectingPolylineTestCaseRule();
-
-    @Rule
-    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
-
     @Test
-    public void testValidLineNoSelfIntersection()
+    public void testHighPriorityEdgeIntersection()
     {
-        this.verifier.actual(this.setup.getValidLineNoSelfIntersection(), check);
-        this.verifier.verifyExpectedSize(0);
-    }
-
-    @Test
-    public void testInvalidLineNonShapeSelfIntersection()
-    {
-        this.verifier.actual(this.setup.getInvalidLineNonShapeSelfIntersection(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testInvalidLineShapePointSelfIntersection()
-    {
-        this.verifier.actual(this.setup.getInvalidLineShapePointSelfIntersection(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testInvalidLineGeometryWaterwayTag()
-    {
-        this.verifier.actual(this.setup.getInvalidLineGeometryWaterwayTag(), check);
-        this.verifier.verifyExpectedSize(0);
-    }
-
-    @Test
-    public void testInvalidLineGeometryHighwayFootwayTag()
-    {
-        this.verifier.actual(this.setup.getInvalidLineGeometryHighwayFootwayTag(), check);
-        this.verifier.verifyExpectedSize(0);
-    }
-
-    @Test
-    public void testValidEdgeNoSelfIntersection()
-    {
-        this.verifier.actual(this.setup.getValidEdgeNoSelfIntersection(), check);
-        this.verifier.verifyExpectedSize(0);
-    }
-
-    @Test
-    public void testInvalidEdgeNonShapeIntersection()
-    {
-        this.verifier.actual(this.setup.getInvalidEdgeNonShapeIntersection(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testInvalidEdgeShapeIntersection()
-    {
-        this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testInvalidEdgeGeometryHighwayPrimaryTag()
-    {
-        this.verifier.actual(this.setup.getInvalidEdgeGeometryHighwayPrimaryTag(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testInvalidEdgeGeometryBuildingTag()
-    {
-        this.verifier.actual(this.setup.getInvalidEdgeGeometryBuildingTag(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testValidAreaNoSelfIntersection()
-    {
-        this.verifier.actual(this.setup.getValidAreaNoSelfIntersection(), check);
-        this.verifier.verifyExpectedSize(0);
-    }
-
-    @Test
-    public void testInvalidAreaNonShapeSelfIntersection()
-    {
-        this.verifier.actual(this.setup.getInvalidAreaNonShapeSelfIntersection(), check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testInvalidAreaShapeIntersection()
-    {
-        this.verifier.actual(this.setup.getInvalidAreaShapeIntersection(), check);
+        this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(),
+                this.minimumHighwayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 
     @Test
     public void testInvalidAreaBuildTag()
     {
-        this.verifier.actual(this.setup.getInvalidAreaBuildingTag(), check);
+        this.verifier.actual(this.setup.getInvalidAreaBuildingTag(), this.check);
         this.verifier.verifyExpectedSize(1);
     }
 
     @Test
-    public void testHighPriorityEdgeIntersection()
+    public void testInvalidAreaNonShapeSelfIntersection()
     {
-        this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), minimumHighwayCheck);
+        this.verifier.actual(this.setup.getInvalidAreaNonShapeSelfIntersection(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidAreaShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidAreaShapeIntersection(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeGeometryBuildingTag()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeGeometryBuildingTag(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeGeometryHighwayPrimaryTag()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeGeometryHighwayPrimaryTag(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeNonShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeNonShapeIntersection(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidEdgeShapeIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidEdgeShapeIntersection(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidLineGeometryHighwayFootwayTag()
+    {
+        this.verifier.actual(this.setup.getInvalidLineGeometryHighwayFootwayTag(), this.check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidLineGeometryWaterwayTag()
+    {
+        this.verifier.actual(this.setup.getInvalidLineGeometryWaterwayTag(), this.check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testInvalidLineNonShapeSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidLineNonShapeSelfIntersection(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testInvalidLineShapePointSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getInvalidLineShapePointSelfIntersection(), this.check);
         this.verifier.verifyExpectedSize(1);
     }
 
@@ -135,7 +113,28 @@ public class SelfIntersectingPolyLineCheckTest
     public void testLowPriorityEdgeIntersection()
     {
         this.verifier.actual(this.setup.getLowPriorityInvalidEdgeIntersection(),
-                minimumHighwayCheck);
+                this.minimumHighwayCheck);
         this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testValidAreaNoSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getValidAreaNoSelfIntersection(), this.check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testValidEdgeNoSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getValidEdgeNoSelfIntersection(), this.check);
+        this.verifier.verifyExpectedSize(0);
+    }
+
+    @Test
+    public void testValidLineNoSelfIntersection()
+    {
+        this.verifier.actual(this.setup.getValidLineNoSelfIntersection(), this.check);
+        this.verifier.verifyExpectedSize(0);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
@@ -15,17 +15,17 @@ public class FloatingEdgeCheckTest
     public FloatingEdgeCheckTestRule setup = new FloatingEdgeCheckTestRule();
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
-    private FloatingEdgeCheck check = new FloatingEdgeCheck(
+    private final FloatingEdgeCheck check = new FloatingEdgeCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"FloatingEdgeCheck\":{\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
-    private FloatingEdgeCheck minimumHighwayCheck = new FloatingEdgeCheck(
+    private final FloatingEdgeCheck minimumHighwayCheck = new FloatingEdgeCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"FloatingEdgeCheck\":{\"highway.minimum\": \"PRIMARY_LINK\",\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
 
     @Test
     public void testBidirectionalFloatingEdge()
     {
-        this.verifier.actual(this.setup.floatingBidirectionalEdgeAtlas(), check);
+        this.verifier.actual(this.setup.floatingBidirectionalEdgeAtlas(), this.check);
         this.verifier.verifyNotNull();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
@@ -33,22 +33,29 @@ public class FloatingEdgeCheckTest
     @Test
     public void testConnectedEdge()
     {
-        this.verifier.actual(this.setup.connectedEdgeAtlas(), check);
+        this.verifier.actual(this.setup.connectedEdgeAtlas(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
     public void testFloatingEdge()
     {
-        this.verifier.actual(this.setup.floatingEdgeAtlas(), check);
+        this.verifier.actual(this.setup.floatingEdgeAtlas(), this.check);
         this.verifier.verifyNotNull();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
+    public void testInlineConfigFloatingEdge()
+    {
+        this.verifier.actual(this.setup.floatingEdgeAtlas(), this.minimumHighwayCheck);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
     public void testMixedAtlas()
     {
-        this.verifier.actual(this.setup.mixedAtlas(), check);
+        this.verifier.actual(this.setup.mixedAtlas(), this.check);
         this.verifier.verifyNotNull();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
@@ -56,14 +63,7 @@ public class FloatingEdgeCheckTest
     @Test
     public void testSyntheticBorderEdge()
     {
-        this.verifier.actual(this.setup.syntheticBorderAtlas(), check);
+        this.verifier.actual(this.setup.syntheticBorderAtlas(), this.check);
         this.verifier.verifyEmpty();
-    }
-
-    @Test
-    public void testInlineConfigFloatingEdge()
-    {
-        this.verifier.actual(this.setup.floatingEdgeAtlas(), minimumHighwayCheck);
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
@@ -24,26 +24,26 @@ public class SharpAngleCheckTest
             .inlineConfiguration("{\"SharpAngleCheck\":{\"threshold.degrees\": 97.0}}");
 
     @Test
-    public void sharpeAngleTest()
-    {
-        this.verifier.actual(this.setup.sharpeAngleAtlas(),
-                new SharpAngleCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
     public void notSharpeAngleTest()
     {
         this.verifier.actual(this.setup.notSharpeAngleAtlas(),
-                new SharpAngleCheck(inlineConfiguration));
+                new SharpAngleCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void sharpeAngleTest()
+    {
+        this.verifier.actual(this.setup.sharpeAngleAtlas(),
+                new SharpAngleCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
     public void sharpeAnglesTest()
     {
         this.verifier.actual(this.setup.sharpeAnglesAtlas(),
-                new SharpAngleCheck(inlineConfiguration));
+                new SharpAngleCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert
                 .assertTrue(flag.getInstructions().contains("2 angles that are too sharp")));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheckTestRule.java
@@ -171,74 +171,74 @@ public class AddressPointMatchCheckTestRule extends CoreTestRule
                             "name=Jones" }) })
     private Atlas pointWithEmptyStreetNameEdgeCandidatesDuplicateNames;
 
-    public Atlas pointWithStreetNameStreetNumberAndAssociatedStreet()
+    public Atlas pointWithEmptyStreetNameEdgeCandidatesDuplicateNames()
     {
-        return pointWithStreetNameStreetNumberAndAssociatedStreet;
-    }
-
-    public Atlas pointWithNoStreetNameStreetNumberAndAssociatedStreet()
-    {
-        return pointWithNoStreetNameStreetNumberAndAssociatedStreet;
-    }
-
-    public Atlas pointWithNoStreetNameStreetNumberAndNoAssociatedStreet()
-    {
-        return pointWithNoStreetNameStreetNumberAndNoAssociatedStreet;
-    }
-
-    public Atlas pointWithStreetNameStreetNumber()
-    {
-        return pointWithStreetNameStreetNumber;
-    }
-
-    public Atlas pointWithStreetNameNoStreetNumberNoCandidates()
-    {
-        return pointWithStreetNameNoStreetNumberNoCandidates;
-    }
-
-    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates()
-    {
-        return pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates;
-    }
-
-    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates()
-    {
-        return pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates;
-    }
-
-    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames()
-    {
-        return pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames;
-    }
-
-    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames()
-    {
-        return pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames;
-    }
-
-    public Atlas pointWithEmptyStreetNameNoStreetNumberNoCandidates()
-    {
-        return pointWithEmptyStreetNameNoCandidates;
-    }
-
-    public Atlas pointWithEmptyStreetNamePointCandidatesNoDuplicates()
-    {
-        return pointWithEmptyStreetNamePointCandidatesNoDuplicates;
+        return this.pointWithEmptyStreetNameEdgeCandidatesDuplicateNames;
     }
 
     public Atlas pointWithEmptyStreetNameEdgeCandidatesNoDuplicates()
     {
-        return pointWithEmptyStreetNameEdgeCandidatesNoDuplicates;
+        return this.pointWithEmptyStreetNameEdgeCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithEmptyStreetNameNoStreetNumberNoCandidates()
+    {
+        return this.pointWithEmptyStreetNameNoCandidates;
     }
 
     public Atlas pointWithEmptyStreetNamePointCandidatesDuplicateNames()
     {
-        return pointWithEmptyStreetNamePointCandidatesDuplicateNames;
+        return this.pointWithEmptyStreetNamePointCandidatesDuplicateNames;
     }
 
-    public Atlas pointWithEmptyStreetNameEdgeCandidatesDuplicateNames()
+    public Atlas pointWithEmptyStreetNamePointCandidatesNoDuplicates()
     {
-        return pointWithEmptyStreetNameEdgeCandidatesDuplicateNames;
+        return this.pointWithEmptyStreetNamePointCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithNoStreetNameStreetNumberAndAssociatedStreet()
+    {
+        return this.pointWithNoStreetNameStreetNumberAndAssociatedStreet;
+    }
+
+    public Atlas pointWithNoStreetNameStreetNumberAndNoAssociatedStreet()
+    {
+        return this.pointWithNoStreetNameStreetNumberAndNoAssociatedStreet;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames()
+    {
+        return this.pointWithStreetNameNoStreetNumberEdgeCandidatesDuplicateNames;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates()
+    {
+        return this.pointWithStreetNameNoStreetNumberEdgeCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberNoCandidates()
+    {
+        return this.pointWithStreetNameNoStreetNumberNoCandidates;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames()
+    {
+        return this.pointWithStreetNameNoStreetNumberPointCandidatesDuplicateNames;
+    }
+
+    public Atlas pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates()
+    {
+        return this.pointWithStreetNameNoStreetNumberPointCandidatesNoDuplicates;
+    }
+
+    public Atlas pointWithStreetNameStreetNumber()
+    {
+        return this.pointWithStreetNameStreetNumber;
+    }
+
+    public Atlas pointWithStreetNameStreetNumberAndAssociatedStreet()
+    {
+        return this.pointWithStreetNameStreetNumberAndAssociatedStreet;
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingAreaTagCombinationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/ConflictingAreaTagCombinationCheckTestRule.java
@@ -93,58 +93,58 @@ public class ConflictingAreaTagCombinationCheckTestRule extends CoreTestRule
                     "area=no", "natural=water", "landuse=port" }) })
     private Atlas areaNoNaturalLandUseTagAtlas;
 
-    public Atlas getBuildingNaturalTagAtlas()
+    public Atlas getAreaNoNaturalLandUseTagAtlas()
     {
-        return buildingNaturalTagAtlas;
-    }
-
-    public Atlas getBuildingHighwayTagAtlas()
-    {
-        return buildingHighwayTagAtlas;
+        return this.areaNoNaturalLandUseTagAtlas;
     }
 
     public Atlas getBuildingHighwayServicesAtlas()
     {
-        return buildingHighwayServicesAtlas;
+        return this.buildingHighwayServicesAtlas;
     }
 
-    public Atlas getNaturalManMadeTagAtlas()
+    public Atlas getBuildingHighwayTagAtlas()
     {
-        return naturalManMadeTagAtlas;
+        return this.buildingHighwayTagAtlas;
     }
 
-    public Atlas getNaturalHighwayTagAtlas()
+    public Atlas getBuildingNaturalTagAtlas()
     {
-        return naturalHighwayTagAtlas;
-    }
-
-    public Atlas getNaturalLeisureTagAtlas()
-    {
-        return naturalLeisureTagAtlas;
-    }
-
-    public Atlas getWaterLandUseTagAtlas()
-    {
-        return waterLandUseTagAtlas;
-    }
-
-    public Atlas getWaterLandUseAquacultureAtlas()
-    {
-        return waterLandUseAquacultureAtlas;
-    }
-
-    public Atlas getWaterManMadeChimneyAtlas()
-    {
-        return waterManMadeChimneyAtlas;
+        return this.buildingNaturalTagAtlas;
     }
 
     public Atlas getLandUseHighwayAtlas()
     {
-        return landUseHighwayAtlas;
+        return this.landUseHighwayAtlas;
     }
 
-    public Atlas getAreaNoNaturalLandUseTagAtlas()
+    public Atlas getNaturalHighwayTagAtlas()
     {
-        return areaNoNaturalLandUseTagAtlas;
+        return this.naturalHighwayTagAtlas;
+    }
+
+    public Atlas getNaturalLeisureTagAtlas()
+    {
+        return this.naturalLeisureTagAtlas;
+    }
+
+    public Atlas getNaturalManMadeTagAtlas()
+    {
+        return this.naturalManMadeTagAtlas;
+    }
+
+    public Atlas getWaterLandUseAquacultureAtlas()
+    {
+        return this.waterLandUseAquacultureAtlas;
+    }
+
+    public Atlas getWaterLandUseTagAtlas()
+    {
+        return this.waterLandUseTagAtlas;
+    }
+
+    public Atlas getWaterManMadeChimneyAtlas()
+    {
+        return this.waterManMadeChimneyAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheckTest.java
@@ -24,26 +24,26 @@ public class InvalidLanesTagCheckTest
             "{\"InvalidLanesTagCheck\":{\"lanes.filter\":\"lanes->1,1.5,2\"}}");
 
     @Test
-    public void validLanesTag()
-    {
-        this.verifier.actual(this.setup.validLanesTag(),
-                new InvalidLanesTagCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
     public void invalidLanesTag()
     {
         this.verifier.actual(this.setup.invalidLanesTag(),
-                new InvalidLanesTagCheck(inlineConfiguration));
+                new InvalidLanesTagCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validLanesTag()
+    {
+        this.verifier.actual(this.setup.validLanesTag(),
+                new InvalidLanesTagCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
     public void validLanesTagTollBooth()
     {
         this.verifier.actual(this.setup.validLanesTagTollBooth(),
-                new InvalidLanesTagCheck(inlineConfiguration));
+                new InvalidLanesTagCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheckTest.java
@@ -24,34 +24,10 @@ public class MixedCaseNameCheckTest
             "{\"MixedCaseNameCheck\":{\"check_name.countries\":[\"USA\",\"GRC\"],\"name.language.keys\":[\"name:en\",\"name:el\"],\"lower_case\":{\"prepositions\":[\"and\", \"to\", \"of\"],\"articles\":[\"a\", \"an\", \"the\"]},\"words.split.characters\":\" -/&@\",\"name_affixes\":[\"Mc\", \"Mac\", \"Mck\",\"Mhic\", \"Mic\"],\"units.mixed_case\":[\"kV\"]}}");
 
     @Test
-    public void invalidNamePointTest()
-    {
-        this.verifier.actual(this.setup.invalidNamePointAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void invalidNameNodeTest()
-    {
-        this.verifier.actual(this.setup.invalidNameNodeAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void invalidNameLineTest()
-    {
-        this.verifier.actual(this.setup.invalidNameLineAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
     public void invalidNameAreaTest()
     {
         this.verifier.actual(this.setup.invalidNameAreaAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
@@ -59,167 +35,63 @@ public class MixedCaseNameCheckTest
     public void invalidNameEdgeTest()
     {
         this.verifier.actual(this.setup.invalidNameEdgeAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void invalidNamePointOneWordTest()
+    public void invalidNameLineTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointOneWordAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.invalidNameLineAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointHyphenTest()
+    public void invalidNameNodeTest()
     {
-        this.verifier.actual(this.setup.validNamePointHyphenAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointNumberTest()
-    {
-        this.verifier.actual(this.setup.validNamePointNumberAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void invalidNamePointHyphenTest()
-    {
-        this.verifier.actual(this.setup.invalidNamePointHyphenAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.invalidNameNodeAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void validNamePointAffixTest()
-    {
-        this.verifier.actual(this.setup.validNamePointAffixAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
     public void invalidNamePointAffixTest()
     {
         this.verifier.actual(this.setup.invalidNamePointAffixAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void validNamePointApostropheTest()
-    {
-        this.verifier.actual(this.setup.validNamePointApostropheAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointApostropheLowerTest()
-    {
-        this.verifier.actual(this.setup.validNamePointApostropheLowerAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointApostropheAllCapsTest()
-    {
-        this.verifier.actual(this.setup.validNamePointApostropheAllCapsAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointCapsApostropheTest()
-    {
-        this.verifier.actual(this.setup.validNamePointCapsApostropheAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointCapsLowerApostropheTest()
-    {
-        this.verifier.actual(this.setup.validNamePointCapsLowerApostropheAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
     public void invalidNamePointApostropheTest()
     {
         this.verifier.actual(this.setup.invalidNamePointApostropheAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointAllCapsTest()
+    public void invalidNamePointChnTest()
     {
-        this.verifier.actual(this.setup.validNamePointAllCapsAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointNoCapsTest()
-    {
-        this.verifier.actual(this.setup.validNamePointNoCapsAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointLowerCasePrepositionTest()
-    {
-        this.verifier.actual(this.setup.validNamePointLowerCasePrepositionAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointLowerCaseArticleTest()
-    {
-        this.verifier.actual(this.setup.validNamePointLowerCaseArticleAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void validNamePointLowerCaseArticleStartTest()
-    {
-        this.verifier.actual(this.setup.validNamePointLowerCaseArticleStartAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
-    }
-
-    @Test
-    public void invalidNamePointLowerCaseArticleStartTest()
-    {
-        this.verifier.actual(this.setup.invalidNamePointLowerCaseArticleStartAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.invalidNamePointChnAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void validNamePointMixedCaseUnitTest()
-    {
-        this.verifier.actual(this.setup.validNamePointMixedCaseUnitAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
     public void invalidNamePointEnTest()
     {
         this.verifier.actual(this.setup.invalidNamePointEnAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointGreekElTest()
+    {
+        this.verifier.actual(this.setup.invalidNamePointGreekElAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
@@ -227,47 +99,175 @@ public class MixedCaseNameCheckTest
     public void invalidNamePointGreekTest()
     {
         this.verifier.actual(this.setup.invalidNamePointGreekAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
-    public void validNamePointGreekTest()
+    public void invalidNamePointHyphenTest()
     {
-        this.verifier.actual(this.setup.validNamePointGreekAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.invalidNamePointHyphenAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointLowerCaseArticleStartTest()
+    {
+        this.verifier.actual(this.setup.invalidNamePointLowerCaseArticleStartAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointOneWordTest()
+    {
+        this.verifier.actual(this.setup.invalidNamePointOneWordAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void invalidNamePointTest()
+    {
+        this.verifier.actual(this.setup.invalidNamePointAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validNamePointAffixTest()
+    {
+        this.verifier.actual(this.setup.validNamePointAffixAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointGreekElTest()
+    public void validNamePointAllCapsTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointGreekElAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void validNamePointGreekElTest()
-    {
-        this.verifier.actual(this.setup.validNamePointGreekElAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+        this.verifier.actual(this.setup.validNamePointAllCapsAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
-    public void invalidNamePointChnTest()
+    public void validNamePointApostropheAllCapsTest()
     {
-        this.verifier.actual(this.setup.invalidNamePointChnAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.actual(this.setup.validNamePointApostropheAllCapsAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointApostropheLowerTest()
+    {
+        this.verifier.actual(this.setup.validNamePointApostropheLowerAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointApostropheTest()
+    {
+        this.verifier.actual(this.setup.validNamePointApostropheAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointCapsApostropheTest()
+    {
+        this.verifier.actual(this.setup.validNamePointCapsApostropheAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointCapsLowerApostropheTest()
+    {
+        this.verifier.actual(this.setup.validNamePointCapsLowerApostropheAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
     public void validNamePointChnTest()
     {
         this.verifier.actual(this.setup.validNamePointChnAtlas(),
-                new MixedCaseNameCheck(inlineConfiguration));
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointGreekElTest()
+    {
+        this.verifier.actual(this.setup.validNamePointGreekElAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointGreekTest()
+    {
+        this.verifier.actual(this.setup.validNamePointGreekAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointHyphenTest()
+    {
+        this.verifier.actual(this.setup.validNamePointHyphenAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointLowerCaseArticleStartTest()
+    {
+        this.verifier.actual(this.setup.validNamePointLowerCaseArticleStartAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointLowerCaseArticleTest()
+    {
+        this.verifier.actual(this.setup.validNamePointLowerCaseArticleAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointLowerCasePrepositionTest()
+    {
+        this.verifier.actual(this.setup.validNamePointLowerCasePrepositionAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointMixedCaseUnitTest()
+    {
+        this.verifier.actual(this.setup.validNamePointMixedCaseUnitAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointNoCapsTest()
+    {
+        this.verifier.actual(this.setup.validNamePointNoCapsAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void validNamePointNumberTest()
+    {
+        this.verifier.actual(this.setup.validNamePointNumberAtlas(),
+                new MixedCaseNameCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/UnusualLayerTagsCheckTestRule.java
@@ -410,6 +410,11 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
         return this.minusTwoLayerTagTunnelEdgeAtlas;
     }
 
+    public Atlas missingBridgeTagJunctionLayerEdgeAtlas()
+    {
+        return this.missingBridgeTagJunctionLayerEdgeAtlas;
+    }
+
     public Atlas missingLayerTagBridgeEdgeAtlas()
     {
         return this.missingLayerTagBridgeEdgeAtlas;
@@ -520,6 +525,21 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
         return this.plusTwoLayerTagBridgeEdgeAtlas;
     }
 
+    public Atlas validBuildingPassageTunnelLayerEdgeAtlas()
+    {
+        return this.validBuildingPassageTunnelLayerEdgeAtlas;
+    }
+
+    public Atlas validLayerTagRoundaboutEdgeAtlas()
+    {
+        return this.validLayerTagRoundaboutEdgeAtlas;
+    }
+
+    public Atlas whitespaceBridgeRoundaboutLayerTagEdgeAtlas()
+    {
+        return this.whitespaceBridgeRoundaboutLayerTagEdgeAtlas;
+    }
+
     public Atlas whitespaceLayerTagBridgeEdgeAtlas()
     {
         return this.whitespaceLayerTagBridgeEdgeAtlas;
@@ -558,25 +578,5 @@ public class UnusualLayerTagsCheckTestRule extends CoreTestRule
     public Atlas zeroLayerTagTunnelEdgeAtlas()
     {
         return this.zeroLayerTagTunnelEdgeAtlas;
-    }
-
-    public Atlas validLayerTagRoundaboutEdgeAtlas()
-    {
-        return this.validLayerTagRoundaboutEdgeAtlas;
-    }
-
-    public Atlas missingBridgeTagJunctionLayerEdgeAtlas()
-    {
-        return this.missingBridgeTagJunctionLayerEdgeAtlas;
-    }
-
-    public Atlas whitespaceBridgeRoundaboutLayerTagEdgeAtlas()
-    {
-        return whitespaceBridgeRoundaboutLayerTagEdgeAtlas;
-    }
-
-    public Atlas validBuildingPassageTunnelLayerEdgeAtlas()
-    {
-        return validBuildingPassageTunnelLayerEdgeAtlas;
     }
 }


### PR DESCRIPTION
### Description:

This is a followup change to https://github.com/osmlab/atlas/pull/462

The `RequireThis` plugin in Checkstyle was updated after `6.17`, and this update was missed.

Adding
```xml
<property name="validateOnlyOverlapping" value="false"/>
``` 
enforces the same behavior as before.

Thanks @Huyuntj for finding out!

Also contains:
- Code re-ordering

### Potential Impact:

No impact other than formatting

### Unit Test Approach:

N/A

### Test Results:

N/A