### PR TITLE
Maproulette-upload-dag, fix for url encoding issues.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -144,9 +144,11 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     {
         final JsonObject challengeJson = challenge.toJson(challenge.getName());
         final String type = challengeJson.has(Survey.KEY_ANSWERS) ? KEY_SURVEY : KEY_CHALLENGE;
+        final String encodedChallengeQuery = URLEncoder
+                .encode(challenge.getName(), StandardCharsets.UTF_8).replace("+", "%20");
         return create(
                 String.format("/api/v2/project/%d/challenge/%s", project.getId(),
-                        URLEncoder.encode(challenge.getName(), StandardCharsets.UTF_8).replace("+", "%20")),
+                        encodedChallengeQuery),
                 String.format("/api/v2/%s", type), String.format("/api/v2/%s/", type) + "%s",
                 challengeJson, String.format("Created/Updated Challenge with ID {} and name %s",
                         challenge.getName()));

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -3,13 +3,13 @@ package org.openstreetmap.atlas.checks.maproulette;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
@@ -144,18 +144,9 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     {
         final JsonObject challengeJson = challenge.toJson(challenge.getName());
         final String type = challengeJson.has(Survey.KEY_ANSWERS) ? KEY_SURVEY : KEY_CHALLENGE;
-        String encodedChallengeQuery = challenge.getName();
-        try
-        {
-            encodedChallengeQuery = URIUtil.encodeQuery(challenge.getName());
-        }
-        catch (final URIException error)
-        {
-            logger.info("Unable to encode Challenge name {}.", challenge.getName());
-        }
         return create(
                 String.format("/api/v2/project/%d/challenge/%s", project.getId(),
-                        encodedChallengeQuery),
+                        URLEncoder.encode(challenge.getName(), StandardCharsets.UTF_8).replace("+", "%20")),
                 String.format("/api/v2/%s", type), String.format("/api/v2/%s/", type) + "%s",
                 challengeJson, String.format("Created/Updated Challenge with ID {} and name %s",
                         challenge.getName()));


### PR DESCRIPTION
### Description:

java.lang.NoClassDefFoundError: org/apache/commons/httpclient/URIException
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteClient.<init>(MapRouletteClient.java:83)

This is happening because the URIUtil class which is used in Atlas checks is of older Apache Commons version i.e., 2.6. OSM Integrity is using Apache Commons version 4.1.

The newer version doesn't have the class URIUtil. So, I replaced the URIUtil with URLEncoder from JDK11. It takes care of encoding the string using URLEncoder. But, spaces are encoded to "+" instead of "%20" as mentioned in the below document. It is taken care of using replace method from String class.

https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLEncoder.html

### Potential Impact:

Changes made to Atlas checks

### Unit Test Approach:

No changes made to existing tests.

### Test Results:

Verified in maproulette.org staging environment by running the Maproulette upload configuration locally.

