### PR TITLE
Making the PGS Tag filter a blank string.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
@@ -40,7 +40,7 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
             SHARP_ANGLE_INSTRUCTIONS);
     private static final double MINIMUM_DISTANCE_BETWEEN_NODES = 100;
     private static final double MINIMUM_NODE_PAIR_THRESHOLD_PERCENTAGE = 30.0;
-    private static final String COASTLINE_TAG_FILTER_DEFAULT = "source->PGS";
+    private static final String COASTLINE_TAG_FILTER_DEFAULT = "";
     private static final double SHARP_ANGLE_THRESHOLD_DEFAULT = Integer.MAX_VALUE;
 
     private static final double HUNDRED_PERCENT = 100.0;


### PR DESCRIPTION
### Description:

Leaving a blank string for the PGS Tag filter. We still want to keep the filter in place, in case we want to filter for PGS Tags again.

### Potential Impact:

We should see an increase in flag counts. The plan is to generate all coastlines and use existing tools (flag db) to filter checks data moving forward.
