### PR TITLE
Add simple Dockerfile sandbox & docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# Use base image: https://github.com/keeganwitt/docker-gradle
+FROM gradle:jdk11
+
+RUN mkdir /app/atlas-checks
+COPY . /app/atlas-checks
+
+ENTRYPOINT ["/app/atlas-checks/gradlew"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use base image: https://github.com/keeganwitt/docker-gradle
 FROM gradle:jdk11
 
-RUN mkdir /app/atlas-checks
+RUN mkdir -p /app/atlas-checks
 COPY . /app/atlas-checks
 
 ENTRYPOINT ["/app/atlas-checks/gradlew"]

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -18,6 +18,10 @@ There are a couple of requirements for building and running a new Atlas Check. T
 - Some form of IDE
     - There are multiple editors that you can use to help you build your Atlas Check. You can use text editors like [Notepad(++)](https://notepad-plus-plus.org/), [Vim](http://www.vim.org/download.php), [Emacs](https://www.gnu.org/software/emacs/) or [Sublime](https://www.sublimetext.com). Or you can use a full integrated development environment like [Intellij Idea](https://www.jetbrains.com/idea/) or [Eclipse](https://eclipse.org).
 
+Alternatively, use the [Dockerfile](/Dockerfile) to create a development environment. See the docker
+[documentation](/docs/docker.md) for installation instructions.
+
+
 ### Building Check Template
 Building a check template is as easy as running a very basic command using gradle:
 `./gradlew buildCheck -PCheckName=CheckName`
@@ -226,17 +230,7 @@ The properties of each flag will contain the following items:
 
 ### Currently Available Checks
 
-- [PoolSizeCheck](tutorials/tutorial1-PoolSizeCheck.md)
-- [BuildingRoadIntersectionCheck](checks/buildingRoadIntersectionCheck.md)
-- [SelfIntersectingPolylineCheck](checks/selfIntersectingPolylineCheck.md)
-- [FloatingEdgeCheck](checks/floatingEdgeCheck.md)
-- [RoundAboutClosedLoopCheck](checks/roundaboutClosedLoopCheck.md)
-- [SharpAngleCheck](checks/sharpAngleCheck.md)
-- [SinkIslandCheck](tutorials/tutorial3-SinkIslandCheck.md)
-- [SnakeRoadCheck](checks/snakeRoadCheck.md)
-- [DuplicateNodeCheck](checks/duplicateNodeCheck.md)
-- [OrphanNodeCheck](tutorials/tutorial2-OrphanNodeCheck.md)
-- [InvalidTurnRestrictionCheck](checks/invalidTurnRestrictionCheck.md)
+See the [checks catalog](/docs/available_checks.md) for a list and description of available checks.
 
 ** For Best Practices around writing Atlas Checks, please view our [best practices document](bestpractices.md). **
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
-# Docker
+# Development - Docker
 
-A simple Docker container for local development use. The base image is derived from
+Use the [Dockerfile](/Dockerfile) to build a simple Docker container for development. The base image is derived from
 [docker-gradle](https://github.com/keeganwitt/docker-gradle), a simple image that contains 
 both gradle (v6.4) and [adoptopenjdk11](https://github.com/AdoptOpenJDK/openjdk-docker).
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,14 +7,14 @@ both gradle (v6.4) and [adoptopenjdk11](https://github.com/AdoptOpenJDK/openjdk-
 ## Installation and setup
 Create docker image (in atlas-checks root).
 ```bash
-docker run [image name] [gradle command]
+docker build --rm --tag checks .
 ```
 
 Create a docker container from the "checks" image. By default, the container exposes the gradle
 wrapper (`gradlew`) script that invokes project's latest version of gradle. With this, you can
 run the following commands: `run, build, buildCheck`
 ```bash
-docker build --rm --tag checks .
+docker run [image name] [gradle command]
 ```
 
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,42 @@
+# Docker
+
+A simple Docker container for local development use. The base image is derived from
+[docker-gradle](https://github.com/keeganwitt/docker-gradle), a simple image that contains 
+both gradle (v6.4) and [adoptopenjdk11](https://github.com/AdoptOpenJDK/openjdk-docker).
+
+## Installation and setup
+Create docker image (in atlas-checks root).
+```bash
+docker run [image name] [gradle command]
+```
+
+Create a docker container from the "checks" image. By default, the container exposes the gradle
+wrapper (`gradlew`) script that invokes project's latest version of gradle. With this, you can
+run the following commands: `run, build, buildCheck`
+```bash
+docker build --rm --tag checks .
+```
+
+
+## Examples
+Build the project (runs unit and integration tests).
+```
+docker run checks clean build
+```
+
+Run the default gradle run command. This will download a example pbf from geofabrik, execute the
+atlas checks specified in the default configuration, and save the results to 
+`/app/atlas-checks/build/example/flag`
+
+```
+docker run checks run
+```
+
+Run the gradle run command using your local directory as the source. This is useful for local
+development -- as changes to to the source code will be reflected when executing the command. Also,
+outputs will be stored on your local machine.
+```bash
+docker run --mount type=bind,src=/path/to/local/atlas-checks,dst=/app/atlas-checks checks run \
+-Pchecks.local.countries=AIA \
+-Pchecks.local.checkFilter=SpikyBuildingCheck
+```


### PR DESCRIPTION
### Description:

This adds a simple Dockerfile & documentation for local development use. By default, the `gradlew` command is exposed by the Docker container.

Steps for use:
1. Create image
```bash
docker build --rm --tag [image name] .
```
2. Create container from image and execute command
```bash
docker run [image name] [gradle command]
```

Example
```bash
docker build --rm --tag checks .
docker run checks run -Pchecks.local.checkFilter=SpikyBuildingCheck \
-Pchecks.local.countries=AIA
```

Fixes #289 #293 

### Potential Impact:

No downstream impact

### Unit Test Approach:

Created and image and container. Was able to execute both gradlew build and run commands.

### Test Results:

Tests pass!

