### PR TITLE
Add CheckFlag Special Identifier Method 

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.flag;
 
+import static org.openstreetmap.atlas.checks.constants.CommonConstants.EMPTY_STRING;
+
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
 import java.io.Serializable;
@@ -31,6 +33,7 @@ import org.openstreetmap.atlas.geography.geojson.GeoJsonBuilder.GeometryWithProp
 import org.openstreetmap.atlas.geography.geojson.GeoJsonType;
 import org.openstreetmap.atlas.geography.geojson.GeoJsonUtils;
 import org.openstreetmap.atlas.streaming.resource.WritableResource;
+import org.openstreetmap.atlas.utilities.collections.EnhancedCollectors;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.collections.MultiIterable;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
@@ -56,7 +59,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 
     private static final Distance TEN_METERS = Distance.meters(10);
 
-    private final String identifier;
+    private String identifier;
     private String challengeName = null;
     private final List<String> instructions = new ArrayList<>();
     private final Set<FlaggedObject> flaggedObjects = new LinkedHashSet<>();
@@ -481,6 +484,20 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         this.challengeName = challengeName;
     }
 
+    /**
+     * Set the {@link CheckFlag}'s identifier equal to the sorted concatenation of all the ids of
+     * its flagged features.
+     *
+     * @return this {@link CheckFlag}
+     */
+    public CheckFlag setObjectIdentifiersAsFlagIdentifier()
+    {
+        this.identifier = String.join(EMPTY_STRING, this.flaggedObjects.stream().map(
+                item -> String.valueOf(item.getProperties().get(FlaggedObject.ITEM_IDENTIFIER_TAG)))
+                .collect(EnhancedCollectors.toUnmodifiableSortedSet()));
+        return this;
+    }
+
     @Override
     public String toString()
     {
@@ -526,4 +543,5 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         // Turn that bounds into a GeoJSON geometry.
         return GeoJsonUtils.boundsToPolygonGeometry(bounds);
     }
+
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/OverlappingAOIPolygonCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/OverlappingAOIPolygonCheck.java
@@ -129,7 +129,7 @@ public class OverlappingAOIPolygonCheck extends BaseCheck
         if (hasOverlap)
         {
             this.markAsFlagged(object.getIdentifier());
-            return Optional.of(flag);
+            return Optional.of(flag.setObjectIdentifiersAsFlagIdentifier());
         }
 
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -145,7 +145,7 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
                     this.getLocalizedInstruction(0, object.getOsmIdentifier(),
                             new StringList(getIdentifiers(overlappingEdges)).join(", ")));
             flag.addObject(object);
-            return Optional.of(flag);
+            return Optional.of(flag.setObjectIdentifiersAsFlagIdentifier());
         }
         return Optional.empty();
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -137,7 +137,7 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
                     }
                 }
             }
-            return Optional.of(flag);
+            return Optional.of(flag.setObjectIdentifiersAsFlagIdentifier());
         }
         return Optional.empty();
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -129,7 +129,9 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
         final CheckFlag flag = new CheckFlag(getTaskIdentifier(building));
         flag.addObject(building);
         this.handleIntersections(intersectingEdges, flag, building);
-        return flag.getPolyLines().size() > 1 ? Optional.of(flag) : Optional.empty();
+        return flag.getPolyLines().size() > 1
+                ? Optional.of(flag.setObjectIdentifiersAsFlagIdentifier())
+                : Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BuildingRoadIntersectionCheck.java
@@ -129,9 +129,7 @@ public class BuildingRoadIntersectionCheck extends BaseCheck<Long>
         final CheckFlag flag = new CheckFlag(getTaskIdentifier(building));
         flag.addObject(building);
         this.handleIntersections(intersectingEdges, flag, building);
-        return flag.getPolyLines().size() > 1
-                ? Optional.of(flag.setObjectIdentifiersAsFlagIdentifier())
-                : Optional.empty();
+        return flag.getPolyLines().size() > 1 ? Optional.of(flag) : Optional.empty();
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -120,7 +120,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                 newFlag.addInstruction(
                         this.getLocalizedInstruction(1, invalidEdge.getOsmIdentifier()));
             });
-            return Optional.of(newFlag);
+            return Optional.of(newFlag.setObjectIdentifiersAsFlagIdentifier());
         }
         return Optional.empty();
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/IntersectingBuildingsCheck.java
@@ -185,7 +185,7 @@ public class IntersectingBuildingsCheck extends BaseCheck<String>
 
         if (hadIntersection)
         {
-            return Optional.of(flag);
+            return Optional.of(flag.setObjectIdentifiersAsFlagIdentifier());
         }
 
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
@@ -157,7 +157,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
                 }
 
             });
-            return Optional.of(flag);
+            return Optional.of(flag.setObjectIdentifiersAsFlagIdentifier());
         }
 
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -135,7 +135,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
             this.markAsFlagged(object.getOsmIdentifier());
             connectivityFlag.addInstruction(this.getLocalizedInstruction(0,
                     object.getOsmIdentifier(), String.join(", ", disconnectedObjects)));
-            return Optional.of(connectivityFlag);
+            return Optional.of(connectivityFlag.setObjectIdentifiersAsFlagIdentifier());
         }
 
         return Optional.empty();

--- a/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
@@ -156,4 +156,14 @@ public class CheckFlagTest
         this.setup.getAtlas().entities().forEach(flag::addObject);
         testSerialization(flag);
     }
+
+    @Test
+    public void testSetObjectIdentifiersAsFlagIdentifier()
+    {
+        final CheckFlag flag = new CheckFlag("a-identifier");
+        flag.addObject(this.setup.getAtlasWithRelations().node(2));
+        flag.addObject(this.setup.getAtlasWithRelations().node(1));
+        flag.setObjectIdentifiersAsFlagIdentifier();
+        Assert.assertEquals("12", flag.getIdentifier());
+    }
 }


### PR DESCRIPTION
### Description:

Some checks are creating flags that change from run to run but are the same other than their identifier. This happens when multiple AtlasObjects are flagged but the starting object can be any of them, and the flag id is based on the starting object. Depending on which object is the starting object, the flag id changes but the rest of the flag is the same. 

Some checks avoid this by creating a set of objects to flag and passing them to the flag constructor. However this defeats the purpose of having an `addObject()` method, and makes adding an object and instructions extra cumbersome as you can't use `addObject(AtlasObject, String)`. 

This creates an alternative by adding the `CheckFlag.setObjectIdentifiersAsFlagIdentifier()` method. This method sets the flags identifier equal to a sorted concatenation of the identifiers of the flags FlaggedObjects. This gives the option to use `addObject()` and use object ids for the flag id. It also maintains the option to use a custom identifier when a specific atlas id or another special id is required. 

This also updates checks that suffer from the aforementioned variance in flag ids. 

### Potential Impact:

Some checks will have different flag ids than previously. 

### Unit Test Approach:

Added a unit test to check that the new method works to both sort and concatenate the flagged object ids as expected. 

### Test Results:

Tested running all the affected checks and verified their new flag ids were as expected. 

