### PR TITLE
[WIP]Atlas-checks global edit time filter

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -6,6 +6,10 @@
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
     "enabled.value.default": true
   },
+  "_TimeFilter": {
+    "min": "2010-01-01",
+    "max": "2015-07-29"
+  },
   "PoolSizeCheck": {
     "surface": {
       "maximum": 1000.0,

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -7,8 +7,7 @@
     "enabled.value.default": true
   },
   "_TimeFilter": {
-    "min": "2010-01-01",
-    "max": "2015-07-29"
+
   },
   "PoolSizeCheck": {
     "surface": {

--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -498,7 +498,11 @@ public abstract class BaseCheck<T> implements Check, Serializable
     }
 
     /**
-     * @return
+     * Determines if the given AtlasObject has a last_edit_time tag, and the value of that tag is
+     * within the range specified in the configuration file.
+     *
+     * @return true if the last_edit_time tag's value is within the filter range or if it doesn't
+     *         exist, false otherwise
      */
     private boolean isWithinEditTimeRange(final AtlasObject incomingObject)
     {
@@ -513,12 +517,15 @@ public abstract class BaseCheck<T> implements Check, Serializable
                 || this.timeFilterMax == null && objectDate.isMoreThanOrEqualsTo(this.timeFilterMin)
                 || this.timeFilterMin == null && objectDate.isLessThanOrEqualsTo(this.timeFilterMax)
                 || this.timeFilterMax != null && this.timeFilterMin != null
-                && objectDate.isLessThanOrEqualsTo(this.timeFilterMax)
-                && objectDate.isMoreThanOrEqualsTo(this.timeFilterMin);
+                        && objectDate.isLessThanOrEqualsTo(this.timeFilterMax)
+                        && objectDate.isMoreThanOrEqualsTo(this.timeFilterMin);
     }
 
     /**
-     * @return
+     * Given a time string in the form YYY-MM-DD, convert it to a {@link Duration} object. The time
+     * string comes from the configuration file.
+     *
+     * @return a {@link Duration} representing the time string.
      */
     private Function<String, Duration> parseDate()
     {


### PR DESCRIPTION
### Description:

An optional, global tag-based time filter is injected into every check in the project. This is done at check instantiation time via BaseCheck. The idea here is to filter atlas objects (in BaseCheck.checkObjectFilter) for ones that have a last_edit_time tag within a specified time range. This time range is defined by min/max configurable in the project configuration file.

Note: the time range is defined under the ```_TimeFilter``` construct in the configuration file. During check loading time, this should not be read since it doesn't exist in the ```org.openstreetmap.atlas.checks.validation``` package. Another location for the filters could be in ```CheckResourceLoader```. Or if there's another place that's better, I'm happy to move it.

### Potential Impact:

Filters are optional. No impact when off, and the chance of fewer flags when they're on.

### Unit Test Approach:
Incoming

### Test Results:
Incoming

