### PR TITLE
[MapRouletteUploadCommand] Pick up Challenge name from configuration

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -144,7 +144,8 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         final JsonObject challengeJson = challenge.toJson(challenge.getName());
         final String type = challengeJson.has(Survey.KEY_ANSWERS) ? KEY_SURVEY : KEY_CHALLENGE;
         return create(
-                String.format("/api/v2/project/%d/challenge/%s", project.getId(), URLEncoder.encode(challenge.getName(), "UTF-8")),
+                String.format("/api/v2/project/%d/challenge/%s", project.getId(),
+                        URLEncoder.encode(challenge.getName(), "UTF-8")),
                 String.format("/api/v2/%s", type), String.format("/api/v2/%s/", type) + "%s",
                 challengeJson, String.format("Created/Updated Challenge with ID {} and name %s",
                         challenge.getName()));

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.checks.maproulette;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -143,8 +144,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         final JsonObject challengeJson = challenge.toJson(challenge.getName());
         final String type = challengeJson.has(Survey.KEY_ANSWERS) ? KEY_SURVEY : KEY_CHALLENGE;
         return create(
-                String.format("/api/v2/project/%d/challenge/%s", project.getId(),
-                        challenge.getName()),
+                String.format("/api/v2/project/%d/challenge/%s", project.getId(), URLEncoder.encode(challenge.getName(), "UTF-8")),
                 String.format("/api/v2/%s", type), String.format("/api/v2/%s/", type) + "%s",
                 challengeJson, String.format("Created/Updated Challenge with ID {} and name %s",
                         challenge.getName()));

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -174,7 +174,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             final Gson gson = new GsonBuilder().disableHtmlEscaping()
                     .registerTypeAdapter(Challenge.class, new ChallengeDeserializer()).create();
             final Challenge result = gson.fromJson(gson.toJson(challengeMap), Challenge.class);
-            result.setName(checkName);
+            result.setName(result.getName().isEmpty() ? checkName : result.getName());
             return result;
         });
     }


### PR DESCRIPTION
### Description:

This updates the `MapRouletteUploadCommand` to pick up the Challenge `name` from the default configuration object if it exists.
```json
  "AddressPointMatchCheck": {
    "challenge": {
      "name": "Missing Address Points",
      "description": "Tasks contain nodes which either have no street name or incorrect street names",
      "instruction": "Open your favorite editor and edit the node street names"
    }
  }
```
Before creating new challenges, the MR client checks if the challenge exists via the `/api/v2/project/{id}/challenge/{challenge_name_string}`. To allow for challenges with special characters/spaces etc., I've encoded the challenge name string.

### Potential Impact:

No downstream impact. Command is optional

### Unit Test Approach:

Existing Challenge Deserialization unit tests handle this case. Using the default configuration, I added names to both `SinkIslandCheck` & `BuildingRoadIntersection`.

### Test Results:

Challenges uploaded to MR as expected.

<img width="896" alt="Screen Shot 2019-08-04 at 9 45 37 PM" src="https://user-images.githubusercontent.com/1947857/62439663-883c1500-b701-11e9-9bbf-e337be3c0cbb.png">


