### PR TITLE
[FlagDatabase] Set feature flag_id as foreign key

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
@@ -56,7 +56,7 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
     private static final String OSM_ID_LEGACY = "osmid";
     private static final String CREATE_FLAG_SQL = "INSERT INTO flag(flag_id, check_name, instructions, date_created) VALUES (?,?,?,?);";
     private static final String CREATE_FEATURE_SQL = String.format(
-            "INSERT INTO feature (flag_id, geom, osm_id, atlas_id, iso_country_code, tags, item_type, date_created) VALUES (?,%s,?,?,?,?);",
+            "INSERT INTO feature (flag_id, geom, osm_id, atlas_id, iso_country_code, tags, item_type, date_created) VALUES ((SELECT id FROM flag WHERE flag_id = ? LIMIT 1),%s,?,?,?,?);",
             "ST_GeomFromGeoJSON(?), ?, ?");
     private static final int THREE = 3;
     private static final int FOUR = 4;

--- a/src/main/resources/org/openstreetmap/atlas/checks/database/schema.sql
+++ b/src/main/resources/org/openstreetmap/atlas/checks/database/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS flag (
 	flag_id text not null,
 	check_name text not null,
 	instructions text not null,
-	generator text,
+	run_uri text,
 	software_version varchar(8),
 	date_created timestamp
 );

--- a/src/main/resources/org/openstreetmap/atlas/checks/database/schema.sql
+++ b/src/main/resources/org/openstreetmap/atlas/checks/database/schema.sql
@@ -7,14 +7,14 @@ CREATE TABLE IF NOT EXISTS flag (
 	flag_id text not null,
 	check_name text not null,
 	instructions text not null,
-	run_uri text,
-	integrity_version varchar(8),
+	generator text,
+	software_version varchar(8),
 	date_created timestamp
 );
 
 CREATE TABLE IF NOT EXISTS feature (
   id serial primary key,
-  flag_id text not null,
+  flag_id integer references flag(id),
   geom geometry not null,
   osm_id bigint not null,
   atlas_id bigint not null,


### PR DESCRIPTION
### Description:

I've updated the `flag_id` column in the `feature` table to reference the `flag.id` column (instead of `flag.flag_id`) in the `flag` table. 

This issue was exposed when creating a view (as a QGIS layer) that left joins the flag & feature table together on the `flag_id` (non unique check flag identifier) column:
```SQL
CREATE MATERIALIZED VIEW IF NOT EXISTS vw_check_flags AS
SELECT feature.id, feature.flag_id, geom, osm_id, atlas_id, iso_country_code, item_type, tags, flag.check_name, flag.instructions
FROM flag, feature
WHERE feature.flag_id = flag.id
``` 

I've also updated the software version column name to be more generic.

### Potential Impact:

The value and data type in the feature table has changed from text to integer. Also, the software version column name has changed. This should not be a problem given we don't have a switch built in the populate this column.

### Unit Test Approach:

No changes to unit tests, however, I've tested that the flag_id foreign key column correctly populates the feature table.

### Test Results:

Table populates data as expected.

<img width="967" alt="Screen Shot 2019-09-30 at 8 38 18 PM" src="https://user-images.githubusercontent.com/1947857/65932372-48707180-e3c2-11e9-8525-f2cbdc074bc6.png">


