### PR TITLE
[DNM] InconsistentRoadClassificationCheck bug fix

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -113,13 +113,6 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             newFlag.addObject(object);
             newFlag.addInstruction(this.getLocalizedInstruction(0, object.getOsmIdentifier()));
 
-            collectedEdges.forEach(invalidEdge ->
-            {
-                this.markAsFlagged(invalidEdge.getIdentifier());
-                newFlag.addObject(invalidEdge);
-                newFlag.addInstruction(
-                        this.getLocalizedInstruction(1, invalidEdge.getOsmIdentifier()));
-            });
             return Optional.of(newFlag);
         }
         return Optional.empty();
@@ -188,7 +181,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private boolean isValidCrossingEdge(final AtlasObject object)
     {
         if (Edge.isMasterEdgeIdentifier(object.getIdentifier())
-                && !TagPredicates.IS_AREA.test(object) && !this.isFlagged(object.getIdentifier()))
+                && !TagPredicates.IS_AREA.test(object))
         {
             final Optional<HighwayTag> highway = HighwayTag.highwayTag(object);
             if (highway.isPresent())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
@@ -233,6 +233,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
             final Edge edge)
     {
         return edge.outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .filter(connectedEdge -> referenceHighwayType
                         .isOfEqualClassification(connectedEdge.highwayTag())
                         && this.areInTheSimilarDirection(edge, connectedEdge));
@@ -251,6 +252,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
 
         // Split the outEdges into those that are inconsistent links and those that are not
         final Map<Boolean, List<Edge>> edgesAreProblematicLinks = referenceEdge.outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .filter(this.allConnectedEdgesFilter(referenceEdge, referenceHighwayType))
                 .collect(Collectors.partitioningBy(
                         edge -> this.isProblematicLink(edge, referenceHighwayType)));
@@ -328,6 +330,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     private boolean isBypassed(final Edge inconsistency, final HighwayTag referenceHighwayTag)
     {
         return inconsistency.start().outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .anyMatch(edge -> !edge.equals(inconsistency)
                         && edge.end().equals(inconsistency.end())
                         && edge.highwayTag().isIdenticalClassification(referenceHighwayTag));
@@ -343,6 +346,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     private boolean isContinuousOutgoingEdge(final Edge edge)
     {
         return edge.outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .anyMatch(connectedEdge -> edge.highwayTag()
                         .isOfEqualClassification(connectedEdge.highwayTag())
                         && this.areInTheSimilarDirection(edge, connectedEdge));

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
@@ -16,6 +16,7 @@ import org.openstreetmap.atlas.geography.Heading;
 import org.openstreetmap.atlas.geography.Segment;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.JunctionTag;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
@@ -85,7 +86,8 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        if (object instanceof Edge && !isFlagged(object.getOsmIdentifier()))
+        if (object instanceof Edge && ((Edge) object).isMasterEdge()
+                && !isFlagged(object.getOsmIdentifier()))
         {
             final Edge edge = (Edge) object;
 
@@ -112,7 +114,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
                 .findInconsistentEdges(edge);
         if (!inconsistentEdgeTuples.isEmpty())
         {
-            final CheckFlag flag = createFlag(item,
+            final CheckFlag flag = createFlag(new OsmWayWalker((Edge) item).collectEdges(),
                     this.getLocalizedInstruction(0, edge.getOsmIdentifier(), edge.highwayTag()));
             markAsFlagged(edge.getOsmIdentifier());
             inconsistentEdgeTuples.forEach(inconsistentEdgeTuple ->

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -23,8 +23,8 @@ public class EdgeCrossingEdgeCheckTest
     {
         this.verifier.actual(this.setup.invalidCrossingItemsAtlas(),
                 new EdgeCrossingEdgeCheck(this.configuration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(4, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(1, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -41,8 +41,8 @@ public class EdgeCrossingEdgeCheckTest
         this.verifier.actual(this.setup.invalidCrossingItemsWithInvalidLayerTagAtlas(),
                 new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.verifyNotEmpty();
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(flags.size(), 1));
-        this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 4));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(4, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(1, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -51,8 +51,8 @@ public class EdgeCrossingEdgeCheckTest
         this.verifier.actual(this.setup.invalidCrossingItemsWithSameLayerTagAtlas(),
                 new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"EdgeCrossingEdgeCheck\":{\"minimum.highway.type\":\"track\"}}")));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(flags.size(), 1));
-        this.verifier.verify(flag -> Assert.assertEquals(flag.getFlaggedObjects().size(), 2));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(1, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -61,7 +61,8 @@ public class EdgeCrossingEdgeCheckTest
         this.verifier.actual(this.setup.invalidCrossingNonMasterItemsAtlas(),
                 new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.verifyNotEmpty();
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(4, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(1, flag.getFlaggedObjects().size()));
     }
 
     @Test


### PR DESCRIPTION

### Description:

InconsistentRoadClassificationCheck flags Edges in a nondeterministic manor. It should only flag master Edges and use the OsmWayWalker. Fixed this issue in current PR.

### Potential Impact:

Changes made to Atlas checks.

### Unit Test Approach:

No additional tests are included.

### Test Results:

Tested by running the check on atlas files and the changes are working as expected.
