### PR TITLE
[GeneralizedCoastlineCheck] Added source=PGS tag filter

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -147,7 +147,7 @@
   "GeneralizedCoastlineCheck": {
     "node.minimum.distance": 100.0,
     "node.minimum.threshold": 30.0,
-    "PGSfilter": true,
+    "coastline.tags.filters": "source->PGS",
     "challenge": {
       "description": "Coastlines whose nodes are too far apart.",
       "blurb": "Ways",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -147,6 +147,7 @@
   "GeneralizedCoastlineCheck": {
     "node.minimum.distance": 100.0,
     "node.minimum.threshold": 30.0,
+    "PGSfilter": true,
     "challenge": {
       "description": "Coastlines whose nodes are too far apart.",
       "blurb": "Ways",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
@@ -39,7 +39,7 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
     private static final long serialVersionUID = 1576217971819771231L;
     private final double percentageThreshold;
     private final Distance minimumDistanceBetweenNodes;
-    private static TaggableFilter coastlineTagFilter;
+    private final TaggableFilter coastlineTagFilter;
 
     public GeneralizedCoastlineCheck(final Configuration configuration)
     {
@@ -63,9 +63,8 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        final Predicate<Relation> memberIsCoastline = relation -> isCoastline(relation);
-        final Predicate<Relation> memberIsSourcePGS = relation -> this.coastlineTagFilter
-                .test(relation);
+        final Predicate<Relation> memberIsCoastline = this::isCoastline;
+        final Predicate<Relation> memberIsSourcePGS = this.coastlineTagFilter::test;
 
         return object instanceof LineItem
                 && (isCoastline(object) && this.coastlineTagFilter.test(object)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
@@ -162,7 +162,7 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
                 .collect(Collectors.toList());
     }
 
-   /**
+    /**
      * Given a coastline {@link LineItem}, extract the {@link Location}s of offending {@link Angle}s
      *
      * @param coast

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
@@ -162,7 +162,7 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
                 .collect(Collectors.toList());
     }
 
-    /**
+   /**
      * Given a coastline {@link LineItem}, extract the {@link Location}s of offending {@link Angle}s
      *
      * @param coast

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
@@ -161,8 +161,8 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
                 .map(segment -> segment.start().midPoint(segment.end()))
                 .collect(Collectors.toList());
     }
-    
-     /**
+
+    /**
      * Given a coastline {@link LineItem}, extract the {@link Location}s of offending {@link Angle}s
      *
      * @param coast
@@ -180,7 +180,7 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
             return resultList;
         }
         return Collections.emptyList();
-    }    
+    }
 
     /**
      * This method checks if a {@link AtlasObject} has relation members and satisfies the predicate.

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTest.java
@@ -72,7 +72,7 @@ public class GeneralizedCoastlineCheckTest
     {
         this.verifier.actual(this.setup.getOneLineSegmentGeneralizedNoSource(),
                 new GeneralizedCoastlineCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"GeneralizedCoastlineCheck\":{\"PGSfilter\": false}}")));
+                        "{\"GeneralizedCoastlineCheck\":{\"coastline.tags.filters\": \"\"}}")));
         this.verifier.verifyExpectedSize(1);
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTest.java
@@ -68,6 +68,31 @@ public class GeneralizedCoastlineCheckTest
     }
 
     @Test
+    public void oneLineSegmentGeneralizedNoSource()
+    {
+        this.verifier.actual(this.setup.getOneLineSegmentGeneralizedNoSource(),
+                new GeneralizedCoastlineCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"GeneralizedCoastlineCheck\":{\"PGSfilter\": false}}")));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void oneLineSegmentGeneralizedSourcePGS()
+    {
+        this.verifier.actual(this.setup.getOneLineSegmentGeneralizedSourcePGS(),
+                new GeneralizedCoastlineCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void oneLineSegmentGeneralizedSourceSurvey()
+    {
+        this.verifier.actual(this.setup.getOneLineSegmentGeneralizedSourceSurvey(),
+                new GeneralizedCoastlineCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void oneLineSegmentNotGeneralized()
     {
         this.verifier.actual(this.setup.getOneLineSegmentNotGeneralized(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTestRule.java
@@ -129,7 +129,6 @@ public class GeneralizedCoastlineCheckTestRule extends CoreTestRule
                     @Loc(value = GENERALIZED_TWENTYFOUR), @Loc(value = GENERALIZED_TWENTYFIVE) }) })
     private Atlas oneLineGeneralizedOneLineNotGeneralized;
 
-
     @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
             @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }) })
     private Atlas oneLineSegmentGeneralizedSourcePGS;
@@ -146,7 +145,6 @@ public class GeneralizedCoastlineCheckTestRule extends CoreTestRule
             @Loc(value = GENERALIZED_TWENTYSIX), @Loc(value = GENERALIZED_TWENTYSEVEN),
             @Loc(value = GENERALIZED_TWENTYEIGHT) }) })
     private Atlas withSharpAngle;
-
 
     public Atlas getExactThresholdGeneralized()
     {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTestRule.java
@@ -50,7 +50,7 @@ public class GeneralizedCoastlineCheckTestRule extends CoreTestRule
     @TestAtlas(
             // One generalized coastline, one noisy line
             lines = {
-                    @Line(id = "1", tags = "natural=coastline", coordinates = {
+                    @Line(id = "1", tags = { "natural=coastline", "source=PGS" }, coordinates = {
                             @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }),
                     @Line(id = "2", tags = "natural=scrub", coordinates = {
                             @Loc(value = GENERALIZED_TWENTYTWO), @Loc(value = GENERALIZED_SIX) }) },
@@ -58,7 +58,7 @@ public class GeneralizedCoastlineCheckTestRule extends CoreTestRule
             nodes = { @Node(id = "3", coordinates = @Loc(value = GENERALIZED_EIGHT)),
                     @Node(id = "4") },
             // Relation containing all the lines and nodes in this test atlas
-            relations = { @Relation(tags = { "natural=coastline" }, members = {
+            relations = { @Relation(tags = { "natural=coastline", "source=PGS" }, members = {
                     @Member(id = "1", role = "na", type = "line"),
                     @Member(id = "2", role = "na", type = "line"),
                     @Member(id = "3", role = "na", type = "node"),
@@ -66,62 +66,76 @@ public class GeneralizedCoastlineCheckTestRule extends CoreTestRule
     private Atlas withSingleRelationGeneralized;
 
     @TestAtlas(lines = {
-            @Line(id = "1", tags = "natural=coastline", coordinates = {
+            @Line(id = "1", tags = { "natural=coastline", "source=PGS" }, coordinates = {
                     @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }),
-            @Line(id = "2", tags = "natural=coastline", coordinates = {
+            @Line(id = "2", tags = { "natural=coastline", "source=PGS" }, coordinates = {
                     @Loc(value = GENERALIZED_TEN), @Loc(value = GENERALIZED_TWELVE) }) },
             // Noisy nodes
             nodes = { @Node(id = "3", coordinates = @Loc(value = GENERALIZED_EIGHT)),
                     @Node(id = "4") }, relations = {
                             // Nested relation
-                            @Relation(id = "123", tags = { "natural=coastline" }, members = {
-                                    @Member(id = "1", role = "na", type = "line"),
-                                    @Member(id = "2", role = "na", type = "line"),
-                                    @Member(id = "3", role = "na", type = "node"),
-                                    @Member(id = "4", role = "na", type = "node") }),
+                            @Relation(id = "123", tags = { "natural=coastline",
+                                    "source=PGS" }, members = {
+                                            @Member(id = "1", role = "na", type = "line"),
+                                            @Member(id = "2", role = "na", type = "line"),
+                                            @Member(id = "3", role = "na", type = "node"),
+                                            @Member(id = "4", role = "na", type = "node") }),
 
                             // Outer relation
-                            @Relation(tags = { "natural=coastline" }, members = {
+                            @Relation(tags = { "natural=coastline", "source=PGS" }, members = {
                                     @Member(id = "123", role = "na", type = "relation") }) })
     private Atlas withNestedRelationGeneralized;
 
-    @TestAtlas(lines = { @Line(tags = { "natural=coastline" }, coordinates = {
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
             @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }) })
     private Atlas oneLineSegmentGeneralized;
 
-    @TestAtlas(lines = { @Line(tags = { "natural=coastline" }, coordinates = {
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
             @Loc(value = GENERALIZED_THREE), @Loc(value = GENERALIZED_FOUR) }) })
     private Atlas oneLineSegmentNotGeneralized;
 
-    @TestAtlas(lines = {
-            @Line(coordinates = { @Loc(value = GENERALIZED_FIVE), @Loc(value = GENERALIZED_SIX),
-                    @Loc(value = GENERALIZED_SEVEN), @Loc(value = GENERALIZED_EIGHT),
-                    @Loc(value = GENERALIZED_NINE), @Loc(value = GENERALIZED_TEN),
-                    @Loc(value = GENERALIZED_ELEVEN) }, tags = { "natural=coastline" }) })
+    @TestAtlas(lines = { @Line(coordinates = { @Loc(value = GENERALIZED_FIVE),
+            @Loc(value = GENERALIZED_SIX), @Loc(value = GENERALIZED_SEVEN),
+            @Loc(value = GENERALIZED_EIGHT), @Loc(value = GENERALIZED_NINE),
+            @Loc(value = GENERALIZED_TEN),
+            @Loc(value = GENERALIZED_ELEVEN) }, tags = { "natural=coastline", "source=PGS" }) })
     private Atlas moreThanThresholdGeneralized;
 
-    @TestAtlas(lines = {
-            @Line(tags = { "natural=coastline" }, coordinates = { @Loc(value = GENERALIZED_TWELVE),
-                    @Loc(value = GENERALIZED_THIRTEEN), @Loc(value = GENERALIZED_FOURTEEN),
-                    @Loc(value = GENERALIZED_FIFTEEN), @Loc(value = GENERALIZED_SIXTEEN),
-                    @Loc(value = GENERALIZED_SEVENTEEN), @Loc(value = GENERALIZED_EIGHTEEN),
-                    @Loc(value = GENERALIZED_NINETEEN), @Loc(value = GENERALIZED_TWENTY) }) })
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
+            @Loc(value = GENERALIZED_TWELVE), @Loc(value = GENERALIZED_THIRTEEN),
+            @Loc(value = GENERALIZED_FOURTEEN), @Loc(value = GENERALIZED_FIFTEEN),
+            @Loc(value = GENERALIZED_SIXTEEN), @Loc(value = GENERALIZED_SEVENTEEN),
+            @Loc(value = GENERALIZED_EIGHTEEN), @Loc(value = GENERALIZED_NINETEEN),
+            @Loc(value = GENERALIZED_TWENTY) }) })
     private Atlas lessThanThresholdNotGeneralized;
 
-    @TestAtlas(lines = { @Line(tags = { "natural=coastline" }, coordinates = {
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
             @Loc(value = GENERALIZED_TWENTYONE), @Loc(value = GENERALIZED_TWENTYTWO),
             @Loc(value = GENERALIZED_TWENTYTHREE) }) })
     private Atlas exactThresholdGeneralized;
 
     @TestAtlas(lines = {
-            @Line(tags = { "natural=coastline" }, coordinates = { @Loc(value = GENERALIZED_TWELVE),
-                    @Loc(value = GENERALIZED_THIRTEEN), @Loc(value = GENERALIZED_FOURTEEN),
-                    @Loc(value = GENERALIZED_FIFTEEN), @Loc(value = GENERALIZED_SIXTEEN),
-                    @Loc(value = GENERALIZED_SEVENTEEN), @Loc(value = GENERALIZED_EIGHTEEN),
-                    @Loc(value = GENERALIZED_NINETEEN), @Loc(value = GENERALIZED_TWENTY) }),
-            @Line(tags = { "natural=coastline" }, coordinates = {
+            @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
+                    @Loc(value = GENERALIZED_TWELVE), @Loc(value = GENERALIZED_THIRTEEN),
+                    @Loc(value = GENERALIZED_FOURTEEN), @Loc(value = GENERALIZED_FIFTEEN),
+                    @Loc(value = GENERALIZED_SIXTEEN), @Loc(value = GENERALIZED_SEVENTEEN),
+                    @Loc(value = GENERALIZED_EIGHTEEN), @Loc(value = GENERALIZED_NINETEEN),
+                    @Loc(value = GENERALIZED_TWENTY) }),
+            @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
                     @Loc(value = GENERALIZED_TWENTYFOUR), @Loc(value = GENERALIZED_TWENTYFIVE) }) })
     private Atlas oneLineGeneralizedOneLineNotGeneralized;
+
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
+            @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }) })
+    private Atlas oneLineSegmentGeneralizedSourcePGS;
+
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=survey" }, coordinates = {
+            @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }) })
+    private Atlas oneLineSegmentGeneralizedSourceSurvey;
+
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline" }, coordinates = {
+            @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }) })
+    private Atlas oneLineSegmentGeneralizedNoSource;
 
     public Atlas getExactThresholdGeneralized()
     {
@@ -146,6 +160,21 @@ public class GeneralizedCoastlineCheckTestRule extends CoreTestRule
     public Atlas getOneLineSegmentGeneralized()
     {
         return this.oneLineSegmentGeneralized;
+    }
+
+    public Atlas getOneLineSegmentGeneralizedNoSource()
+    {
+        return this.oneLineSegmentGeneralizedNoSource;
+    }
+
+    public Atlas getOneLineSegmentGeneralizedSourcePGS()
+    {
+        return this.oneLineSegmentGeneralizedSourcePGS;
+    }
+
+    public Atlas getOneLineSegmentGeneralizedSourceSurvey()
+    {
+        return this.oneLineSegmentGeneralizedSourceSurvey;
     }
 
     public Atlas getOneLineSegmentNotGeneralized()


### PR DESCRIPTION
### Description:

Added a `source=PGS` tag filter to the GeneralizedCoastlineCheck.  Features with `source=PGS` tag are often generalized so this filter was added to filter for those features specifically. 

### Potential Impact:

This will filter out generalized coastline features that do not have the tag `source=PGS` by default so the number of features found by this check previously will change. The filter for `source=PGS` is configurable since it was added to the configuration.json.


### Unit Test Approach:

Updated the existing unit tests to have test atlases with `source=PGS`. Additional tests were added for testing `source=PGS` tag filtering.

### Test Results:

Unit tests pass
