### PR TITLE
SinkIslandCheck Navigability Enhancement

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -40,6 +40,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  * @author nachtm
  * @author sayas01
  * @author seancoulter
+ * @author bbreithaupt
  */
 public class SinkIslandCheck extends BaseCheck<Long>
 {
@@ -49,10 +50,13 @@ public class SinkIslandCheck extends BaseCheck<Long>
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections
             .singletonList("Road is impossible to get out of.");
     private static final float LOAD_FACTOR = 0.8f;
-    private static final Predicate<AtlasObject> NAVIGABLE_HIGHWAYS = object -> Validators
-            .isOfType(object, MotorVehicleTag.class, MotorVehicleTag.YES)
-            || Validators.isOfType(object, MotorcarTag.class, MotorcarTag.YES)
-            || Validators.isOfType(object, VehicleTag.class, VehicleTag.YES);
+    private static final Predicate<AtlasObject> NAVIGABLE_HIGHWAYS = object -> Validators.isOfType(
+            object, MotorVehicleTag.class, MotorVehicleTag.YES, MotorVehicleTag.DESIGNATED,
+            MotorVehicleTag.PERMISSIVE)
+            || Validators.isOfType(object, MotorcarTag.class, MotorcarTag.YES,
+                    MotorcarTag.DESIGNATED, MotorcarTag.PERMISSIVE)
+            || Validators.isOfType(object, VehicleTag.class, VehicleTag.YES, VehicleTag.DESIGNATED,
+                    VehicleTag.PERMISSIVE);
     private static final Predicate<AtlasObject> SERVICE_ROAD = object -> Validators.isOfType(object,
             HighwayTag.class, HighwayTag.SERVICE);
     private static final Predicate<AtlasObject> IS_AT_LEAST_SERVICE_ROAD = object -> ((Edge) object)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -136,8 +136,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
             }
 
             // Retrieve all the valid outgoing edges to explore
-            final Set<Edge> outEdges = candidate.outEdges().stream().filter(this::validEdge)
-                    .collect(Collectors.toSet());
+            final List<Edge> outEdges = candidate.outEdges().stream().filter(this::validEdge)
+                    .distinct().sorted().collect(Collectors.toList());
 
             // Validate highway=pedestrian edges connected to candidate if candidate is
             // motor_vehicle=yes (add to outEdges)
@@ -145,8 +145,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
                     .equals(MotorVehicleTag.YES.name()))
             {
                 outEdges.addAll(candidate.outEdges().stream()
-                        .filter(HighwayTag::isPedestrianNavigableHighway)
-                        .collect(Collectors.toSet()));
+                        .filter(HighwayTag::isPedestrianNavigableHighway).distinct().sorted()
+                        .collect(Collectors.toList()));
             }
 
             if (outEdges.isEmpty())

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -14,6 +14,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  * @author nachtm
  * @author sayas01
  * @author seancoulter
+ * @author bbreithaupt
  */
 public class SinkIslandCheckTest
 {
@@ -22,6 +23,14 @@ public class SinkIslandCheckTest
 
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void permittedSelectAccessTest()
+    {
+        this.verifier.actual(this.setup.permittedSelectAccessAtlas(),
+                new SinkIslandCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
 
     @Test
     public void testEdgesEndingInBuilding()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -15,6 +15,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
  * @author nachtm
  * @author sayas01
  * @author seancoulter
+ * @author bbreithaupt 
  */
 public class SinkIslandCheckTestRule extends CoreTestRule
 {
@@ -207,6 +208,32 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                             "highway=service", "motor_vehicle=yes" }) })
     private Atlas pedestrianRoadAndMotorVehicleYesRoad;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_6)),
+                    @Node(coordinates = @Loc(value = TEST_7), tags = {
+                            "synthetic_boundary_node=yes" }) },
+            // edges
+            edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }, tags = {
+                            "highway=primary", "oneway=yes", "motor_vehicle=designated" }),
+                    @Edge(coordinates = { @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = {
+                            "highway=primary", "oneway=yes", "motor_vehicle=permissive" }),
+                    @Edge(coordinates = { @Loc(value = TEST_3), @Loc(value = TEST_4) }, tags = {
+                            "highway=primary", "oneway=yes", "motorcar=designated" }),
+                    @Edge(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5) }, tags = {
+                            "highway=primary", "oneway=yes", "motorcar=permissive" }),
+                    @Edge(coordinates = { @Loc(value = TEST_5), @Loc(value = TEST_6) }, tags = {
+                            "highway=primary", "oneway=yes", "vehicle=designated" }),
+                    @Edge(coordinates = { @Loc(value = TEST_6), @Loc(value = TEST_7) }, tags = {
+                            "highway=primary", "oneway=yes", "vehicle=permissive" }), })
+    private Atlas permittedSelectAccessAtlas;
+
     public Atlas getEdgeConnectedToPedestrianNetwork()
     {
         return this.pedestrianNetwork;
@@ -285,5 +312,10 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     public Atlas getTwoEdgesWithAmenityAtlas()
     {
         return this.twoEdgesWithAmenityAtlas;
+    }
+
+    public Atlas permittedSelectAccessAtlas()
+    {
+        return this.permittedSelectAccessAtlas;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -15,7 +15,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
  * @author nachtm
  * @author sayas01
  * @author seancoulter
- * @author bbreithaupt 
+ * @author bbreithaupt
  */
 public class SinkIslandCheckTestRule extends CoreTestRule
 {


### PR DESCRIPTION
### Description:
SinkIslandCheck has a list of tag key/values that are used to help define navigable Edges for the check. This updates that list to include the values `designated` and `permissive` for the `motorcar`, `motor_vehicle`, and `vehicle` tags. 

This also makes a small change to the checks graph search to make it more deterministic. Instead of using an unsorted set to collect connected Edges, a sorted list is now used. This ensures candidates are added to the queue in the same order on every run. 

### Potential Impact:
Small drops in flag counts should be expected.

### Unit Test Approach:

A unit test was added to test the new values

### Test Results:
Checked the difference in flags for 7 countries. Out of 84 flags, all were found to now be correctly handled in terms of navigability. 

