### PR TITLE
Atlas-Checks version bump from 6.0.5 to 6.0.6 in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=6.0.5-SNAPSHOT
+version=6.0.6-SNAPSHOT
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
The next version bump from atlas-checks 6.0.5 to 6.0.6.