### PR TITLE
JDK 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please see the [contributing guidelines](https://github.com/osmlab/atlas/blob/de
 
 ### Requirements
 To run Atlas Checks the following is required:
-1. [Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+1. [OpenJDK 11](https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.5_10.pkg)
 2. [Gradle](https://gradle.org/install)
 3. [Git Command Line Tools](https://git-scm.com/downloads)
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ apply from: 'gradle/execute.gradle'
 
 description = "Atlas Checks"
 
-sourceCompatibility=1.8
-targetCompatibility=1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 repositories
 {
@@ -41,6 +41,15 @@ repositories
 
 configurations
 {
+    all {
+        resolutionStrategy {
+            // Force the version compatible with the latest version
+            // of Spark brought in by atlas generator
+            force 'com.fasterxml.jackson.core:jackson-core:2.6.7'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
+        }
+
+    }
     compile
     {
         resolutionStrategy
@@ -51,11 +60,6 @@ configurations
             // Snappy 1.1.1.6 is the one that has the proper .so libs.
             // https://github.com/xerial/snappy-java/issues/6
             force 'org.xerial.snappy:snappy-java:1.1.1.6'
-
-            // Force the version compatible with the latest version
-            // of Spark brought in by atlas generator
-            force 'com.fasterxml.jackson.core:jackson-core:2.9.8'
-            force 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
         }
     }
     shaded
@@ -68,11 +72,6 @@ configurations
             // Snappy 1.1.1.6 is the one that has the proper .so libs.
             // https://github.com/xerial/snappy-java/issues/6
             force 'org.xerial.snappy:snappy-java:1.1.1.6'
-
-            // Force the version compatible with the latest version
-            // of Spark brought in by atlas generator
-            force 'com.fasterxml.jackson.core:jackson-core:2.9.8'
-            force 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
         }
         // Hadoop and Spark are way too fat.
         exclude group: 'org.apache.hadoop'
@@ -156,6 +155,6 @@ gradle.startParameter.excludedTaskNames += skippedTaskNames
 
 idea {
     project {
-        languageLevel = '1.8'
+        languageLevel = '11'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ configurations
             force 'com.fasterxml.jackson.core:jackson-core:2.6.7'
             force 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
         }
-
     }
     compile
     {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,9 +1,9 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '5.9.1',
+    atlas: '6.0.1',
     commons:'2.6',
-    atlas_generator: '4.3.5',
+    atlas_generator: '5.0.0',
     atlas_checkstyle: '5.6.9',
     postgis: '2.1.7.2',
     postgres: '42.2.6',


### PR DESCRIPTION
### Description:

This PR sets Atlas Checks to target JDK 11. Updating to 11 required a few changes to dependencies:

- Atlas generator 5.0.0 (brings in spark 2.4.4)
- Atlas 6.0.1 (requires us to override its version of jackson (2.9.8) to the spark 2.4.4 supported 2.9.7 )

### Potential Impact:

Atlas checks build will no longer support JDK 8

### Unit Test Approach:

Local build

### Test Results:

Build passed

