### PR TITLE
Bumping gradle.properties to 6.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=5.2.4-SNAPSHOT
+version=6.0.0-SNAPSHOT
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
Description:

Update gradle.properties version to 6.0.0

Potential Impact:

Unit Test Approach:

built locally

Test Results:

successful
