### PR TITLE
ShardedIntegrityChecksSparkJob RDD Union Removal

### DIFF
--- a/docs/shardedchecks.md
+++ b/docs/shardedchecks.md
@@ -33,9 +33,6 @@ In order to load geographically connected shards together the job requires a def
 #### In Memory Atlas Type
 By default Sharded Checks uses a [Dynamic Atlas](https://github.com/osmlab/atlas/tree/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/dynamic). It is also possible to use a [Multi Atlas](https://github.com/osmlab/atlas/tree/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/multi) to load Atlas files. This can be done by setting the `multiAtlas` parameter to `true`. It has been found that a Multi Atlas is the more performant in non-distributed environments.
 
-#### Spark Storage
-By default Spark uses memory before disk when storing an RDD. In environments with large mounts of available memory this works well. In memory limited environments this can bog down when trying to process large data sets. In these scenarios it is more efficient to save everything directly to disk. This can be done by setting the `sparkStorageDiskOnly` to `true`.
-
 #### Shared Arguments
 The following are brief descriptions of the parameters that Sharded Atlas Checks shares with the normal job
 


### PR DESCRIPTION
### Description:
In earlier designs of the ShardedIntegrityChecksSparkJob it was necessary to gather all UniqueCheckFlagContainers together into a single RDD. This was required to perform a sorting and reduction process to countrify the results. Now that the tasks are parallelized in a countrified manor this is no longer necessary, and causes spark to perform a very large, unnecessary shuffle operation.  

This removes the RDD union in favor of running the flag reduction and file writing operations as part of each countrified stream. This should increase performance for the job on clusters by reducing the amount of communication necessary between executors. 

With the removal of the union it is no longer necessary to persist any RDDs. As such, the spark storage option is no longer needed, and has been removed. 

### Potential Impact:
Should improve performance and stability when running on a cluster. 

### Unit Test Approach:

No changes to unit tests.

### Test Results:
Tested locally on 5 small countries. Results were identical to those produced before the enhancement. 

