### PR TITLE
[FloatingEdgeCheck] No longer flag floating edges in airports

### DIFF
--- a/docs/checks/floatingEdgeCheck.md
+++ b/docs/checks/floatingEdgeCheck.md
@@ -2,7 +2,7 @@
 
 #### Description
 
-This check will look for any edges (Roads) that do not contain any incoming or outgoing edges. 
+This check will look for any edges (Roads) outside of airports that do not contain any incoming or outgoing edges.
 The appearance on the map would be that of a road simply floating in the middle of nowhere. 
 No one for any navigation, no ability to enter the edge (road) from any point and no way to exit it. 
 To resolve the issue a mapper would either remove the edge as invalid or connect it to the surrounding

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -19,13 +19,13 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
- * This check will look for any edges that do not contain any incoming or outgoing edges. The
- * appearance on the map would be that of a road simply floating in the middle of nowhere. No way
- * for any navigation, no ability to enter the {@link Edge} (road) from any point and no way to exit
- * it. To resolve the issue a mapper would either remove the edge as invalid or connect it to a
- * connected set of edges.
+ * This check will look for any edges outside of airport boundaries that do not contain any incoming
+ * or outgoing edges. The appearance on the map would be that of a road simply floating in the
+ * middle of nowhere. No way for any navigation, no ability to enter the {@link Edge} (road) from
+ * any point and no way to exit it. To resolve the issue a mapper would either remove the edge as
+ * invalid or connect it to a connected set of edges.
  *
- * @author cuthbertm, gpogulsky
+ * @author cuthbertm, gpogulsky, seancoulter
  */
 public class FloatingEdgeCheck extends BaseCheck<Long>
 {

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
@@ -53,6 +53,13 @@ public class FloatingEdgeCheckTest
     }
 
     @Test
+    public void testFloatingEdgeContainedInAirportPolygon()
+    {
+        this.verifier.actual(this.setup.floatingEdgeInAirportPolygon(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testInlineConfigFloatingEdge()
     {
         this.verifier.actual(this.setup.floatingEdgeAtlas(), this.minimumHighwayCheck);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
@@ -23,6 +23,13 @@ public class FloatingEdgeCheckTest
                     "{\"FloatingEdgeCheck\":{\"highway.minimum\": \"PRIMARY_LINK\",\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
 
     @Test
+    public void testAirportIntersectingEdge()
+    {
+        this.verifier.actual(this.setup.airportAtlas(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testBidirectionalFloatingEdge()
     {
         this.verifier.actual(this.setup.floatingBidirectionalEdgeAtlas(), this.check);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
@@ -20,6 +20,14 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
     private static final String TEST_2 = "37.33531,-122.009566";
     private static final String TEST_3 = "37.3314171,-122.0304871";
 
+    private static final String TEST_4 = "47.6027,-122.3182";
+    private static final String TEST_5 = "47.6027,-122.3130";
+    private static final String TEST_6 = "47.6008,-122.3130";
+    private static final String TEST_7 = "47.6009,-122.3179";
+
+    private static final String TEST_8 = "47.6025,-122.3181";
+    private static final String TEST_9 = "47.6011,-122.3177";
+
     private static final String LOCATION_1 = "1.11,1.11";
     private static final String LOCATION_2 = "1.12,1.12";
 
@@ -56,6 +64,14 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_1) }, tags = { "highway=SECONDARY" }) })
     private Atlas floatingBidirectionalEdgeAtlas;
 
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_4)),
+            @Node(coordinates = @Loc(value = TEST_5)), @Node(coordinates = @Loc(value = TEST_6)),
+            @Node(coordinates = @Loc(value = TEST_7)), @Node(coordinates = @Loc(value = TEST_8)), @Node(coordinates = @Loc(value = TEST_9)) }, edges = {
+            @Edge(coordinates = { @Loc(value = TEST_8), @Loc(value = TEST_9) }, tags = {
+                    "highway=SECONDARY" }) }, areas = {
+            @Area(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5), @Loc(value = TEST_6), @Loc(value = TEST_7) }, tags = { "aeroway=taxiway" }) })
+    private Atlas floatingEdgeInAirportAtlas;
+
     @TestAtlas(nodes = {
             @Node(coordinates = @Loc(value = LOCATION_1), tags = { "synthetic_boundary_node=YES" }),
             @Node(coordinates = @Loc(value = LOCATION_2)) }, edges = {
@@ -78,6 +94,11 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
     public Atlas airportAtlas()
     {
         return this.airportAtlas;
+    }
+
+    public Atlas floatingEdgeInAirportPolygon()
+    {
+        return this.floatingEdgeInAirportAtlas;
     }
 
     public Atlas connectedEdgeAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
@@ -6,6 +6,7 @@ package org.openstreetmap.atlas.checks.validation.linear.edges;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
@@ -21,6 +22,16 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
 
     private static final String LOCATION_1 = "1.11,1.11";
     private static final String LOCATION_2 = "1.12,1.12";
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)), @Node(coordinates = @Loc(value = TEST_3)),
+            @Node(coordinates = @Loc(value = LOCATION_1)),
+            @Node(coordinates = @Loc(value = LOCATION_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=SECONDARY" }) }, areas = {
+                                    @Area(coordinates = { @Loc(value = TEST_1),
+                                            @Loc(value = TEST_2) }, tags = { "aeroway=taxiway" }) })
+    private Atlas airportAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
             @Node(coordinates = @Loc(value = TEST_2)),
@@ -64,6 +75,11 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_2) }, tags = { "highway=SECONDARY" }) })
     private Atlas mixedAtlas;
 
+    public Atlas airportAtlas()
+    {
+        return this.airportAtlas;
+    }
+
     public Atlas connectedEdgeAtlas()
     {
         return this.connectedEdgeAtlas;
@@ -88,4 +104,5 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
     {
         return this.syntheticBorderAtlas;
     }
+
 }


### PR DESCRIPTION
### Description:

This PR changes FloatingEdgeCheck so that it no longer flags Edges that are within/overlap an airport area. Edge networks found in airports often do not follow the same navigation standards as other road networks and so they shouldn't be subject to the same Check logic.

### Potential Impact:

FloatingEdgeCheck should not flag floating edges that are in airports now.

### Unit Test Approach:

Unit tests with overlap on an airport taxiway, and containment within an airport

### Test Results:

Unit tests pass

