### PR TITLE
FlagDatabaseSubCommand: Add Meta Data Arguments

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommand.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.checks.database;
 
+import static org.openstreetmap.atlas.checks.constants.CommonConstants.EMPTY_STRING;
 import static org.openstreetmap.atlas.checks.utility.FileUtility.LogOutputFileType;
 import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.FEATURES;
 import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.PROPERTIES;
@@ -53,9 +54,11 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
 {
     private static final String FLAG_PATH_INPUT = "flag_path";
     private static final String DATABASE_URL_INPUT = "database_url";
+    private static final String RUN_URI_INPUT = "run_uri";
+    private static final String SOFTWARE_VERSION_INPUT = "software_version";
     private static final String ISO_COUNTRY_CODE = "iso_country_code";
     private static final String OSM_ID_LEGACY = "osmid";
-    private static final String CREATE_FLAG_SQL = "INSERT INTO flag(flag_id, check_name, instructions, date_created) VALUES (?,?,?,?);";
+    private static final String CREATE_FLAG_SQL = "INSERT INTO flag(flag_id, check_name, instructions, run_uri, software_version, date_created) VALUES (?,?,?,?,?,?);";
     private static final String CREATE_FEATURE_SQL = String.format(
             "INSERT INTO feature (flag_id, geom, osm_id, atlas_id, iso_country_code, tags, item_type, date_created) VALUES (?,%s,?,?,?,?);",
             "ST_GeomFromGeoJSON(?), ?, ?");
@@ -237,7 +240,11 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
             sql.setString(1, flag.getIdentifier());
             sql.setString(2, flag.getChallengeName().orElse(""));
             sql.setString(THREE, flag.getInstructions().replace("\n", " ").replace("'", "''"));
-            sql.setObject(FOUR, this.timestamp);
+            sql.setString(FOUR, this.optionAndArgumentDelegate.getOptionArgument(RUN_URI_INPUT)
+                    .orElse(EMPTY_STRING));
+            sql.setString(FIVE, this.optionAndArgumentDelegate
+                    .getOptionArgument(SOFTWARE_VERSION_INPUT).orElse(EMPTY_STRING));
+            sql.setObject(SIX, this.timestamp);
 
             sql.executeUpdate();
         }
@@ -371,6 +378,11 @@ public class FlagDatabaseSubCommand extends AbstractAtlasShellToolsCommand
                 OptionOptionality.REQUIRED, FLAG_PATH_INPUT);
         this.registerOptionWithRequiredArgument(DATABASE_URL_INPUT, 't',
                 "Database connection string", OptionOptionality.REQUIRED, DATABASE_URL_INPUT);
+        this.registerOptionWithRequiredArgument(RUN_URI_INPUT, 'u', "Flag generation URI",
+                OptionOptionality.OPTIONAL, RUN_URI_INPUT);
+        this.registerOptionWithRequiredArgument(SOFTWARE_VERSION_INPUT, 'v',
+                "Version of the software that generated the flags.", OptionOptionality.OPTIONAL,
+                SOFTWARE_VERSION_INPUT);
         super.registerOptionsAndArguments();
     }
 

--- a/src/main/resources/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandExamplesSection.txt
+++ b/src/main/resources/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandExamplesSection.txt
@@ -2,3 +2,5 @@ Load Atlas Checks flags into a locally hosted database named flag_test on port 5
 #$ flag-database --flag_path=/path/to/log/files --database_url=127.0.0.1/flag_test
 Load Atlas Check flags into database server 17.42.121.44 with custom port, username, schema
 #$ flag-database --flag_path=/path/to/log/files --database_url=17.42.121.44:4000/flag?user=postgres&currentSchema=public
+Load Atlas Checks flags into a locally hosted database and provide flag generation meta data
+#$ flag-database --flag_path=/path/to/log/files --database_url=127.0.0.1/flag_test --run_uri=https://run.atlaschecks.fake/run/2145 --software_version=5.1.8

--- a/src/main/resources/org/openstreetmap/atlas/checks/database/schema.sql
+++ b/src/main/resources/org/openstreetmap/atlas/checks/database/schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS flag (
 	check_name text not null,
 	instructions text not null,
 	run_uri text,
-	software_version varchar(8),
+	software_version text,
 	date_created timestamp
 );
 

--- a/src/test/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/database/FlagDatabaseSubCommandTest.java
@@ -101,6 +101,9 @@ public class FlagDatabaseSubCommandTest
         final String flag = this.getResource("checkflags1.log").get(0);
         final CheckFlag checkFlag = gson.fromJson(flag, CheckFlag.class);
 
+        // Run the command with the expectation it will fail, to run the argument parser.
+        command.runSubcommand("--flag_path=/bad/path", "--database_url=none");
+        // Run executeFlagStatement that depends on arguments being parsed.
         command.executeFlagStatement(this.preparedStatement, checkFlag);
 
         Mockito.verify(this.preparedStatement).executeUpdate();
@@ -134,6 +137,10 @@ public class FlagDatabaseSubCommandTest
     {
         final FlagDatabaseSubCommand command = new FlagDatabaseSubCommand();
         final List<String> flags = this.getResource("checkflags1.log");
+
+        // Run the command with the expectation it will fail, to run the argument parser.
+        command.runSubcommand("--flag_path=/bad/path", "--database_url=none");
+        // Run processCheckFlags that depends on arguments being parsed.
         command.processCheckFlags(flags, this.preparedStatement, this.preparedStatement2);
 
         Mockito.verify(this.preparedStatement, Mockito.times(2)).executeUpdate();


### PR DESCRIPTION
### Description:

This adds two new arguments to the FlagDatabaseSubCommand: `run_uri` and `software_version`. Both are optional arguments used to pass meta data about the generation of the flags that are being uploaded. 

This also changes the type of the software_version column to remove an arbitrary character limit. 

### Potential Impact:

None, the arguments are optional. 

### Unit Test Approach:

Updated two unit tests so that the arguments can be retrieved from the `executeFlagStatement` method. 

### Test Results:

Tested uploading data to a local database using the new arguments. 

Both before the update and when not passing the arguments the flag table looked like this:
<img width="944" alt="Screen Shot 2019-10-30 at 9 18 42 AM" src="https://user-images.githubusercontent.com/24948563/67882416-70590f00-faff-11e9-954b-08dcd57b1943.png">

When the arguments were provided (tested using long and short form argument names) the flag table looked like this:
<img width="943" alt="Screen Shot 2019-10-30 at 11 39 45 AM" src="https://user-images.githubusercontent.com/24948563/67888307-1d388980-fb0a-11e9-8a8e-33a630ca2ec9.png">



