### PR TITLE
Update FlaggedRelation to Output Atlas Identifier and OSM Identifier as String

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -3,6 +3,7 @@ package org.openstreetmap.atlas.checks.flag;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.gson.JsonElement;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.MultiPolygon;
@@ -64,6 +65,12 @@ public class FlaggedRelation extends FlaggedObject
     public JsonObject asGeoJsonFeature(final String flagIdentifier)
     {
         final JsonObject featureProperties = this.relation.getGeoJsonProperties();
+        final JsonElement osmIdentifier = featureProperties.get(OSM_IDENTIFIER_TAG);
+        final JsonElement identifier = featureProperties.get(GeoJsonUtils.IDENTIFIER);
+        featureProperties.remove(OSM_IDENTIFIER_TAG);
+        featureProperties.remove(GeoJsonUtils.IDENTIFIER);
+        featureProperties.addProperty(OSM_IDENTIFIER_TAG, osmIdentifier.toString());
+        featureProperties.addProperty(GeoJsonUtils.IDENTIFIER, identifier.toString());
         featureProperties.addProperty("flag:id", flagIdentifier);
         featureProperties.addProperty("flag:type", FlaggedRelation.class.getSimpleName());
         return GeoJsonUtils.feature(this.multipolygonGeometry.asGeoJsonGeometry(),
@@ -205,7 +212,7 @@ public class FlaggedRelation extends FlaggedObject
         // bounding box as a polygon geometry.
         else
         {
-            return MultiPolygon.forOuters(relation.bounds());
+            return MultiPolygon.forPolygon(relation.bounds());
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -212,7 +212,7 @@ public class FlaggedRelation extends FlaggedObject
         // bounding box as a polygon geometry.
         else
         {
-            return MultiPolygon.forPolygon(relation.bounds());
+            return MultiPolygon.forOuters(relation.bounds());
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -69,6 +69,9 @@ public class FlaggedRelation extends FlaggedObject
         final JsonObject featureProperties = this.relation.getGeoJsonProperties();
         final JsonElement osmIdentifier = featureProperties.get(OSM_IDENTIFIER_TAG);
         final JsonElement identifier = featureProperties.get(IDENTIFIER);
+        // Since the properties of all other FlaggedObjects are String, osmIdentifier and
+        // identifier values of FlaggedRelation, which are Integers are removed and added as String
+        // here
         featureProperties.remove(OSM_IDENTIFIER_TAG);
         featureProperties.remove(IDENTIFIER);
         featureProperties.addProperty(OSM_IDENTIFIER_TAG, osmIdentifier.toString());

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -1,9 +1,11 @@
 package org.openstreetmap.atlas.checks.flag;
 
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonUtils.IDENTIFIER;
+import static org.openstreetmap.atlas.geography.geojson.GeoJsonUtils.feature;
+
 import java.util.Map;
 import java.util.Optional;
 
-import com.google.gson.JsonElement;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.MultiPolygon;
@@ -13,13 +15,13 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
 import org.openstreetmap.atlas.geography.atlas.items.complex.RelationOrAreaToMultiPolygonConverter;
-import org.openstreetmap.atlas.geography.geojson.GeoJsonUtils;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
@@ -66,15 +68,14 @@ public class FlaggedRelation extends FlaggedObject
     {
         final JsonObject featureProperties = this.relation.getGeoJsonProperties();
         final JsonElement osmIdentifier = featureProperties.get(OSM_IDENTIFIER_TAG);
-        final JsonElement identifier = featureProperties.get(GeoJsonUtils.IDENTIFIER);
+        final JsonElement identifier = featureProperties.get(IDENTIFIER);
         featureProperties.remove(OSM_IDENTIFIER_TAG);
-        featureProperties.remove(GeoJsonUtils.IDENTIFIER);
+        featureProperties.remove(IDENTIFIER);
         featureProperties.addProperty(OSM_IDENTIFIER_TAG, osmIdentifier.toString());
-        featureProperties.addProperty(GeoJsonUtils.IDENTIFIER, identifier.toString());
+        featureProperties.addProperty(IDENTIFIER, identifier.toString());
         featureProperties.addProperty("flag:id", flagIdentifier);
         featureProperties.addProperty("flag:type", FlaggedRelation.class.getSimpleName());
-        return GeoJsonUtils.feature(this.multipolygonGeometry.asGeoJsonGeometry(),
-                featureProperties);
+        return feature(this.multipolygonGeometry.asGeoJsonGeometry(), featureProperties);
     }
 
     /**


### PR DESCRIPTION
### Description:

For all FlaggedObjects, except FlaggedRelation, the "osmIdentifer" and "identifier" fields in the feature properties are string. In case of FlaggedRelation, these fields are populated as integers. This PR updates the "asGeoJsonFeature" method in FlaggedRelation to populate the  "osmIdentifer" and "identifier" fields as string instead of as integers.

List potential impact to downstream libraries here (ex. atlas-checks, atlas-generator)
The "identifier" and "osmIdentifier" keys in the properties of geojson features for FlaggedRelation will be string just like in other FlaggedObjects.

### Unit Test Approach:

Locally ran the updates on checks that flag relation and verified the geojson and log files

### Test Results:
Before updates:

<img src="https://user-images.githubusercontent.com/42149840/81218353-eb115400-8f92-11ea-9035-28f94384f75d.png" height=300 width=300 />

After updates:

<img src="https://user-images.githubusercontent.com/42149840/81218332-e51b7300-8f92-11ea-8388-9c1cfae50b04.png" height=300 width=300 />




