### PR TITLE
[MapRouletteUploadCommand] Use full country name for MR uploads

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -14,12 +14,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.Task;
 import org.openstreetmap.atlas.checks.maproulette.serializer.ChallengeDeserializer;
 import org.openstreetmap.atlas.checks.maproulette.serializer.TaskDeserializer;
 import org.openstreetmap.atlas.checks.utility.FileUtility;
+import org.openstreetmap.atlas.locale.IsoCountry;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
@@ -122,10 +124,16 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                             {
                                 final Challenge challenge = this
                                         .getChallenge(task.getChallengeName(), instructions);
-                                // Prepend the challenge name with the ISO country code, if one
-                                // exists. Then try to add the task for upload
+                                // Prepend the challenge name with the full country name if one
+                                // exists, else country code if it exists. Then try to add the task
+                                // for upload
                                 countryCode.ifPresent(iso -> challenge.setName(String.join(" - ",
-                                        countryCode.get(), task.getChallengeName())));
+                                        Arrays.stream(countryCode.get().split(","))
+                                                .map(country -> IsoCountry.displayCountry(country)
+                                                        .orElse(country))
+                                                .collect(Collectors.toList()).toString()
+                                                .replace("[", "").replace("]", ""),
+                                        task.getChallengeName())));
                                 this.addTask(challenge, task);
                             }
                             catch (URISyntaxException | UnsupportedEncodingException error)


### PR DESCRIPTION
### Description:
We've been uploading MapRoulette challenges using the ISO country identifier as part of the challenge name. We should be converting ISO codes to full country names in challenge names for MapRoulette uploads, so challenge locations are more immediately obvious for editors. For example, ARG - SinkIslandCheck should become Argentina - SinkIslandCheck. This PR changes the country identifier from the ISO code to the full country name.

### Potential Impact:

Challenge naming standard is changed to include full country name, not ISO code.

### Unit Test Approach:

Same unit tests

### Test Results:

Tests pass, and a sample upload excerpt shows the following:
<img width="687" alt="image" src="https://user-images.githubusercontent.com/31253489/69767245-3431c200-1130-11ea-9537-7dd30836ac2d.png">

