### PR TITLE
Snake road check bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.checks.validation.linear.edges;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
@@ -168,9 +169,14 @@ public class SnakeRoadCheck extends BaseCheck<Long>
             // Process it
             walk.visitEdge(current, connection);
 
+            final Set<Edge> oneLayerRemovedConnections = walk
+                    .getConnectedMasterEdgeOfTheSameWay(connection);
+            oneLayerRemovedConnections.forEach(
+                    onceRemovedConnection -> walk.checkIfEdgeHeadingDifferenceExceedsThreshold(
+                            connection, onceRemovedConnection));
+
             // Add its neighbors to the next layer
-            walk.populateOneLayerRemovedConnections(
-                    walk.getConnectedMasterEdgeOfTheSameWay(connection));
+            walk.populateOneLayerRemovedConnections(oneLayerRemovedConnections);
 
             // If we've processed all directly connected edges, check the next layer of connections
             if (walk.getDirectConnections().isEmpty())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadNetworkWalk.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadNetworkWalk.java
@@ -48,7 +48,7 @@ public class SnakeRoadNetworkWalk
         // We use a TreeSet here to order the edges by their Atlas identifier. This helps us easily
         // grab the first and last Edge making up the road and check connections for false
         // positives.
-        this.visitedEdges = new TreeSet<AtlasObject>((one, two) ->
+        this.visitedEdges = new TreeSet<>((one, two) ->
         {
             return Long.compare(one.getIdentifier(), two.getIdentifier());
         });
@@ -186,7 +186,6 @@ public class SnakeRoadNetworkWalk
         this.visitedEdges.add(comingTo);
         this.setGreatestValence(comingTo.start());
         this.setGreatestValence(comingTo.end());
-        checkIfEdgeHeadingDifferenceExceedsThreshold(comingFrom, comingTo);
     }
 
     /**


### PR DESCRIPTION
### Description:

This is a bug fix for the existing Snake Road Check.
Existing code is meeting all the requirements except for instead of doing heading difference for connected edges the current edge was doing heading difference with all the edges on the highway. This issue is fixed with new code changes.

Criteria to identify Snake Road is as follows:
- At some point, two consecutive edges making up the Snake road must have a heading difference of at least 60 degrees.
- The snake road must have at least 3 edges
- At least one edge making up the snake road should have a valence greater than 4
- To be considered a snake road, you should either have no road name or have any connected ways that share the 
same name that you do. This is done to prevent flagging strange portions of highways that may exhibit the behavior of a snake road.


### Potential Impact:

Changes made to Atlas checks.

### Unit Test Approach:

Existing tests.

### Test Results:

Ran the check on atlas files before and after code changes and made sure the number of flags created are less. Also, with the help of analyst making sure the generated flags are still satisfying criteria for Snake Road check.

Ran SnakeRoadCheck bug on approximately 65 MB data Atlas files and found below metrics.
With old code: 84 flags were created.
With new code changes: 34 flags were created.
Flag count is decreased as expected and also verified each flag generated is satisfying snake road check requirement.

