### PR TITLE
InvalidMultiPolygonRelationCheck Overlap Test Limits

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -376,6 +376,8 @@
   },
   "InvalidMultiPolygonRelationCheck": {
     "members.one.ignore": true,
+    "overlap.points.minimum": 0,
+    "overlap.points.maximum": 2000000,
     "challenge": {
       "description": "Tasks containing improperly formed multipolygon relations.",
       "blurb": "Invalid Multipolygon Relations",

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTest.java
@@ -95,6 +95,24 @@ public class InvalidMultiPolygonRelationCheckTest
     }
 
     @Test
+    public void overlappingOutersMaximumPointsTest()
+    {
+        this.verifyCheck(this.setup.overlappingOutersAtlas(),
+                ConfigurationResolver.inlineConfiguration(
+                        "{\"InvalidMultiPolygonRelationCheck\":{\"overlap.points.maximum\":2}}"),
+                0, Collections.emptyList());
+    }
+
+    @Test
+    public void overlappingOutersMinimumPointsTest()
+    {
+        this.verifyCheck(this.setup.overlappingOutersAtlas(),
+                ConfigurationResolver.inlineConfiguration(
+                        "{\"InvalidMultiPolygonRelationCheck\":{\"overlap.points.minimum\":2000}}"),
+                0, Collections.emptyList());
+    }
+
+    @Test
     public void overlappingOutersTest()
     {
         this.verifyCheck(this.setup.overlappingOutersAtlas(),


### PR DESCRIPTION
### Description:
InvalidMultiPolygonRelationCheck was recently enhanced to include tests for overlapping polygon members. However these test are computationally heavy. In the case of extremely large multipolygon relations this can take an excessive amount of time. To help manage this two new configurable are added. These configurable are used to limit the size of relations that are checked for overlapping polygons in their geometry. If the number of shape points in a multipolygon relation's geometry falls outside the limits of the configurables then the overlap test will be skipped. All other tests in the check will still be performed on all multipolygon relations. 

**New Configurables**:
`"overlap.points.minimum"`: minimum number of shape points to be eligible for overlap tests (default 0)
`"overlap.points.maximum"`: maximum number of shape points to be eligible for overlap tests (default 200000)

**Example Large Multipolygon**
https://www.openstreetmap.org/relation/4647128

### Potential Impact:

This could drop a few flags.
New configurables to manage.

### Unit Test Approach:
Added unit tests for the new configurables.

### Test Results:

Tested on 6 countries. No dropped flags were found. Run time in one country was increased from about 3 hours to about 10 minutes. 

