### PR TITLE
[MapRouletteUploadCommand] Fix countrified challenge names

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -141,10 +141,10 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                             {
                                 final Map<String, Challenge> countryToChallengeMap = this.checkNameChallengeMap
                                         .computeIfAbsent(task.getChallengeName(),
-                                                theName -> new HashMap<>());
+                                                ignore -> new HashMap<>());
                                 final Challenge challenge = countryToChallengeMap.computeIfAbsent(
                                         countryCode.orElse(""),
-                                        theName -> this.getChallenge(task.getChallengeName(),
+                                        ignore -> this.getChallenge(task.getChallengeName(),
                                                 instructions, countryCode));
                                 this.addTask(challenge, task);
                             }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -60,7 +60,9 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             string -> Arrays.asList(string.split(",")), Optionality.OPTIONAL);
     private static final String PARAMETER_CHALLENGE = "challenge";
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteUploadCommand.class);
-    private final Map<String, Challenge> checkNameChallengeMap;
+
+    // Challenge name --> [ ISO --> countrified Challenge ]
+    private final Map<String, Map<String, Challenge>> checkNameChallengeMap;
 
     public static void main(final String[] args)
     {
@@ -137,8 +139,13 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                         {
                             try
                             {
-                                final Challenge challenge = this.getChallenge(
-                                        task.getChallengeName(), instructions, countryCode);
+                                final Map<String, Challenge> countryToChallengeMap = this.checkNameChallengeMap
+                                        .computeIfAbsent(task.getChallengeName(),
+                                                theName -> new HashMap<>());
+                                final Challenge challenge = countryToChallengeMap.computeIfAbsent(
+                                        countryCode.orElse(""),
+                                        theName -> this.getChallenge(task.getChallengeName(),
+                                                instructions, countryCode));
                                 this.addTask(challenge, task);
                             }
                             catch (URISyntaxException | UnsupportedEncodingException error)
@@ -173,19 +180,16 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
     private Challenge getChallenge(final String checkName,
             final Configuration fallbackConfiguration, final Optional<String> countryCode)
     {
-        return this.checkNameChallengeMap.computeIfAbsent(checkName, name ->
-        {
-            final Map<String, String> challengeMap = fallbackConfiguration
-                    .get(getChallengeParameter(checkName), Collections.emptyMap()).value();
-            final Gson gson = new GsonBuilder().disableHtmlEscaping()
-                    .registerTypeAdapter(Challenge.class, new ChallengeDeserializer()).create();
-            final Challenge result = gson.fromJson(gson.toJson(challengeMap), Challenge.class);
-            // Prepend the challenge name with the full country name if one exists
-            final String challengeName = String.join(" - ", this.getCountryDisplayName(countryCode),
-                    result.getName().isEmpty() ? checkName : result.getName());
-            result.setName(challengeName);
-            return result;
-        });
+        final Map<String, String> challengeMap = fallbackConfiguration
+                .get(getChallengeParameter(checkName), Collections.emptyMap()).value();
+        final Gson gson = new GsonBuilder().disableHtmlEscaping()
+                .registerTypeAdapter(Challenge.class, new ChallengeDeserializer()).create();
+        final Challenge result = gson.fromJson(gson.toJson(challengeMap), Challenge.class);
+        // Prepend the challenge name with the full country name if one exists
+        final String challengeName = String.join(" - ", this.getCountryDisplayName(countryCode),
+                result.getName().isEmpty() ? checkName : result.getName());
+        result.setName(challengeName);
+        return result;
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -46,7 +46,7 @@ public class MapRouletteUploadCommandTest
     public void testCheckFilter()
     {
         final String[] additionalArguments = { "-checks=SomeCheck" };
-        this.runAndTest(additionalArguments, 1, 1, 1);
+        this.runAndTest(additionalArguments, 1, 2, 2);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class MapRouletteUploadCommandTest
     public void testExecute()
     {
         final String[] additionalArguments = {};
-        this.runAndTest(additionalArguments, 1, 3, 3);
+        this.runAndTest(additionalArguments, 1, 4, 4);
     }
 
     @Test
@@ -91,6 +91,7 @@ public class MapRouletteUploadCommandTest
         Assert.assertEquals("Canada - Spiky Buildings", challengeNames.get(0));
         Assert.assertEquals("Mexico, Belize - Intersecting Lines", challengeNames.get(1));
         Assert.assertEquals("United States - Address Point Match", challengeNames.get(2));
+        Assert.assertEquals("Uruguay - Address Point Match", challengeNames.get(3));
     }
 
     @Before
@@ -105,6 +106,7 @@ public class MapRouletteUploadCommandTest
             unzippedProcessor.process(this.setup.getOneBasicFlag());
             unzippedProcessor.process(this.setup.getTwoCountryFlag());
             unzippedProcessor.process(this.setup.getAnotherBasicFlag());
+            unzippedProcessor.process(this.setup.getFlagSameCheck());
             unzippedProcessor.process(new ShutdownEvent());
 
             // Create a zipped file

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTestRule.java
@@ -20,7 +20,8 @@ public class MapRouletteUploadCommandTestRule extends CoreTestRule
     private static final String CENTER = "0,0";
     private static final String IDENTIFIER_1 = "1";
     private static final String IDENTIFIER_2 = "2";
-    private static final String IDENTIFIER_3 = "2";
+    private static final String IDENTIFIER_3 = "3";
+    private static final String IDENTIFIER_4 = "4";
     private static final String CHALLENGE_1 = "SomeCheck";
     private static final String CHALLENGE_2 = "SomeOtherCheck";
     private static final String CHALLENGE_3 = "AnotherCheck";
@@ -30,12 +31,19 @@ public class MapRouletteUploadCommandTestRule extends CoreTestRule
             @Point(coordinates = @Loc(value = CENTER), id = "1", tags = { "iso_country_code=USA" }),
             @Point(coordinates = @Loc(value = CENTER), id = "2", tags = { "iso_country_code=CAN" }),
             @Point(coordinates = @Loc(value = CENTER), id = "3", tags = {
-                    "iso_country_code=MEX,BLZ" }) })
+                    "iso_country_code=MEX,BLZ" }),
+            @Point(coordinates = @Loc(value = CENTER), id = "4", tags = {
+                    "iso_country_code=URY" }) })
     private Atlas basicAtlas;
 
     public CheckFlagEvent getAnotherBasicFlag()
     {
         return this.getBasicFlag(IDENTIFIER_2, this.basicAtlas.point(2L), CHALLENGE_2);
+    }
+
+    public CheckFlagEvent getFlagSameCheck()
+    {
+        return this.getBasicFlag(IDENTIFIER_4, this.basicAtlas.point(4L), CHALLENGE_1);
     }
 
     public CheckFlagEvent getOneBasicFlag()


### PR DESCRIPTION
### Description:

The MapRoulette upload command is able to upload a subset of flags in the input directory according to which countries are passed in to the `-countries` flag. However, there were issues when a given Check was found in more than one country passed in to the `-countries` flag. For example, if LineCrossingWaterBodyCheck was found in PER and PRY, and those two countries had their flags uploaded using the upload command. This caused the flags from both countries to be grouped under a single Challenge (determined by encounter order while parsing the log file), e.g. everything goes under "Peru - LineCrossingWaterBodyCheck".

The fix in this PR makes sure that if a Check name is found in more than one country, separate challenges are created and flags stored accordingly. In the example above, this means there's now a challenge for "Paraguay - LineCrossingWaterBodyCheck" and "Peru - LineCrossingWaterBodyCheck".


### Potential Impact:

Countrified Challenge names more accurately reflect the flags they hold

### Unit Test Approach:

Edited unit tests for this fix

Also did upload tests using the command.

Before the fix:
<img width="928" alt="image" src="https://user-images.githubusercontent.com/31253489/82086427-5b128f00-96a3-11ea-9423-e116b1a11e16.png">


After the fix
<img width="928" alt="image" src="https://user-images.githubusercontent.com/31253489/82085632-2e11ac80-96a2-11ea-9298-790a7905a565.png">

### Test Results:

Unit tests pass

