### PR TITLE
Update Gradle Run to Use Sharded Checks By Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To start working with Atlas Checks follow the steps below:
 2. Switch to newly created directory: `cd atlas-checks`
 3. Execute `./gradlew run`
 
-This command will build and run Atlas Checks with all the default options against a sample OSM PBF of Belize downloaded from [here](https://apple.box.com/s/3k3wcc0lq1fhqgozxr4mdi0llf95byo3). GeoJSON output will be produced that contains all the results found from the run. Those outputs will be found in `atlas-checks/build/examples/data/output`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
+This command will build and run Atlas Checks with all the default options against a sample Atlases of Belize downloaded from [here](https://uc6f1395c4244d78e8c5da2efa27.dl.dropboxusercontent.com/zip_download_get/Aa7gnKbK7HUcG3UNuQzIjDJz3DFvn8hzVoPyUM32Egx_xI7sz3i3cjCOEjl0XTr6-qZxirkoR3Tb3lgNBX75xO82S3g_Yzc7fx4DbxBeGGRw6g). GeoJSON output will be produced that contains all the results found from the run. Those outputs will be found in `atlas-checks/build/examples/data/output`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
 
 ## Working with Configuration
 See [configuration docs](docs/configuration.md) for more information about the configuration files that can be used to define specific details around the Atlas Checks application.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To start working with Atlas Checks follow the steps below:
 2. Switch to newly created directory: `cd atlas-checks`
 3. Execute `./gradlew run`
 
-This command will build and run Atlas Checks with all the default options against a sample Atlases of Belize downloaded from [here](https://uc6f1395c4244d78e8c5da2efa27.dl.dropboxusercontent.com/zip_download_get/Aa7gnKbK7HUcG3UNuQzIjDJz3DFvn8hzVoPyUM32Egx_xI7sz3i3cjCOEjl0XTr6-qZxirkoR3Tb3lgNBX75xO82S3g_Yzc7fx4DbxBeGGRw6g). GeoJSON output will be produced that contains all the results found from the run. Those outputs will be found in `atlas-checks/build/examples/data/output`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
+This command will build and run Atlas Checks with all the default options against a sample Atlases of Belize downloaded from [here](https://www.dropbox.com/sh/54aqfbs12suqd9t/AAC8bpVWCgGLY-SZ30XKIY92a/atlas/BLZ). GeoJSON output will be produced that contains all the results found from the run. Those outputs will be found in `atlas-checks/build/examples/data/output`. For more information on running Atlas Checks as a standalone application click [here](docs/standalone.md).
 
 ## Working with Configuration
 See [configuration docs](docs/configuration.md) for more information about the configuration files that can be used to define specific details around the Atlas Checks application.

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -9,7 +9,7 @@ about the basemap data.
 
 ### Prerequisites
 There are a couple of requirements for building and running a new Atlas Check. The following are required:
-- [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 
+- [Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html) 
     - Click on the link to go and install the latest Java 8 JDK. Follow the instructions for Linux, Mac or Windows operating systems.
 - [Gradle](https://gradle.org/install) 
     - Click on the link to go and install the latest version of Gradle. Follow the instructions for Linux, Mac or Windows operating systems

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -9,7 +9,7 @@ about the basemap data.
 
 ### Prerequisites
 There are a couple of requirements for building and running a new Atlas Check. The following are required:
-- [Java 11](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html) 
+- [Java 11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot) 
     - Click on the link to go and install the latest Java 8 JDK. Follow the instructions for Linux, Mac or Windows operating systems.
 - [Gradle](https://gradle.org/install) 
     - Click on the link to go and install the latest version of Gradle. Follow the instructions for Linux, Mac or Windows operating systems

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -1,6 +1,6 @@
 # Running Atlas Checks as a Standalone Application
 
-For prerequisites for running checks see [dev.md](dev.md). To run the checks only the first two prerequisites are required, Java8 and Gradle.
+For prerequisites for running checks see [dev.md](dev.md). To run the checks only the first two prerequisites are required, Java11 and Gradle.
 
 Atlas Checks can easily be executed using all the default settings with no additional requirements by simply executing
 the following statement in the root directory of the cloned Atlas Checks repository:
@@ -13,12 +13,12 @@ This will run Atlas Checks using the [configuration.json](../config/configuratio
 
 Atlas Checks allows you to run the checks against PBF files.
 
-`./gradlew run` will download a sample BLZ (Belize) PBF file and run the cheks on it automatically.
+`./gradlew run -Pchecks.local.sharded=false -Pchecks.local.input=https://download.geofabrik.de/central-america/belize-latest.osm.pbf` will download a BLZ (Belize) PBF file and run the checks on it automatically.
 
-If you want to supply a location to a remote PBF you can use a project property in Gradle to set the PBF location
-and execute
+You can change the value of the `checks.local.input` parameter to any remote PBF file you like.
 
-`gradle run -Pchecks.local.input=https://download.geofabrik.de/africa/south-africa-latest.osm.pbf`
+The `checks.local.sharded` parameter must be set to `false` to use gradle run with a PBF. The sharded checks job only works with sharded Atlas files. 
+
 
 #### Running against PBF with Bounding Box
 
@@ -28,7 +28,7 @@ area allows Atlas Checks to complete faster, or simply for focus. Like running a
 the PBF file using either a URL location or a local file, but in this case you would include the bounding
 box as well.
 
-`./gradlew run -Pchecks.local.input=https://download.geofabrik.de/africa/south-africa-latest.osm.pbf -Pchecks.local.pbfBoundingBox=lat,lon:lat,lon`
+`./gradlew run -Pchecks.local.sharded=false -Pchecks.local.input=https://download.geofabrik.de/africa/south-africa-latest.osm.pbf -Pchecks.local.pbfBoundingBox=lat,lon:lat,lon`
 
 In the above case you would replace lat,lon:lat,lon with the actual bounds of your box.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ profile=local
 ## Local (default)
 checks.local.sharded=true
 checks.local.configFiles=file://@ROOTDIR@/config/configuration.json
-checks.local.input=file://@BUILDDIR@/example/data/atlases/
+checks.local.input=file://@BUILDDIR@/example/data/atlas/
 checks.local.output=file://@BUILDDIR@/example/data/output/
 checks.local.outputFormats=flags,geojson,metrics
 checks.local.countries=BLZ

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,15 +15,16 @@ project_scm=scm:git:https://github.com/osmlab/atlas-checks.git
 profile=local
 
 ## Local (default)
-checks.local.mainClass=org.openstreetmap.atlas.checks.distributed.IntegrityCheckSparkJob
+checks.local.mainClass=org.openstreetmap.atlas.checks.distributed.ShardedIntegrityChecksSparkJob
 checks.local.configFiles=file://@ROOTDIR@/config/configuration.json
-checks.local.input=file://@BUILDDIR@/example/data/pbfs/
+checks.local.input=file://@BUILDDIR@/example/data/atlases/
 checks.local.output=file://@BUILDDIR@/example/data/output/
 checks.local.outputFormats=flags,geojson,metrics
-checks.local.countries=UNK
+checks.local.countries=BLZ
 #checks.local.pbfBoundingBox=
 checks.local.savePbfAtlas=true
 checks.local.compressOutput=false
 checks.local.startedFolder=file://@BUILDDIR@/example/tmp/
 checks.local.master=local
+checks.local.multiAtlas=true
 checks.local.sparkOptions=spark.executor.memory->4g,spark.driver.memory->4g,spark.rdd.compress->true

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ project_scm=scm:git:https://github.com/osmlab/atlas-checks.git
 profile=local
 
 ## Local (default)
-checks.local.mainClass=org.openstreetmap.atlas.checks.distributed.ShardedIntegrityChecksSparkJob
+checks.local.sharded=true
 checks.local.configFiles=file://@ROOTDIR@/config/configuration.json
 checks.local.input=file://@BUILDDIR@/example/data/atlases/
 checks.local.output=file://@BUILDDIR@/example/data/output/

--- a/gradle/execute.gradle
+++ b/gradle/execute.gradle
@@ -1,19 +1,22 @@
 task downloadAtlases {
     doLast {
-        mkdir "${buildDir}/example/data/atlases/"
-        ant.get(src: "https://dl.dropboxusercontent.com/zip_download_get/Aa7gnKbK7HUcG3UNuQzIjDJz3DFvn8hzVoPyUM32Egx_xI7sz3i3cjCOEjl0XTr6-qZxirkoR3Tb3lgNBX75xO82S3g_Yzc7fx4DbxBeGGRw6g",
-            dest: "${buildDir}/example/data/atlases/BLZ.zip",
+        mkdir "${buildDir}/example/data/atlas/"
+        ant.get(src: "https://dl.dropboxusercontent.com/s/0f6tmuyovwva2jz/BLZ.zip",
+            dest: "${buildDir}/example/data/atlas/BLZ.zip",
             skipexisting: 'true')
-        ant.get(src: "https://dl.dropboxusercontent.com/cd/0/get/A3h0gTqq9G5NiQxtTElNqaOGvb0VoIUlK20O2ub4CYuRCMajHcwyZdyKduGE8p41bmJ_n2GgCO2oRm3b1Mxnrn2nw5vz0M79U2jJJykmAv6FDQ/file",
-                dest: "${buildDir}/example/data/atlases/sharding.txt",
+        ant.get(src: "https://dl.dropboxusercontent.com/s/pb99909ake348mx/tree-6-14-100000.txt",
+                dest: "${buildDir}/example/data/atlas/sharding.txt",
                 skipexisting: 'true')
     }
 }
 
 task unzipAtlases (dependsOn: 'downloadAtlases') {
     doLast {
-        ant.unzip(src: "${buildDir}/example/data/atlases/BLZ.zip",
-            dest: "${buildDir}/example/data/atlases/BLZ")
+        ant.unzip(src: "${buildDir}/example/data/atlas/BLZ.zip",
+            dest: "${buildDir}/example/data/atlas/unzip")
+        ant.copydir(src: "${buildDir}/example/data/atlas/unzip/BLZ",
+            dest: "${buildDir}/example/data/atlas/BLZ")
+        ant.delete(dir: "${buildDir}/example/data/atlas/unzip")
     }
 }
 

--- a/gradle/execute.gradle
+++ b/gradle/execute.gradle
@@ -1,16 +1,19 @@
-task downloadPbf {
+task downloadAtlases {
     doLast {
-        mkdir "${buildDir}/example/data/pbfSource/"
-        ant.get(src: "https://dl.dropboxusercontent.com/s/ddvpimpnbv6o43t/belize-geofabrik-2019-03-13T21-14-02Z.osm.pbf",
-            dest: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
+        mkdir "${buildDir}/example/data/atlases/"
+        ant.get(src: "https://uc6f1395c4244d78e8c5da2efa27.dl.dropboxusercontent.com/zip_download_get/Aa7gnKbK7HUcG3UNuQzIjDJz3DFvn8hzVoPyUM32Egx_xI7sz3i3cjCOEjl0XTr6-qZxirkoR3Tb3lgNBX75xO82S3g_Yzc7fx4DbxBeGGRw6g",
+            dest: "${buildDir}/example/data/atlases/BLZ.zip",
             skipexisting: 'true')
+        ant.get(src: "https://uc023c426e3ebfeb1af0658a9821.dl.dropboxusercontent.com/cd/0/get/A3j9YdKpvcDEeIUMCV5qopbOWJBZ7vUpocaOeTGYWTOIa_XlGOG75UIkfCAHGUi-M79QSRaq0e1U1N28L1j-zv7Hc0ZocsBA2QNDcsDka2Mg0Q/file",
+                dest: "${buildDir}/example/data/atlases/sharding.txt",
+                skipexisting: 'true')
     }
 }
 
-task copyPbf (dependsOn: 'downloadPbf') {
+task unzipAtlases (dependsOn: 'downloadAtlases') {
     doLast {
-        ant.copy(file: "${buildDir}/example/data/pbfSource/belize.osm.pbf",
-            toFile: "${buildDir}/example/data/pbfs/belize.osm.pbf")
+        ant.unzip(src: "${buildDir}/example/data/atlases/BLZ.zip",
+            dest: "${buildDir}/example/data/atlases/BLZ")
     }
 }
 
@@ -52,8 +55,8 @@ task runChecks(type: JavaExec, dependsOn: 'assemble', description: 'Executes the
  * Wraps runChecks to perform any task involving setup or teardown
  */
 task run(dependsOn: ['assemble',
-        'downloadPbf',
-        'copyPbf'], group: 'application', description: 'Runs the Atlas Check framework configured using profiles defined in gradle.properties.') {
+        'downloadAtlases',
+        'unzipAtlases'], group: 'application', description: 'Runs the Atlas Check framework configured using profiles defined in gradle.properties.') {
     doLast {
         runChecks.getCommandLine().each {
             line -> println("$line \\")

--- a/gradle/execute.gradle
+++ b/gradle/execute.gradle
@@ -1,10 +1,10 @@
 task downloadAtlases {
     doLast {
         mkdir "${buildDir}/example/data/atlases/"
-        ant.get(src: "https://uc6f1395c4244d78e8c5da2efa27.dl.dropboxusercontent.com/zip_download_get/Aa7gnKbK7HUcG3UNuQzIjDJz3DFvn8hzVoPyUM32Egx_xI7sz3i3cjCOEjl0XTr6-qZxirkoR3Tb3lgNBX75xO82S3g_Yzc7fx4DbxBeGGRw6g",
+        ant.get(src: "https://dl.dropboxusercontent.com/zip_download_get/Aa7gnKbK7HUcG3UNuQzIjDJz3DFvn8hzVoPyUM32Egx_xI7sz3i3cjCOEjl0XTr6-qZxirkoR3Tb3lgNBX75xO82S3g_Yzc7fx4DbxBeGGRw6g",
             dest: "${buildDir}/example/data/atlases/BLZ.zip",
             skipexisting: 'true')
-        ant.get(src: "https://uc023c426e3ebfeb1af0658a9821.dl.dropboxusercontent.com/cd/0/get/A3j9YdKpvcDEeIUMCV5qopbOWJBZ7vUpocaOeTGYWTOIa_XlGOG75UIkfCAHGUi-M79QSRaq0e1U1N28L1j-zv7Hc0ZocsBA2QNDcsDka2Mg0Q/file",
+        ant.get(src: "https://dl.dropboxusercontent.com/cd/0/get/A3h0gTqq9G5NiQxtTElNqaOGvb0VoIUlK20O2ub4CYuRCMajHcwyZdyKduGE8p41bmJ_n2GgCO2oRm3b1Mxnrn2nw5vz0M79U2jJJykmAv6FDQ/file",
                 dest: "${buildDir}/example/data/atlases/sharding.txt",
                 skipexisting: 'true')
     }
@@ -27,7 +27,9 @@ task unzipAtlases (dependsOn: 'downloadAtlases') {
 task runChecks(type: JavaExec, dependsOn: 'assemble', description: 'Executes the Atlas Check Spark job.') {
     classpath = sourceSets.main.runtimeClasspath
 
-    main = project.property("checks.${project.profile}.mainClass")
+    main = project.property("checks.${project.profile}.sharded").equals("true")
+            ? "org.openstreetmap.atlas.checks.distributed.ShardedIntegrityChecksSparkJob"
+            : "org.openstreetmap.atlas.checks.distributed.IntegrityCheckSparkJob"
 
     // apply arguments defined in the gradle.properties file for this profile
     def flags = project.properties.findAll { property ->


### PR DESCRIPTION
### Description:

This changes the default behavior of the `gradle run` command to use the ShardedIntegrityChecksSparkJob instead of the IntegrityCheckSparkJob. 
The `mainclass` property has been replaced with a `sharded`. This new property acts as a switch to designate which spark job to use. If it is true (default) the sharded job is used, else the regular checks job is used. 

As part of this change the example run had to be altered to use Atlas files instead of a PBF. By default `gradle run` will now download example BLZ atlases and a sharding tree, and run sharded checks on that data. 

The documentation has been updated to reflect these changes. 

### Potential Impact:

If any downstream projects rely on the `gradle run` command they will see a change in the spark job used. 

### Unit Test Approach:

None

### Test Results:

Tested the `gradle run` command on the example data, local atlases, and remote PBFs. Both spark jobs were tested when applicable. Data was correctly acquired, and results were as expected in all cases. 

