### PR TITLE
Leaving a blank string for the PGS Tag filter, under GeneralizedCoast…

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -256,7 +256,7 @@
   "GeneralizedCoastlineCheck": {
     "node.minimum.distance": 100.0,
     "node.minimum.threshold": 30.0,
-    "coastline.tags.filters": "source->PGS",
+    "coastline.tags.filters": "",
     "angle.minimum.threshold": 97.0,
     "challenge": {
       "description": "Coastlines whose nodes are too far apart, and which may have too sharp of angles.",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
@@ -40,7 +40,7 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
             SHARP_ANGLE_INSTRUCTIONS);
     private static final double MINIMUM_DISTANCE_BETWEEN_NODES = 100;
     private static final double MINIMUM_NODE_PAIR_THRESHOLD_PERCENTAGE = 30.0;
-    private static final String COASTLINE_TAG_FILTER_DEFAULT = "source->PGS";
+    private static final String COASTLINE_TAG_FILTER_DEFAULT = "";
     private static final double SHARP_ANGLE_THRESHOLD_DEFAULT = Integer.MAX_VALUE;
 
     private static final double HUNDRED_PERCENT = 100.0;

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTest.java
@@ -95,7 +95,7 @@ public class GeneralizedCoastlineCheckTest
     {
         this.verifier.actual(this.setup.getOneLineSegmentGeneralizedSourceSurvey(),
                 new GeneralizedCoastlineCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.verifyEmpty();
+        this.verifier.verifyExpectedSize(1);
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheckTestRule.java
@@ -90,11 +90,11 @@ public class GeneralizedCoastlineCheckTestRule extends CoreTestRule
                                     @Member(id = "123", role = "na", type = "relation") }) })
     private Atlas withNestedRelationGeneralized;
 
-    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline" }, coordinates = {
             @Loc(value = GENERALIZED_ONE), @Loc(value = GENERALIZED_TWO) }) })
     private Atlas oneLineSegmentGeneralized;
 
-    @TestAtlas(lines = { @Line(tags = { "natural=coastline", "source=PGS" }, coordinates = {
+    @TestAtlas(lines = { @Line(tags = { "natural=coastline" }, coordinates = {
             @Loc(value = GENERALIZED_THREE), @Loc(value = GENERALIZED_FOUR) }) })
     private Atlas oneLineSegmentNotGeneralized;
 


### PR DESCRIPTION
…lineCheck, in the config file.

### Description:

Leaving a blank string for the PGS Tag filter. We still want to keep the filter in place, in case we want to filter for PGS Tags again.

### Potential Impact:

We should see an increase in flag counts. The plan is to generate all coastlines and use existing tools (flag db) to filter checks data moving forward.
