### PR TITLE
[Flag Database] Fix performance issue

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
@@ -137,31 +137,6 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
 
     }
 
-    /**
-     * Add CheckFlag values to parameterized sql INSERT statement
-     *
-     * @param sql
-     *            - PreparedStatement to add parameterized values to
-     * @param flag
-     *            - CheckFlag to insert into flag table
-     */
-    public void batchFlagStatement(final PreparedStatement sql, final CheckFlag flag)
-    {
-        try
-        {
-            sql.setString(1, flag.getIdentifier());
-            sql.setString(2, flag.getChallengeName().orElse(""));
-            sql.setString(THREE, flag.getInstructions().replace("\n", " ").replace("'", "''"));
-            sql.setObject(FOUR, this.timestamp);
-
-            sql.executeUpdate();
-        }
-        catch (final SQLException error)
-        {
-            logger.error("Unable to create Flag {} SQL statement", flag.getIdentifier(), error);
-        }
-    }
-
     /***
      * Create database schema from schema.sql resource file.
      *
@@ -224,48 +199,7 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
                     {
 
                         final List<String> lines = reader.lines().collect(Collectors.toList());
-                        // This counter is used to batch feature records
-                        int counter = 0;
-
-                        for (final String line : lines)
-                        {
-                            final JsonObject parsedFlag = new JsonParser().parse(line)
-                                    .getAsJsonObject();
-                            final JsonArray features = this.filterOutPointsFromGeojson(
-                                    parsedFlag.get(FEATURES).getAsJsonArray());
-                            final CheckFlag flag = gson.fromJson(line, CheckFlag.class);
-
-                            this.batchFlagStatement(flagSqlStatement, flag);
-                            final int flagRecordId;
-                            counter += features.size();
-
-                            try
-                            {
-                                final ResultSet resultSet = flagSqlStatement.getGeneratedKeys();
-                                if (resultSet.next())
-                                {
-                                    flagRecordId = resultSet.getInt(1);
-
-                                    StreamSupport.stream(features.spliterator(), false)
-                                            .forEach(feature -> this.batchFlagFeatureStatement(
-                                                    featureSqlStatement, flag, flagRecordId,
-                                                    feature.getAsJsonObject()));
-                                }
-                                if (counter >= BATCH_SIZE)
-                                {
-                                    featureSqlStatement.executeBatch();
-                                    logger.debug("Batching {} features.", counter);
-                                    counter = 0;
-                                }
-                            }
-                            catch (final SQLException failure)
-                            {
-                                logger.error("Error creating Flag record.", failure);
-                            }
-                        }
-
-                        featureSqlStatement.executeBatch();
-                        logger.debug("Batching the remaining {} features.", counter);
+                        this.processCheckFlags(lines, flagSqlStatement, featureSqlStatement);
 
                     }
                     catch (final IOException error)
@@ -288,6 +222,31 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
         logger.info("Atlas Checks database upload command finished in {}.", timer.elapsedSince());
 
         return 0;
+    }
+
+    /**
+     * Add CheckFlag values to parameterized sql INSERT statement
+     *
+     * @param sql
+     *            - PreparedStatement to add parameterized values to
+     * @param flag
+     *            - CheckFlag to insert into flag table
+     */
+    public void executeFlagStatement(final PreparedStatement sql, final CheckFlag flag)
+    {
+        try
+        {
+            sql.setString(1, flag.getIdentifier());
+            sql.setString(2, flag.getChallengeName().orElse(""));
+            sql.setString(THREE, flag.getInstructions().replace("\n", " ").replace("'", "''"));
+            sql.setObject(FOUR, this.timestamp);
+
+            sql.executeUpdate();
+        }
+        catch (final SQLException error)
+        {
+            logger.error("Unable to create Flag {} SQL statement", flag.getIdentifier(), error);
+        }
     }
 
     @Override
@@ -369,5 +328,70 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
                 .filter(feature -> feature.has(PROPERTIES)
                         && !feature.get(PROPERTIES).getAsJsonObject().entrySet().isEmpty())
                 .collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
+    }
+
+    /**
+     * This function handles parsing each CheckFlag, and batching flag features into the database
+     * 
+     * @param lines
+     *            a List of stringified CheckFlags read in from line-delimited json
+     * @param flagSqlStatement
+     *            Flag PreparedStatement
+     * @param featureSqlStatement
+     *            Feature PreparedStatement
+     */
+    private void processCheckFlags(final List<String> lines,
+            final PreparedStatement flagSqlStatement, final PreparedStatement featureSqlStatement)
+    {
+        int counter = 0;
+
+        try
+        {
+            for (final String line : lines)
+            {
+                final JsonObject parsedFlag = new JsonParser().parse(line).getAsJsonObject();
+                final JsonArray features = this
+                        .filterOutPointsFromGeojson(parsedFlag.get(FEATURES).getAsJsonArray());
+                final CheckFlag flag = gson.fromJson(line, CheckFlag.class);
+                final int flagRecordId;
+
+                // First check if the number of features in our batch is less than the maximum
+                if (counter + features.size() > BATCH_SIZE)
+                {
+                    featureSqlStatement.executeBatch();
+                    logger.debug("Batching {} features.", counter);
+                    counter = 0;
+                }
+
+                // Add flag record to database
+                this.executeFlagStatement(flagSqlStatement, flag);
+
+                try (ResultSet resultSet = flagSqlStatement.getGeneratedKeys())
+                {
+                    if (resultSet.next())
+                    {
+                        // Save flag record unique id to use for feature record
+                        flagRecordId = resultSet.getInt(1);
+
+                        StreamSupport.stream(features.spliterator(), false)
+                                .forEach(feature -> this.batchFlagFeatureStatement(
+                                        featureSqlStatement, flag, flagRecordId,
+                                        feature.getAsJsonObject()));
+
+                        counter += features.size();
+                    }
+
+                }
+            }
+
+            // Execute the remaining features
+            featureSqlStatement.executeBatch();
+            logger.debug("Batching the remaining {} features.", counter);
+
+        }
+        catch (final SQLException failure)
+        {
+            logger.error("Error creating Flag record.", failure);
+        }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
@@ -197,10 +197,8 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
                             PreparedStatement featureSqlStatement = databaseConnection
                                     .prepareStatement(CREATE_FEATURE_SQL))
                     {
-
                         final List<String> lines = reader.lines().collect(Collectors.toList());
                         this.processCheckFlags(lines, flagSqlStatement, featureSqlStatement);
-
                     }
                     catch (final IOException error)
                     {
@@ -344,7 +342,6 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
             final PreparedStatement flagSqlStatement, final PreparedStatement featureSqlStatement)
     {
         int counter = 0;
-
         try
         {
             for (final String line : lines)
@@ -383,11 +380,9 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
 
                 }
             }
-
             // Execute the remaining features
             featureSqlStatement.executeBatch();
             logger.debug("Batching the remaining {} features.", counter);
-
         }
         catch (final SQLException failure)
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
@@ -377,7 +377,6 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
 
                         counter += features.size();
                     }
-
                 }
             }
             // Execute the remaining features

--- a/src/test/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandTest.java
@@ -71,7 +71,7 @@ public class FlagDatabaseSubCommandTest
         final String flag = this.getResource("checkflags1.log").get(0);
         final CheckFlag checkFlag = gson.fromJson(flag, CheckFlag.class);
 
-        command.batchFlagStatement(this.preparedStatement, checkFlag);
+        command.executeFlagStatement(this.preparedStatement, checkFlag);
 
         Mockito.verify(this.preparedStatement).executeUpdate();
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandTest.java
@@ -58,7 +58,7 @@ public class FlagDatabaseSubCommandTest
         final CheckFlag checkFlag = gson.fromJson(flag, CheckFlag.class);
         final JsonElement feature = new JsonParser().parse(flag).getAsJsonObject().get("features");
 
-        command.batchFlagFeatureStatement(this.preparedStatement, checkFlag,
+        command.batchFlagFeatureStatement(this.preparedStatement, checkFlag, 1,
                 feature.getAsJsonArray().get(0).getAsJsonObject());
 
         Mockito.verify(this.preparedStatement).addBatch();
@@ -73,7 +73,7 @@ public class FlagDatabaseSubCommandTest
 
         command.batchFlagStatement(this.preparedStatement, checkFlag);
 
-        Mockito.verify(this.preparedStatement).addBatch();
+        Mockito.verify(this.preparedStatement).executeUpdate();
     }
 
     @Test


### PR DESCRIPTION
### Description:

This makes a couple structural updates to the FlagDatabaseSubCommand in order to fix a performance issue introduced in (#194). Adding a subquery to the feature `INSERT` statement is an expensive operation given there's over 13 million flagged features in the world.

We can no longer batch the flag records because we need to store and pass the primary key to the feature table. Given that, I put a counter in place to batch 1000 feature records at a time.

### Potential Impact:

I changed the name and method signature of the public sub command function from batchFlagStatement to executeFlagStatement. This forced me to update the unit tests as well

### Unit Test Approach:

Updated mock unit tests to verify the right jdbc function was getting called.

### Test Results:

Tested the performance on various checkflag sized outputs.

| size   | flags   | features | runtime (before) | runtime (after) |
|--------|---------|----------|------------------|-----------------|
| 6.3MB  | 24,147  | 54,142   | 2.5 min          | 23 seconds      |
| 13MB   | 73,513  | 131,230  | 29.707 min       | 45.550 seconds  |
| 52.3MB | 150,310 | 230,863  |    TODO              | 2.115 minutes   |

java args: `-Xms10240m -Xmx10240m`

