### PR TITLE
 Inconsistent-road-classification bug fix

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
@@ -16,6 +16,7 @@ import org.openstreetmap.atlas.geography.Heading;
 import org.openstreetmap.atlas.geography.Segment;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.JunctionTag;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
@@ -85,7 +86,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        if (object instanceof Edge && !isFlagged(object.getOsmIdentifier()))
+        if (object instanceof Edge && !isFlagged(object.getOsmIdentifier()) && ((Edge) object).isMasterEdge())
         {
             final Edge edge = (Edge) object;
 
@@ -112,7 +113,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
                 .findInconsistentEdges(edge);
         if (!inconsistentEdgeTuples.isEmpty())
         {
-            final CheckFlag flag = createFlag(item,
+            final CheckFlag flag = createFlag(new OsmWayWalker((Edge) item).collectEdges(),
                     this.getLocalizedInstruction(0, edge.getOsmIdentifier(), edge.highwayTag()));
             markAsFlagged(edge.getOsmIdentifier());
             inconsistentEdgeTuples.forEach(inconsistentEdgeTuple ->
@@ -231,6 +232,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
             final Edge edge)
     {
         return edge.outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .filter(connectedEdge -> referenceHighwayType
                         .isOfEqualClassification(connectedEdge.highwayTag())
                         && this.areInTheSimilarDirection(edge, connectedEdge));
@@ -249,6 +251,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
 
         // Split the outEdges into those that are inconsistent links and those that are not
         final Map<Boolean, List<Edge>> edgesAreProblematicLinks = referenceEdge.outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .filter(this.allConnectedEdgesFilter(referenceEdge, referenceHighwayType))
                 .collect(Collectors.partitioningBy(
                         edge -> this.isProblematicLink(edge, referenceHighwayType)));
@@ -326,6 +329,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     private boolean isBypassed(final Edge inconsistency, final HighwayTag referenceHighwayTag)
     {
         return inconsistency.start().outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .anyMatch(edge -> !edge.equals(inconsistency)
                         && edge.end().equals(inconsistency.end())
                         && edge.highwayTag().isIdenticalClassification(referenceHighwayTag));
@@ -341,6 +345,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     private boolean isContinuousOutgoingEdge(final Edge edge)
     {
         return edge.outEdges().stream()
+                .filter(Edge::isMasterEdge)
                 .anyMatch(connectedEdge -> edge.highwayTag()
                         .isOfEqualClassification(connectedEdge.highwayTag())
                         && this.areInTheSimilarDirection(edge, connectedEdge));

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/InconsistentRoadClassificationCheck.java
@@ -86,7 +86,8 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        if (object instanceof Edge && !isFlagged(object.getOsmIdentifier()) && ((Edge) object).isMasterEdge())
+        if (object instanceof Edge && !isFlagged(object.getOsmIdentifier())
+                && ((Edge) object).isMasterEdge())
         {
             final Edge edge = (Edge) object;
 
@@ -231,8 +232,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
     private Stream<Edge> connectionsSimilarToReferenceEdge(final HighwayTag referenceHighwayType,
             final Edge edge)
     {
-        return edge.outEdges().stream()
-                .filter(Edge::isMasterEdge)
+        return edge.outEdges().stream().filter(Edge::isMasterEdge)
                 .filter(connectedEdge -> referenceHighwayType
                         .isOfEqualClassification(connectedEdge.highwayTag())
                         && this.areInTheSimilarDirection(edge, connectedEdge));
@@ -328,8 +328,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
      */
     private boolean isBypassed(final Edge inconsistency, final HighwayTag referenceHighwayTag)
     {
-        return inconsistency.start().outEdges().stream()
-                .filter(Edge::isMasterEdge)
+        return inconsistency.start().outEdges().stream().filter(Edge::isMasterEdge)
                 .anyMatch(edge -> !edge.equals(inconsistency)
                         && edge.end().equals(inconsistency.end())
                         && edge.highwayTag().isIdenticalClassification(referenceHighwayTag));
@@ -344,8 +343,7 @@ public class InconsistentRoadClassificationCheck extends BaseCheck<Long>
      */
     private boolean isContinuousOutgoingEdge(final Edge edge)
     {
-        return edge.outEdges().stream()
-                .filter(Edge::isMasterEdge)
+        return edge.outEdges().stream().filter(Edge::isMasterEdge)
                 .anyMatch(connectedEdge -> edge.highwayTag()
                         .isOfEqualClassification(connectedEdge.highwayTag())
                         && this.areInTheSimilarDirection(edge, connectedEdge));


### PR DESCRIPTION
### Description:

InconsistentRoadClassificationCheck flags Edges in a nondeterministic manor. It should only flag master Edges and use the OsmWayWalker. Fixed this issue in current PR.

### Potential Impact:

Changes made to Atlas checks.

### Unit Test Approach:

No additional tests are included.

### Test Results:

Tested by running the check on atlas files and the changes are working as expected.
