### PR TITLE
BigNodeBadDataCheck Run Time Bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheck.java
@@ -94,7 +94,6 @@ public class BigNodeBadDataCheck extends BaseCheck<Long>
         else
         {
             final int allPathsCount = bigNode.allPaths().size();
-
             final Set<RestrictedPath> turnRestrictions = bigNode.turnRestrictions();
             final int turnRestrictionCount = turnRestrictions.size();
             // Get list of restricted path OSM ids

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheck.java
@@ -29,9 +29,10 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class BigNodeBadDataCheck extends BaseCheck<Long>
 {
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("This complex intersection has too many paths ({0}) or junction edges ({1}).  "
-                    + "There are {2,number,#} restricted paths and their OSM ids are: {3} ");
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "This complex intersection has too many junction edges ({0}).",
+            "This complex intersection has too many paths ({0}).  "
+                    + "There are {1,number,#} restricted paths and their OSM ids are: {2} ");
     private static final long MAX_NUMBER_JUNCTION_EDGES_THRESHOLD_DEFAULT = 12;
     private static final long MAX_NUMBER_PATHS_THRESHOLD_DEFAULT = 1000;
     private static final String MINIMUM_HIGHWAY_TYPE_DEFAULT = HighwayTag.TOLL_GANTRY.toString();
@@ -77,28 +78,42 @@ public class BigNodeBadDataCheck extends BaseCheck<Long>
         {
             return Optional.empty();
         }
-        final int allPathsCount = bigNode.allPaths().size();
-        final int junctionEdgesCount = bigNode.junctionEdges().size();
-        final Set<RestrictedPath> turnRestrictions = bigNode.turnRestrictions();
-        final int turnRestrictionCount = turnRestrictions.size();
-        // Get list of restricted path OSM ids
-        final List<Long> restrictedPathOsmIds = turnRestrictions.stream()
-                .flatMap(restrictedPath -> Iterables.asList(restrictedPath.getRoute()).stream()
-                        .map(Edge::getOsmIdentifier))
-                .collect(Collectors.toList());
 
-        if (allPathsCount > maxNumberPathsThreshold
-                || junctionEdgesCount > maxNumberJunctionEdgesThreshold)
+        final int junctionEdgesCount = bigNode.junctionEdges().size();
+        if (junctionEdgesCount > maxNumberJunctionEdgesThreshold)
         {
             final CheckFlag flag = createFlag(bigNode,
-                    this.getLocalizedInstruction(0, allPathsCount, junctionEdgesCount,
-                            turnRestrictionCount, restrictedPathOsmIds.toString()));
+                    this.getLocalizedInstruction(0, junctionEdgesCount));
 
             bigNode.edges().forEach(flag::addObject);
             // Add map pin at each BigNode Node
             bigNode.nodes().forEach(b -> flag.addPoint(b.getLocation()));
 
             return Optional.of(flag);
+        }
+        else
+        {
+            final int allPathsCount = bigNode.allPaths().size();
+
+            final Set<RestrictedPath> turnRestrictions = bigNode.turnRestrictions();
+            final int turnRestrictionCount = turnRestrictions.size();
+            // Get list of restricted path OSM ids
+            final List<Long> restrictedPathOsmIds = turnRestrictions.stream()
+                    .flatMap(restrictedPath -> Iterables.asList(restrictedPath.getRoute()).stream()
+                            .map(Edge::getOsmIdentifier))
+                    .collect(Collectors.toList());
+
+            if (allPathsCount > maxNumberPathsThreshold)
+            {
+                final CheckFlag flag = createFlag(bigNode, this.getLocalizedInstruction(1,
+                        allPathsCount, turnRestrictionCount, restrictedPathOsmIds.toString()));
+
+                bigNode.edges().forEach(flag::addObject);
+                // Add map pin at each BigNode Node
+                bigNode.nodes().forEach(b -> flag.addPoint(b.getLocation()));
+
+                return Optional.of(flag);
+            }
         }
 
         return Optional.empty();


### PR DESCRIPTION
### Description:
BigNodeBadDataCheck can often load Edge networks consisting of tens of Edges. In these cases it takes a long time for the AllPathsRouter to execute on the network. In some rare cases the check will even time out before completing due to this.
The AllPathsRouter is used to calculate the number of paths through a big node. If this number is too high then that is one of the conditions for the big node to be flagged.
To fix this issue the check has been altered to only run the AllPathsRouter (through `BigNode.allPaths()`) if no other conditions for flagging are met. 

### Potential Impact:

BigNodeBadDataCheck should run much more quickly. There may be an increase in flags in areas where the check was previously timing out. 
In most cases the flag instructions will no longer include information on the path count or turn restriction count. That will now only occur when the path count is used as the last resort flag condition. 

### Unit Test Approach:
No unit tests were changed or added. All tests pass. 

### Test Results:

Tested the fix on an atlas that previously timed out when trying to run this check. The timeout occurs when it takes longer than 300 minutes for the check to run. The check now runs in under 18 seconds. 
Compared results of an atlas that did complete before and found that the flags were the same, with the exception of the altered instructions. 

