### PR TITLE
[MapRouletteUploadCommand] Encode challenge names with URIUtil

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -3,12 +3,13 @@ package org.openstreetmap.atlas.checks.maproulette;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
@@ -143,9 +144,18 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     {
         final JsonObject challengeJson = challenge.toJson(challenge.getName());
         final String type = challengeJson.has(Survey.KEY_ANSWERS) ? KEY_SURVEY : KEY_CHALLENGE;
+        String encodedChallengeQuery = challenge.getName();
+        try
+        {
+            encodedChallengeQuery = URIUtil.encodeQuery(challenge.getName());
+        }
+        catch (final URIException error)
+        {
+            logger.info("Unable to encode Challenge name {}.", challenge.getName());
+        }
         return create(
                 String.format("/api/v2/project/%d/challenge/%s", project.getId(),
-                        URLEncoder.encode(challenge.getName(), "UTF-8")),
+                        encodedChallengeQuery),
                 String.format("/api/v2/%s", type), String.format("/api/v2/%s/", type) + "%s",
                 challengeJson, String.format("Created/Updated Challenge with ID {} and name %s",
                         challenge.getName()));


### PR DESCRIPTION
### Description:

This updates the MapRoulette createChallenge function to use [URIUtil.encodeQuery](https://hc.apache.org/httpclient-3.x/apidocs/org/apache/commons/httpclient/util/URIUtil.html#encodeQuery(java.lang.String)) to encode Challenges names in the /api/v2/project/{project_id}/challenge/{challange_name_string}.

This will fix an issue where the MapRouletteUpload command would return a 500 when uploading tasks to an existing challenge.
```
16:54:37.982 [main] DEBUG o.o.a.c.m.MapRouletteConnection - 500 - 
{
	"status": "KO",
	"message": "Challenge with name USA - SelfIntersectingPolylineCheck already exists in the database"
}
```

`URLEncoder.encode` replaces space characters with `+` instead of `%20`, which is not properly decoded by the MapRoulette API. 


### Potential Impact:

This will allow us to use MapRouletteUploadCommand on existing projects/challenges

### Unit Test Approach:

Ran the MapRouletteUploadCommand to upload challenges to a test project. Ran the command again and challenges were refreshed with the most recent data.

### Test Results:

Tests worked as expected

