### PR TITLE
Connectivity check bug fix.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/configuration/ConfigurationResolver.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/configuration/ConfigurationResolver.java
@@ -161,9 +161,9 @@ public final class ConfigurationResolver
                 {
                     source.close();
                 }
-                catch (final Throwable throwable)
+                catch (final IOException ioe)
                 {
-                    thrown = throwable;
+                    thrown = ioe;
                 }
             }
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -104,7 +104,8 @@ public class ConnectivityCheck extends BaseCheck<Long>
                         && this.getLayerMap(nearbyNode).keySet().stream()
                                 .anyMatch(nodeLayerMap::containsKey)))
         {
-            // Flag nearby nodes if they are not synthetic boundary node, are start node, are not a
+            // Flag nearby nodes if they are neither synthetic boundary node nor a start node, are
+            // not a
             // barrier, have a valid
             // connected edge, and there is not a valid route to the start node
             if (!SyntheticBoundaryNodeTag.isSyntheticBoundaryNode(nodeNearby)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -104,7 +104,8 @@ public class ConnectivityCheck extends BaseCheck<Long>
                         && this.getLayerMap(nearbyNode).keySet().stream()
                                 .anyMatch(nodeLayerMap::containsKey)))
         {
-            // Flag nearby nodes if they are not synthetic boundary node, are start node, are not a barrier, have a valid
+            // Flag nearby nodes if they are not synthetic boundary node, are start node, are not a
+            // barrier, have a valid
             // connected edge, and there is not a valid route to the start node
             if (!SyntheticBoundaryNodeTag.isSyntheticBoundaryNode(nodeNearby)
                     && !node.equals(nodeNearby) && !BarrierTag.isBarrier(nodeNearby)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -104,9 +104,10 @@ public class ConnectivityCheck extends BaseCheck<Long>
                         && this.getLayerMap(nearbyNode).keySet().stream()
                                 .anyMatch(nodeLayerMap::containsKey)))
         {
-            // Flag nearby nodes if they are not are start node, are not a barrier, have a valid
+            // Flag nearby nodes if they are not synthetic boundary node, are start node, are not a barrier, have a valid
             // connected edge, and there is not a valid route to the start node
-            if (!node.equals(nodeNearby) && !BarrierTag.isBarrier(nodeNearby)
+            if (!SyntheticBoundaryNodeTag.isSyntheticBoundaryNode(nodeNearby)
+                    && !node.equals(nodeNearby) && !BarrierTag.isBarrier(nodeNearby)
                     && !Validators.isOfType(nodeNearby, NoExitTag.class, NoExitTag.YES)
                     && nodeNearby.connectedEdges().stream().anyMatch(this::validEdgeFilter)
                     && !hasValidConnection(node, connectedEdges, nodeNearby))

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -26,6 +26,7 @@ import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
 import org.openstreetmap.atlas.tags.LevelTag;
 import org.openstreetmap.atlas.tags.NoExitTag;
+import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
@@ -68,8 +69,8 @@ public class ConnectivityCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Node && !this.isFlagged(object.getOsmIdentifier())
-                && !BarrierTag.isBarrier(object)
+        return object instanceof Node && !SyntheticBoundaryNodeTag.isSyntheticBoundaryNode(object)
+                && !this.isFlagged(object.getOsmIdentifier()) && !BarrierTag.isBarrier(object)
                 && !Validators.isOfType(object, NoExitTag.class, NoExitTag.YES)
                 && !this.connectedEdgesHaveLevelTags((Node) object)
                 // Node is part of a valid road, for this check

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
@@ -254,4 +254,13 @@ public class ConnectivityCheckTest
                 new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
+
+    @Test
+    public void validSyntheticNodeCheckTest()
+    {
+        this.verifier.actual(this.setup.validSyntheticNodeCheck(),
+                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
@@ -65,6 +65,15 @@ public class ConnectivityCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // Nodes
+            nodes = { @Node(coordinates = @Loc(TEST1)),
+                    @Node(coordinates = @Loc(TEST2), tags = {
+                            "synthetic_boundary_node=yes" }) }, edges = {
+                                    @Edge(coordinates = { @Loc(TEST1), @Loc(TEST2) }, tags = {
+                                            "highway=secondary" }) })
+    private Atlas validationForSyntheticNode;
+
+    @TestAtlas(
+            // Nodes
             nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
                     @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST4)) }, edges = {
                             @Edge(coordinates = { @Loc(TEST1), @Loc(TEST2) }, tags = {
@@ -471,5 +480,10 @@ public class ConnectivityCheckTestRule extends CoreTestRule
     public Atlas validDisconnectedNodesLevelAtlas()
     {
         return this.validDisconnectedNodesLevelAtlas;
+    }
+
+    public Atlas validSyntheticNodeCheck()
+    {
+        return this.validationForSyntheticNode;
     }
 }


### PR DESCRIPTION
### Description:

This PR is a bug fix for existing connectivity check. The code checks for synthetic boundary nodes and if the nodes are not one of them it creates flags. Other validations are left as is.

### Potential Impact:

Changes made to Atlas-checks.

### Unit Test Approach:

Added one unit test for validating flags with added synthetic node.

### Test Results:

Using some Atlas files, verified that the starting node and near by nodes are checking the synthetic boundary condition which is added and filter on it. Also, will take analyst help to analyze the flags correctly.

