### PR TITLE
CheckFlag accepts ? extends AtlasObject

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -327,26 +327,28 @@ public abstract class BaseCheck<T> implements Check, Serializable
                 Collections.singletonList(instruction), points);
     }
 
-    protected CheckFlag createFlag(final Set<AtlasObject> objects, final String instruction)
+    protected CheckFlag createFlag(final Set<? extends AtlasObject> objects,
+            final String instruction)
     {
         return new CheckFlag(this.getTaskIdentifier(objects), objects,
                 Collections.singletonList(instruction));
     }
 
-    protected CheckFlag createFlag(final Set<AtlasObject> objects, final String instruction,
-            final List<Location> points)
+    protected CheckFlag createFlag(final Set<? extends AtlasObject> objects,
+            final String instruction, final List<Location> points)
     {
         return new CheckFlag(this.getTaskIdentifier(objects), objects,
                 Collections.singletonList(instruction), points);
     }
 
-    protected CheckFlag createFlag(final Set<AtlasObject> objects, final List<String> instructions,
-            final List<Location> points)
+    protected CheckFlag createFlag(final Set<? extends AtlasObject> objects,
+            final List<String> instructions, final List<Location> points)
     {
         return new CheckFlag(this.getTaskIdentifier(objects), objects, instructions, points);
     }
 
-    protected CheckFlag createFlag(final Set<AtlasObject> objects, final List<String> instructions)
+    protected CheckFlag createFlag(final Set<? extends AtlasObject> objects,
+            final List<String> instructions)
     {
         return new CheckFlag(this.getTaskIdentifier(objects), objects, instructions);
     }
@@ -394,7 +396,7 @@ public abstract class BaseCheck<T> implements Check, Serializable
      *            set of {@link AtlasObject}s comprising this task
      * @return a unique string identifier for this task, made from the sorted object identifiers
      */
-    protected String getTaskIdentifier(final Set<AtlasObject> objects)
+    protected String getTaskIdentifier(final Set<? extends AtlasObject> objects)
     {
         return new TaskIdentifier(objects).toString();
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/base/TaskIdentifier.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/TaskIdentifier.java
@@ -37,7 +37,7 @@ public class TaskIdentifier
      * @param objects
      *            a {@code Set} of {@link AtlasObject}s used to form the {@code identifier}
      */
-    public TaskIdentifier(final Set<AtlasObject> objects)
+    public TaskIdentifier(final Set<? extends AtlasObject> objects)
     {
         if (objects == null || objects.isEmpty())
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -83,7 +83,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      * @param instructions
      *            a list of free form instructions
      */
-    public CheckFlag(final String identifier, final Set<AtlasObject> objects,
+    public CheckFlag(final String identifier, final Set<? extends AtlasObject> objects,
             final List<String> instructions)
     {
         this(identifier, objects, instructions, new ArrayList<>());
@@ -102,7 +102,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      * @param points
      *            {@code point} {@link Location}s to highlight
      */
-    public CheckFlag(final String identifier, final Set<AtlasObject> objects,
+    public CheckFlag(final String identifier, final Set<? extends AtlasObject> objects,
             final List<String> instructions, final List<Location> points)
     {
         addObjects(objects);
@@ -204,7 +204,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      * @param objects
      *            a list of {@link AtlasObject}s
      */
-    public void addObjects(final Iterable<AtlasObject> objects)
+    public void addObjects(final Iterable<? extends AtlasObject> objects)
     {
         objects.forEach(this::addObject);
     }


### PR DESCRIPTION
### Description:

Currently, CheckFlag constructors that accept a `Set` require the set to be exactly `Set<AtlasObject>`. This creates an awkward step if we, for example, want to flag the results of a walker (which returns `Set<Edge>`). 

According to [PECS](https://stackoverflow.com/questions/2723397/what-is-pecs-producer-extends-consumer-super), we should use the exact match (`<AtlasObject>`) if we are both reading from and adding to the data structure. However, the constructors only read from the set. So, we can safely read any `<? extends AtlasObject>`.

I think this is a pretty clear win as far as improved flexibility goes. 

### Potential Impact:

Increased flexibility in calling `createFlag` and similar methods. There should be no function calls that were valid before but are no longer valid.

Classes in other libraries that extend classes in this classes *and override one of the following methods* may need to update their function signatures. For clarity's sake, here are the function signatures that have changed:
 - `BaseCheck`
   - overloaded `createFlag` functions: `createFlag(final Set<AtlasObject> objects...)`
   - `getTaskIdentifier(final Set<AtlasObject> objects)` 
 - `TaskIdentifier`
   - constructor (this also only reads from the file and is therefore safe).
 - `CheckFlag`
   - constructors
   - `addObjects(final Iterable<AtlasObject> objects)`

### Unit Test Approach:

None are necessary, as only function signatures are changing. 

### Test Results:

Code compiles.