### PR TITLE
[MapRouletteUploadCommand] Filter empty lines

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -118,7 +118,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             {
                 try (BufferedReader reader = FileUtility.getReader(logFile, logOutputFileType))
                 {
-                    reader.lines().forEach(line ->
+                    reader.lines().filter(line -> line.trim().length() > 0).forEach(line ->
                     {
                         // Get Task from geojson
                         final Task task = gson.fromJson(line, Task.class);


### PR DESCRIPTION
### Description:

Small change to the MapRouletteUploadCommand file out empty lines in files, which would cause an NPE when trying to deserialize them into Tasks:

```bash
java.lang.NullPointerException: null
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteUploadCommand.lambda$execute$5(MapRouletteUploadCommand.java:127) ~[classes/:na]
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133) ~[na:na]
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658) ~[na:na]
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteUploadCommand.lambda$execute$6(MapRouletteUploadCommand.java:121) ~[classes/:na]
	at java.base/java.util.Optional.ifPresent(Optional.java:183) ~[na:na]
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteUploadCommand.lambda$execute$7(MapRouletteUploadCommand.java:117) ~[classes/:na]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1540) ~[na:na]
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteUploadCommand.execute(MapRouletteUploadCommand.java:112) ~[classes/:na]
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteCommand.onRun(MapRouletteCommand.java:106) ~[classes/:na]
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteCommand.onRun(MapRouletteCommand.java:87) ~[classes/:na]
	at org.openstreetmap.atlas.utilities.runtime.Command.execute(Command.java:338) ~[atlas-6.1.6.jar:na]
	at org.openstreetmap.atlas.utilities.runtime.Command.run(Command.java:282) ~[atlas-6.1.6.jar:na]
	at org.openstreetmap.atlas.checks.maproulette.MapRouletteUploadCommand.main(MapRouletteUploadCommand.java:69) ~[classes/:na]
```

### Potential Impact:

No downstream impact

### Unit Test Approach:

Uploaded the following data (empty new lines included) with & without this change:
```
{"type" : "FeatureCollection", "features" : [{"type" : "Feature", "geometry" : {"type":"MultiPolygon","coordinates":[[[[116.4181238,40.6935624],[116.4180851,40.6935207],[116.4180269,40.6934571],[116.4179172,40.6934106],[116.4178138,40.6934057],[116.417675,40.6935428],[116.4177073,40.6936113],[116.417675,40.6936921],[116.4175394,40.6938121],[116.4174716,40.6938782],[116.4174586,40.6939467],[116.4175038,40.6940373],[116.4177977,40.6944168],[116.4181303,40.6948624],[116.4183498,40.6950803],[116.4184919,40.6953128],[116.4187438,40.6956409],[116.4188148,40.6957682],[116.4189472,40.6958881],[116.4194509,40.6961868],[116.4199062,40.6964439],[116.4201742,40.6966055],[116.4204971,40.696745],[116.4206553,40.6968331],[116.4207522,40.6969139],[116.4208878,40.6969531],[116.4211171,40.6970216],[116.4212495,40.6970486],[116.4214464,40.6970706],[116.4216111,40.6971147],[116.4216531,40.6971098],[116.4217274,40.6969359],[116.421708,40.6968845],[116.4216176,40.6968625],[116.4212204,40.6967695],[116.4210364,40.6966936],[116.4209492,40.6966055],[116.4208265,40.6965124],[116.420862,40.69639],[116.4207651,40.6963141],[116.4205908,40.6962015],[116.420355,40.6960669],[116.4204293,40.6960106],[116.4204067,40.6958343],[116.4203357,40.6958269],[116.4202969,40.695543],[116.420284,40.695259],[116.4201258,40.6949309],[116.4198965,40.6946322],[116.4195155,40.6942038],[116.419388,40.6941108],[116.4192959,40.6940287],[116.4190973,40.6938415],[116.4187309,40.6936248],[116.4184645,40.6934399],[116.4183762,40.6934665],[116.418339,40.693544],[116.4184342,40.6936039],[116.4185948,40.6937258],[116.4185892,40.6937643],[116.4185286,40.693787],[116.4183697,40.6937178],[116.4182332,40.6936279],[116.418167,40.6936474],[116.4181412,40.693645],[116.4181089,40.6936303],[116.4180895,40.6936132],[116.418083,40.6935936],[116.4180992,40.6935691],[116.4181238,40.6935624]]]]}, "properties" : {"id" : 2460898000000, "atlas_id" : 2460898000000, "osmIdentifier" : 2460898, "itemType" : "RELATION", "iso_country_code" : "CHN", "tags" : {"type": "multipolygon", "flag:id": "2460898000000", "natural": "water", "flag:type": "FlaggedRelation", "last_edit_time": "1349702714000", "last_edit_user_id": "624020", "last_edit_version": "1", "last_edit_changeset": "13412627", "last_edit_user_name": "bigtigerlu"}}}], "properties" : {"id" : "Relation2460898000000", "instructions" : "1. 1. 3 ways have an invalid or missing role in multipolygon relation 2460898. The role must be either outer or inner. The way id(s) are [184737902, 184737903, 184737904]", "generator" : "InvalidMultiPolygonRelationCheck"}}
{"type" : "FeatureCollection", "features" : [{"type" : "Feature", "geometry" : {"type":"MultiPolygon","coordinates":[[[[70.9515833,61.0612578],[70.9515833,61.105089],[71.0308132,61.105089],[71.0308132,61.0612578],[70.9515833,61.0612578]]]]}, "properties" : {"id" : 2143400000000, "atlas_id" : 2143400000000, "osmIdentifier" : 2143400, "itemType" : "RELATION", "iso_country_code" : "RUS", "tags" : {"type": "multipolygon", "flag:id": "2143400000000", "waterway": "riverbank", "flag:type": "FlaggedRelation", "last_edit_time": "1371702228000", "last_edit_user_id": "402319", "last_edit_version": "2", "last_edit_changeset": "16624748", "last_edit_user_name": "Stalker61"}}}], "properties" : {"id" : "Relation2143400000000", "instructions" : "1. 1. The Multipolygon relation 2143400 with members : [160123598, 226505116, 129733621] is not closed at some locations : [POINT (70.9867279 61.105089), POINT (70.9873681 61.1046741)] 2. 1 ways have an invalid or missing role in multipolygon relation 2143400. The role must be either outer or inner. The way id(s) are [226505116]", "generator" : "InvalidMultiPolygonRelationCheck"}}



```

### Test Results:

Tests pass as expected.
