### PR TITLE
[MixedCaseNameCheck] Fix AtlasObject nondeterminism issue

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -25,7 +25,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  *
  * @author bbreithaupt
  */
-public class MixedCaseNameCheck extends BaseCheck<Long>
+public class MixedCaseNameCheck extends BaseCheck<String>
 {
 
     private static final long serialVersionUID = 7109483897229499466L;
@@ -120,13 +120,15 @@ public class MixedCaseNameCheck extends BaseCheck<Long>
     {
         // Valid objects are items that were OSM nodes or ways (Equivalent to Atlas nodes, points,
         // edges, lines and areas)
-        return !(object instanceof Relation) && !this.isFlagged(object.getOsmIdentifier())
+        return !(object instanceof Relation) && !this.isFlagged(this.getUniqueOSMIdentifier(object))
                 && (object.getTags().containsKey(ISOCountryTag.KEY)
                         // Must have an ISO code that is in checkNameCountries...
                         && this.checkNameCountries
                                 .contains(object.tag(ISOCountryTag.KEY).toUpperCase())
                         // And have a name tag
                         && Validators.hasValuesFor(object, NameTag.class)
+                        // And if an Edge, is a master edge
+                        && (!(object instanceof Edge) || ((Edge) object).isMasterEdge())
                         // Or it must have a specific language name tag from languageNameTags
                         || this.languageNameTags.stream()
                                 .anyMatch(key -> object.getOsmTags().containsKey(key)));
@@ -165,7 +167,7 @@ public class MixedCaseNameCheck extends BaseCheck<Long>
         // If mix case id detected, flag
         if (!mixedCaseNameTags.isEmpty())
         {
-            this.markAsFlagged(object.getOsmIdentifier());
+            this.markAsFlagged(this.getUniqueOSMIdentifier(object));
 
             // Instruction includes type of OSM object and list of flagged tags
             final String instruction = this.getLocalizedInstruction(0,


### PR DESCRIPTION
### Description:

MixedCaseNameCheck had 2 nondeterminism issues in which 1.) master/reverse edges were being flagged unpredictably and 2.) Atlas objects of different types but with the same OSM identifier (e.g. an Edge and Area both from the same OSM Way) were being flagged unpredictably. The 2nd issue was due to the check's flags being unique purely by the OSM ids of atlas objects.

This PR fixes these 2 issues by only flagging master edges if the AtlasObject is an edge, and having flags record the unique identifier of atlas objects rather than the OSM identifier. The unique id is the atlas object type and the OSM id. e.g. E389377982

### Potential Impact:

Flag count changes for MixedCaseNameCheck should be anticipated. We should see more flags, if anything.

### Unit Test Approach:

Same unit tests. The unit test Verifier class analyzes CheckFlags, not the Set of unique IDs (```flaggedIdentifiers```) stored by the Check. For this reason I don't think there is a straightforward way to query that Set through the Verifier class. However the change is simple enough that the original unit tests should suffice.

### Test Results:

Unit tests pass
