### PR TITLE
Expose new loadChecksUsingConstructors method

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -15,7 +14,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Streams;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
@@ -24,6 +22,7 @@ import org.openstreetmap.atlas.utilities.time.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Streams;
 import com.google.common.reflect.ClassPath;
 
 /**
@@ -145,98 +144,6 @@ public class CheckResourceLoader
         return loadChecks(this::isEnabledByConfiguration, configuration);
     }
 
-    public <T extends Check> Set<T> loadChecksUsingConstructors(final List<Class<?>[]> constructorArgumentTypes,
-            final List<Object[]> constructorArguments)
-    {
-        return this.loadChecksUsingConstructors(this::isEnabledByConfiguration, constructorArgumentTypes, constructorArguments);
-    }
-
-    /**
-     * Given a list of corresponding types and arguments, try to initialize each enabled check using
-     * each constructor in order.
-     * @param isEnabled
-     *            {@link Predicate} used to determine if a check is enabled
-     * @param constructorArgumentTypes
-     *            {@}
-     * @param constructorArguments
-     * @param <T>
-     * @return A set of enabled, initialized checks.
-     */
-    public <T extends Check> Set<T> loadChecksUsingConstructors(final Predicate<Class> isEnabled,
-            final List<Class<?>[]> constructorArgumentTypes, final List<Object[]> constructorArguments)
-    {
-        final Set<T> checks = new HashSet<>();
-        final Time time = Time.now();
-        try
-        {
-            final ClassPath classPath = ClassPath
-                    .from(Thread.currentThread().getContextClassLoader());
-            this.packages.forEach(packageName -> classPath.getTopLevelClassesRecursive(packageName)
-                    .forEach(classInfo ->
-                    {
-                        final Class<?> checkClass = classInfo.load();
-                        if (this.checkType.isAssignableFrom(checkClass)
-                                && !Modifier.isAbstract(checkClass.getModifiers())
-                                && isEnabled.test(checkClass)
-                                && this.checkWhiteList.map(
-                                whitelist -> whitelist.contains(checkClass.getSimpleName()))
-                                .orElse(true)
-                                && this.checkBlackList.map(blacklist -> !blacklist
-                                .contains(checkClass.getSimpleName())).orElse(true))
-                        {
-                            Streams.zip(constructorArgumentTypes.stream(),
-                                    constructorArguments.stream(),
-                                    (argTypes, args) -> this.initializeCheckWithArguments((Class<T>) checkClass, argTypes, args))
-                                    .filter(Optional::isPresent)
-                                    .map(Optional::get)
-                                    .findFirst()
-                                    .ifPresent(checks::add);
-                        }
-                    }));
-        }
-        catch (final IOException oops)
-        {
-            throw new CoreException("Failed to discover {} classes on classpath",
-                    this.checkType.getSimpleName());
-        }
-
-        logger.info("Loaded {} {} in {}", checks.size(), this.checkType.getSimpleName(),
-                time.elapsedSince());
-        return checks;
-    }
-
-    private <T extends Check> Optional<T> initializeCheckWithArguments(final Class<T> checkClass, final Class<?>[] constructorArgumentTypes, final Object[] constructorArguments)
-    {
-        try
-        {
-            final Constructor<T> constructor = checkClass.getConstructor(constructorArgumentTypes);
-            final T result = constructor.newInstance(constructorArguments);
-            return Optional.of(result);
-        }
-        catch (final NoSuchMethodException oops)
-        {
-            logger.info("No method found for {} with arguments {}", checkClass.toString(),
-                    Stream.of(constructorArgumentTypes).map(Class::toString).collect(Collectors.joining(",")));
-        }
-        catch (final InvocationTargetException oops)
-        {
-            logger.error("Unable to create a configurable instance of {}. Reason {}", checkClass.getSimpleName(), oops.getMessage());
-        }
-        catch (final ClassCastException | InstantiationException
-                | IllegalAccessException oops)
-        {
-            logger.error("Failed to instantiate {}, ignoring. Reason: {}",
-                    checkClass.getName(), oops.getMessage());
-        }
-        return Optional.empty();
-    }
-
-    public static <T> List<T[]> arrayifyInnerList(final List<List<T>> input, final T[] newArray)
-    {
-        return input.stream()
-                .map(innerList -> innerList.toArray(newArray))
-                .collect(Collectors.toList());
-    }
     /**
      * Loads checks that are enabled by some other means, defined by {@code isEnabled}
      *
@@ -252,13 +159,11 @@ public class CheckResourceLoader
     public <T extends Check> Set<T> loadChecks(final Predicate<Class> isEnabled,
             final Configuration configuration)
     {
-        final List<Class<?>[]> constructorArgumentTypes = arrayifyInnerList(Arrays.asList(
-                Collections.singletonList(Configuration.class),
-                Collections.emptyList()), new Class<?>[0]);
-        final List<Object[]> constructorArguments = arrayifyInnerList(Arrays.asList(
-                Collections.singletonList(configuration),
-                Collections.emptyList()), new Object[0]);
-        return this.loadChecksUsingConstructors(isEnabled, constructorArgumentTypes, constructorArguments);
+        final Class<?>[][] constructorArgumentTypes = new Class<?>[][] { { Configuration.class },
+                {} };
+        final Object[][] constructorArguments = new Object[][] { { configuration }, {} };
+        return this.loadChecksUsingConstructors(isEnabled, constructorArgumentTypes,
+                constructorArguments);
     }
 
     /**
@@ -279,6 +184,119 @@ public class CheckResourceLoader
         return loadChecks(
                 checkClass -> this.isEnabledByConfiguration(countryConfiguration, checkClass),
                 countryConfiguration);
+    }
+
+    public <T extends Check> Set<T> loadChecksUsingConstructors(
+            final Class<?>[][] constructorArgumentTypes, final Object[][] constructorArguments)
+    {
+        return this.loadChecksUsingConstructors(this::isEnabledByConfiguration,
+                constructorArgumentTypes, constructorArguments);
+    }
+
+    /**
+     * Given a list of corresponding types and arguments, try to initialize each enabled check using
+     * each constructor in order.
+     *
+     * @param isEnabled
+     *            {@link Predicate} used to determine if a check is enabled
+     * @param constructorArgumentTypes
+     *            {@link List} containing arrays of classes. Each array corresponds to one
+     *            constructor call. For example, to try a constructor that takes in two doubles but
+     *            fall back to a constructor that takes in one double, constructorArgumentTypes
+     *            would look like this: [[Double.TYPE, Double.TYPE], [Double.TYPE]]. An empty
+     *            constructor is denoted by an empty array.
+     * @param constructorArguments
+     *            {@link List} containing arrays of objects. This MUST have the same shape as
+     *            constructorArgumentTypes and the values MUST be the same types and in the same
+     *            order as constructorArgumentTypes. For example, given constructorArgumentTypes of
+     *            [[Double.TYPE, Boolean.TYPE], [Boolean.TYPE, Integer.TYPE], []],
+     *            constructorArguments needs to look like [[double, boolean], [boolean, int], []].
+     * @param <T>
+     *            Any class that extends Check.
+     * @return A set of enabled, initialized checks.
+     */
+    public <T extends Check> Set<T> loadChecksUsingConstructors(final Predicate<Class> isEnabled,
+            final Class<?>[][] constructorArgumentTypes, final Object[][] constructorArguments)
+    {
+        final Set<T> checks = new HashSet<>();
+        final Time time = Time.now();
+        try
+        {
+            final ClassPath classPath = ClassPath
+                    .from(Thread.currentThread().getContextClassLoader());
+            this.packages.forEach(packageName -> classPath.getTopLevelClassesRecursive(packageName)
+                    .forEach(classInfo ->
+                    {
+                        final Class<?> checkClass = classInfo.load();
+                        if (this.checkType.isAssignableFrom(checkClass)
+                                && !Modifier.isAbstract(checkClass.getModifiers())
+                                && isEnabled.test(checkClass)
+                                && this.checkWhiteList.map(
+                                        whitelist -> whitelist.contains(checkClass.getSimpleName()))
+                                        .orElse(true)
+                                && this.checkBlackList.map(blacklist -> !blacklist
+                                        .contains(checkClass.getSimpleName())).orElse(true))
+                        {
+                            Streams.zip(Stream.of(constructorArgumentTypes),
+                                    Stream.of(constructorArguments),
+                                    (argTypes, args) -> this.initializeCheckWithArguments(
+                                            (Class<T>) checkClass, argTypes, args))
+                                    .filter(Optional::isPresent).map(Optional::get).findFirst()
+                                    .ifPresent(checks::add);
+                        }
+                    }));
+        }
+        catch (final IOException oops)
+        {
+            throw new CoreException("Failed to discover {} classes on classpath",
+                    this.checkType.getSimpleName());
+        }
+
+        logger.info("Loaded {} {} in {}", checks.size(), this.checkType.getSimpleName(),
+                time.elapsedSince());
+        return checks;
+    }
+
+    /**
+     * Utility method to try to initialize a given check using a particular constructor.
+     * 
+     * @param checkClass
+     *            the class we want to initialize
+     * @param constructorArgumentTypes
+     *            the signature for the constructor we want to call
+     * @param constructorArguments
+     *            the arguments we want to pass to the constructor
+     * @param <T>
+     *            the type of the class we want to initialize
+     * @return an {@link Optional} containing the initialized check if the call was a success, or
+     *         empty if something went wrong.
+     */
+    private <T extends Check> Optional<T> initializeCheckWithArguments(final Class<T> checkClass,
+            final Class<?>[] constructorArgumentTypes, final Object[] constructorArguments)
+    {
+        try
+        {
+            final Constructor<T> constructor = checkClass.getConstructor(constructorArgumentTypes);
+            final T result = constructor.newInstance(constructorArguments);
+            return Optional.of(result);
+        }
+        catch (final NoSuchMethodException oops)
+        {
+            logger.info("No method found for {} with arguments {}", checkClass.toString(),
+                    Stream.of(constructorArgumentTypes).map(Class::toString)
+                            .collect(Collectors.joining(",")));
+        }
+        catch (final InvocationTargetException oops)
+        {
+            logger.error("Unable to create a configurable instance of {}. Reason {}",
+                    checkClass.getSimpleName(), oops.getMessage());
+        }
+        catch (final ClassCastException | InstantiationException | IllegalAccessException oops)
+        {
+            logger.error("Failed to instantiate {}, ignoring. Reason: {}", checkClass.getName(),
+                    oops.getMessage());
+        }
+        return Optional.empty();
     }
 
     private boolean isEnabledByConfiguration(final Class checkClass)

--- a/src/test/java/org/openstreetmap/atlas/checks/base/checks/ContextAwareTestCheck.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/checks/ContextAwareTestCheck.java
@@ -1,0 +1,34 @@
+package org.openstreetmap.atlas.checks.base.checks;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+import java.util.Optional;
+
+public class ContextAwareTestCheck extends BaseCheck<Long>
+{
+    private final int data;
+
+    public ContextAwareTestCheck(final Configuration configuration, final int otherData)
+    {
+        super(configuration);
+        this.data = otherData;
+    }
+
+    @Override public boolean validCheckForObject(final AtlasObject object)
+    {
+        return false;
+    }
+
+    @Override protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        return Optional.empty();
+    }
+
+    public int getData()
+    {
+        return this.data;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/base/checks/ContextAwareTestCheck.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/base/checks/ContextAwareTestCheck.java
@@ -1,12 +1,17 @@
 package org.openstreetmap.atlas.checks.base.checks;
 
+import java.util.Optional;
+
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
-import java.util.Optional;
-
+/**
+ * A simple test Check that stores some extra data passed in through the constructor.
+ *
+ * @author nachtm
+ */
 public class ContextAwareTestCheck extends BaseCheck<Long>
 {
     private final int data;
@@ -17,18 +22,20 @@ public class ContextAwareTestCheck extends BaseCheck<Long>
         this.data = otherData;
     }
 
-    @Override public boolean validCheckForObject(final AtlasObject object)
+    public int getData()
+    {
+        return this.data;
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
     {
         return false;
     }
 
-    @Override protected Optional<CheckFlag> flag(final AtlasObject object)
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         return Optional.empty();
-    }
-
-    public int getData()
-    {
-        return this.data;
     }
 }


### PR DESCRIPTION
### Description:

Currently, CheckResourceLoader.loadChecks() assumes that the only constructors present on a check are `Check(Configuration config)` and/or `Check()`. However, it would be nice to potentially pass in some extra context through subclasses. For example, I can imagine a `ContextAwareCheck` that subclasses `Check` and stores some extra data passed in at initialization time. 

This PR introduces a new method on `CheckResourceLoader` to allow for this called `loadChecksUsingConstructors`. In the following example, we define the following priority over constructor calls with `constructorArgumentTypes`:
 - `new Check(Configuration config, int value)`
 - `new Check(Configuration config)`
 - `new Check()`

Checks get initialized with the first argument set for which they have a constructor, so this priority list should be structured from specific to general.

```
final Class<?>[][] constructorArgumentTypes = new Class<?>[][] {
                { Configuration.class, Integer.TYPE }, { Configuration.class }, {} };
final Object[][] constructorArguments = new Object[][] { { configuration, 12 },
                { configuration }, {} };
final Set<Check> checks = checkResourceLoader
                .loadChecksUsingConstructors(constructorArgumentTypes, constructorArguments);
```

I've refactored the other `loadChecks` methods to use this under the hood to keep things clean and de-duplicated. 

### Potential Impact:

Just a new function to use. Everything is backwards-compatible. 

### Unit Test Approach:

Added a unit test using an example subclass. Also ran locally on a small country to verify that normal checks work as expected.

### Test Results:

All tests passing. Small country ran all checks as expected.
