### PR TITLE
RoadNameSpellingConsistencyCheck performance improvements.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameSpellingConsistencyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameSpellingConsistencyCheck.java
@@ -76,7 +76,7 @@ public class RoadNameSpellingConsistencyCheck extends BaseCheck<Long>
         // Collect all of the Edges within a search distance, then filter those that have NameTags
         // that are slightly different than edge
         final Set<Edge> inconsistentEdgeSet = new RoadNameSpellingConsistencyCheckWalker(edge,
-                this.maximumSearchDistance).collectEdges().stream().parallel()
+                this.maximumSearchDistance).collectEdges().stream()
                         .filter(incomingEdge -> !this.isFlagged(incomingEdge.getIdentifier()))
                         .filter(RoadNameSpellingConsistencyCheckWalker
                                 .isEdgeWithInconsistentSpelling(edge))

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameSpellingConsistencyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameSpellingConsistencyCheck.java
@@ -76,11 +76,10 @@ public class RoadNameSpellingConsistencyCheck extends BaseCheck<Long>
         // Collect all of the Edges within a search distance, then filter those that have NameTags
         // that are slightly different than edge
         final Set<Edge> inconsistentEdgeSet = new RoadNameSpellingConsistencyCheckWalker(edge,
-                this.maximumSearchDistance)
-                        .collectEdges().stream()
+                this.maximumSearchDistance).collectEdges().stream().parallel()
+                        .filter(incomingEdge -> !this.isFlagged(incomingEdge.getIdentifier()))
                         .filter(RoadNameSpellingConsistencyCheckWalker
                                 .isEdgeWithInconsistentSpelling(edge))
-                        .filter(incomingEdge -> !this.isFlagged(incomingEdge.getIdentifier()))
                         .collect(Collectors.toSet());
 
         // If the Walker found any inconsistent NameTag spellings

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameSpellingConsistencyCheckWalker.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameSpellingConsistencyCheckWalker.java
@@ -209,18 +209,17 @@ class RoadNameSpellingConsistencyCheckWalker extends EdgeWalker
         incomingEdgeNameAlphanumericIdentifierStrings = Arrays
                 .stream(incomingEdgeName.split(WHITESPACE_REGEX))
                 .filter(substring -> Stream.of(CJKNumbers.values())
-                                .anyMatch(cjkNumber -> substring.contains(
-                                        new String(Character.toChars(cjkNumber.getValue()))))
+                        .anyMatch(cjkNumber -> substring
+                                .contains(new String(Character.toChars(cjkNumber.getValue()))))
                         || ALPHANUMERIC_IDENTIFIER_STRING_PATTERN.matcher(substring).matches()
-                        || CHARACTER_IDENTIFIER_STRING_PATTERN.matcher(substring).matches()
-                        )
+                        || CHARACTER_IDENTIFIER_STRING_PATTERN.matcher(substring).matches())
                 .collect(Collectors.toList());
 
         final List<String> startingEdgeNameAlphanumericIdentifierStrings = Arrays
                 .stream(startingEdgeName.split(WHITESPACE_REGEX))
                 .filter(substring -> Stream.of(CJKNumbers.values())
-                        .anyMatch(cjkNumber -> substring.contains(
-                                new String(Character.toChars(cjkNumber.getValue()))))
+                        .anyMatch(cjkNumber -> substring
+                                .contains(new String(Character.toChars(cjkNumber.getValue()))))
                         || ALPHANUMERIC_IDENTIFIER_STRING_PATTERN.matcher(substring).matches()
                         || CHARACTER_IDENTIFIER_STRING_PATTERN.matcher(substring).matches())
                 .collect(Collectors.toList());


### PR DESCRIPTION
### Description:

This PR is created to improve the performance of the RoadNameSpellingConsistencyCheck <rdar://problem/57118015>

Myself and Sean performed some tests on smaller 348MB and on larger data set. We came to a conclusion that regex used in RoadNameSpellingConsistencyCheckWalker.java is consuming considerable amount of time to run the check. Used profiler in IntelliJ to understand the metrics.

Handling the logic without regex is complex. So, made few minor changes to the existing code base to reduce the time to at least few seconds.

### Potential Impact:
Execution time before changes are 78 to 82 secs for 340MB test data.
Execution time after changes are 70 to 74 secs for 340 MB test data.

### Unit Test Approach:
No changes for the tests.

### Test Results:
Profiler output on 340 MB test data is as follows:
<img width="1635" alt="Profiler_output" src="https://user-images.githubusercontent.com/16053580/70178841-92b3ee80-16a2-11ea-87b9-b67123c9483c.png">
