### PR TITLE
[ShadowDetectionCheck]Tag parsing bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -297,7 +297,7 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
             minLevel = Double.parseDouble(
                     object.getOsmTags().getOrDefault(BuildingMinLevelTag.KEY, ZERO_STRING));
         }
-        // We want to flag AtlasObjects with bad tag values
+        // We want to ignore but propagate AtlasObjects with bad tag values
         catch (final NumberFormatException badTagValue)
         {
             return true;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -202,6 +202,7 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
         while (!toCheck.isEmpty())
         {
             final AtlasObject checking = toCheck.poll();
+
             // If a connection to the ground is found the parts are not floating
             if (!isOffGround(checking))
             {
@@ -287,8 +288,8 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
      */
     private boolean isOffGround(final AtlasObject object)
     {
-        Double minHeight;
-        Double minLevel;
+        final double minHeight;
+        final double minLevel;
         try
         {
             minHeight = Double
@@ -296,11 +297,10 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
             minLevel = Double.parseDouble(
                     object.getOsmTags().getOrDefault(BuildingMinLevelTag.KEY, ZERO_STRING));
         }
-        // We want to flag if there is a bad value
+        // We want to flag AtlasObjects with bad tag values
         catch (final NumberFormatException badTagValue)
         {
-            minHeight = 1.0;
-            minLevel = 1.0;
+            return true;
         }
         return minHeight > 0 || minLevel > 0;
     }
@@ -362,9 +362,11 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
         try
         {
             // Set partMinHeight
-            final double partMinHeight = MinHeightTag.get(part).map(Altitude::asMeters)
-                    .orElseGet(() -> Double.parseDouble(partTags.get(BuildingMinLevelTag.KEY))
-                            * LEVEL_TO_METERS_CONVERSION);
+            final double partMinHeight = MinHeightTag.get(part).map(Altitude::asMeters).orElseGet(
+                    () -> partTags.containsKey(BuildingMinLevelTag.KEY)
+                            ? Double.parseDouble(partTags.get(BuildingMinLevelTag.KEY))
+                                    * LEVEL_TO_METERS_CONVERSION
+                            : 0);
 
             // Set partMaxHeight
             final double partMaxHeight = HeightTag.get(part).map(Altitude::asMeters)

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTest.java
@@ -36,6 +36,14 @@ public class ShadowDetectionCheckTest
     }
 
     @Test
+    public void invalidBuildingMissingTag()
+    {
+        this.verifier.actual(this.setup.invalidBuildingMissingTagAtlas(),
+                new ShadowDetectionCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void invalidBuildingPartSingleAtlas()
     {
         this.verifier.actual(this.setup.invalidBuildingPartSingleAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheckTestRule.java
@@ -329,6 +329,17 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
                                     "building:part=yes", "height=91'10\"", "min_height=11'6\"" }) })
     private Atlas validBuildingPartsTouchHeightFeetInchesAtlas;
 
+    @TestAtlas(
+            // areas
+            areas = {
+                    @Area(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_4), @Loc(value = TEST_3) }, tags = { "building=yes",
+                                    "height=20", "min_height=10m" }),
+                    @Area(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_3), @Loc(TEST_5),
+                            @Loc(TEST_6) }, tags = { "height=30", "min_height=10",
+                                    "building=yes" }) })
+    private Atlas invalidBuildingMissingTagAtlas;
+
     public Atlas invalidBuildingAndPartStackedAtlas()
     {
         return this.invalidBuildingAndPartStackedAtlas;
@@ -337,6 +348,11 @@ public class ShadowDetectionCheckTestRule extends CoreTestRule
     public Atlas invalidBuildingBadMinAtlas()
     {
         return this.invalidBuildingBadMinAtlas;
+    }
+
+    public Atlas invalidBuildingMissingTagAtlas()
+    {
+        return this.invalidBuildingMissingTagAtlas;
     }
 
     public Atlas invalidBuildingPartSingleAtlas()


### PR DESCRIPTION
### Description:

ShadowDetectionCheck had an issue parsing tags in neighborsHeightContains(). The program can guarantee that one of MinHeightTag and BuildingMinLevelTag exists (via validCheckForObject). It will fall back on the latter if either the former doesn't exist or has an invalid value. In the first case, this is OK since a BuildingMinLevelTag is guaranteed to exist. But in the second case, we can't guarantee that BuildingMinLevelTag exists too. So an NPE is thrown in this case when it tries to parse the empty BuildingMinLevelTag tag.

The PR makes a simple change to address this issue, where if BuildingMinLevelTag doesn't exist then a default value is used.

### Potential Impact:

With the elimination of failures, we can expect to see more flags in some countries.

### Unit Test Approach:

Added a unit test for the use case causing the failure.
Did a run on TWN and verified that there were no failures.
<img width="337" alt="image" src="https://user-images.githubusercontent.com/31253489/71218738-87062180-2277-11ea-929a-e9c02cbc75dd.png">
Above, the first line is the flag output from the baseline (failure) TWN run. Second line is the fixed TWN run. Note the flag increase.

### Test Results:

Tests all pass
