### PR TITLE
Add construction configuration

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
@@ -21,6 +21,9 @@ public class FloatingEdgeCheckTest
     private final FloatingEdgeCheck minimumHighwayCheck = new FloatingEdgeCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"FloatingEdgeCheck\":{\"highway.minimum\": \"PRIMARY_LINK\",\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
+    private final FloatingEdgeCheck constructionCheck = new FloatingEdgeCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"FloatingEdgeCheck\":{\"construction.check\": true,\"length\":{\"maximum.kilometers\":16.093,\"minimum.meters\": 1.0}}}"));
 
     @Test
     public void testAirportIntersectingEdge()
@@ -50,6 +53,13 @@ public class FloatingEdgeCheckTest
         this.verifier.actual(this.setup.floatingEdgeAtlas(), this.check);
         this.verifier.verifyNotNull();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void testFloatingEdgeConstruction()
+    {
+        this.verifier.actual(this.setup.floatingEdgeConstructionAtlas(), this.constructionCheck);
+        this.verifier.verifyEmpty();
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
@@ -8,6 +8,7 @@ import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
@@ -94,6 +95,15 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_2) }, tags = { "highway=SECONDARY" }) })
     private Atlas mixedAtlas;
 
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=SECONDARY" }) }, lines = {
+                                    @Line(coordinates = { @Loc(value = TEST_2),
+                                            @Loc(value = TEST_3) }, tags = { "highway=CONSTRUCTION",
+                                                    "construction=RESIDENTIAL" }) })
+    private Atlas floatingEdgeConstructionAtlas;
+
     public Atlas airportAtlas()
     {
         return this.airportAtlas;
@@ -114,6 +124,11 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
         return this.floatingEdgeAtlas;
     }
 
+    public Atlas floatingEdgeConstructionAtlas()
+    {
+        return this.floatingEdgeConstructionAtlas;
+    }
+
     public Atlas floatingEdgeInAirportPolygon()
     {
         return this.floatingEdgeInAirportAtlas;
@@ -128,5 +143,4 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
     {
         return this.syntheticBorderAtlas;
     }
-
 }


### PR DESCRIPTION
### Description:
This added enhancement will allow for the option to check if floating edges are connected to construction roads or not. By default, edges are considered floating if they are connected to construction roads and not connected to any other edges.

### Potential Impact:

No impact if configuration is left as default. If the configuration is changed to true, there will be less edges flagged.