### PR TITLE
ApproximateWayCheck

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,54 +4,10 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
-  },
-  "PoolSizeCheck": {
-    "surface": {
-      "maximum": 1000.0,
-      "minimum": 50.0
-    }
-  },
-  "SpikyBuildingCheck": {
-    "spiky.angle.maximum": 15.0,
-    "curve": {
-      "degrees": {
-        "maximum.single_heading_change": 25.0,
-        "minimum.total_heading_change": 10.0
-      },
-      "points.minimum": 4
-    },
-    "challenge": {
-      "description": "Find poorly digitized buildings with sharp angles in their geometry",
-      "blurb": "Fix buildings with spiky geometry",
-      "instruction": "Open your favorite editor and validate that the buildings are mapped correctly",
-      "difficulty": "NORMAL",
-      "tags":"building"
-    }
-  },
-  "OrphanNodeCheck": {
-
-  },
-  "AddressPointMatchCheck": {
-    "bounds.size": 150.0,
-    "challenge": {
-      "description": "Tasks contain nodes which either have no street name or incorrect street names",
-      "blurb": "Nodes without street names, or with incorrect street names",
-      "instruction": "Open your favorite editor and edit the node street names",
-      "difficulty": "EASY",
-      "defaultPriority": "LOW"
-    }
-  },
-  "AddressStreetNameCheck": {
-    "bounds.size": 100.0,
-    "challenge": {
-      "description": "Tasks contain nodes with addr:street names that don't match the surrounding roads",
-      "blurb": "Nodes with mismatched addr:street names",
-      "instruction": "Open your favorite editor and edit the node street names",
-      "difficulty": "HARD"
-    }
+    "enabled.value.default": false
   },
   "ApproximateWayCheck": {
+    "enabled": true,
     "deviation.minimum.meters": 35.0,
     "angle.minimum": 100.0,
     "bezierStep": 0.01,

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,10 +4,9 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "ApproximateWayCheck": {
-    "enabled": true,
     "deviation.minimum.meters": 35.0,
     "angle.minimum": 100.0,
     "bezierStep": 0.01,

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -55,7 +55,7 @@
     "deviation": {
       "minimum.meters": 10.0,
       "ratio": {
-        "max": 0.13
+        "max": 0.12
       }
     },
     "angle": {
@@ -65,9 +65,9 @@
     "bezierStep": 0.01,
     "highway.minimum": "secondary",
     "challenge": {
-      "description": "Tasks contain ways that are crudely drawn, curves with too few nodes",
+      "description": "Tasks contain ways that are crudely drawn.",
       "blurb": "Crudely drawn ways",
-      "instructions": "Improve the accuracy of the way by adding more nodes to better match the road",
+      "instructions": "Improve the accuracy of the way by adding more nodes and/or readjusting existing nodes to better match the actual road",
       "difficulty": "EASY"
     }
   },

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -55,7 +55,13 @@
     "deviation.minimum.meters": 35.0,
     "angle.minimum": 100.0,
     "bezierStep": 0.01,
-    "highway.minimum": "service"
+    "highway.minimum": "service",
+    "challenge": {
+      "description": "Tasks contain ways that are crudely drawn, curves with too few nodes",
+      "blurb": "Crudely drawn ways",
+      "instructions": "Improve the accuracy of the way by adding more nodes to better match the road",
+      "difficulty": "EASY"
+    }
   },
   "AreasWithHighwayTagCheck":{
     "tag.filters":"highway->*&area->yes",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -52,10 +52,18 @@
     }
   },
   "ApproximateWayCheck": {
-    "deviation.minimum.meters": 35.0,
-    "angle.minimum": 100.0,
+    "deviation": {
+      "minimum.meters": 10.0,
+      "ratio": {
+        "max": 0.13
+      }
+    },
+    "angle": {
+      "max": 140.0,
+      "min": 60.0
+    },
     "bezierStep": 0.01,
-    "highway.minimum": "service",
+    "highway.minimum": "secondary",
     "challenge": {
       "description": "Tasks contain ways that are crudely drawn, curves with too few nodes",
       "blurb": "Crudely drawn ways",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -51,6 +51,12 @@
       "difficulty": "HARD"
     }
   },
+  "ApproximateWayCheck": {
+    "deviation.minimum.meters": 35.0,
+    "angle.minimum": 100.0,
+    "bezierStep": 0.01,
+    "highway.minimum": "service"
+  },
   "AreasWithHighwayTagCheck":{
     "tag.filters":"highway->*&area->yes",
     "challenge":{

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -49,7 +49,8 @@
       "blurb": "Nodes with mismatched addr:street names",
       "instruction": "Open your favorite editor and edit the node street names",
       "difficulty": "HARD"
-    },
+    }
+  },
   "ApproximateWayCheck": {
     "deviation.minimum.meters": 35.0,
     "angle.minimum": 100.0,

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -6,6 +6,50 @@
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
     "enabled.value.default": true
   },
+  "PoolSizeCheck": {
+    "surface": {
+      "maximum": 1000.0,
+      "minimum": 50.0
+    }
+  },
+  "SpikyBuildingCheck": {
+    "spiky.angle.maximum": 15.0,
+    "curve": {
+      "degrees": {
+        "maximum.single_heading_change": 25.0,
+        "minimum.total_heading_change": 10.0
+      },
+      "points.minimum": 4
+    },
+    "challenge": {
+      "description": "Find poorly digitized buildings with sharp angles in their geometry",
+      "blurb": "Fix buildings with spiky geometry",
+      "instruction": "Open your favorite editor and validate that the buildings are mapped correctly",
+      "difficulty": "NORMAL",
+      "tags":"building"
+    }
+  },
+  "OrphanNodeCheck": {
+
+  },
+  "AddressPointMatchCheck": {
+    "bounds.size": 150.0,
+    "challenge": {
+      "description": "Tasks contain nodes which either have no street name or incorrect street names",
+      "blurb": "Nodes without street names, or with incorrect street names",
+      "instruction": "Open your favorite editor and edit the node street names",
+      "difficulty": "EASY",
+      "defaultPriority": "LOW"
+    }
+  },
+  "AddressStreetNameCheck": {
+    "bounds.size": 100.0,
+    "challenge": {
+      "description": "Tasks contain nodes with addr:street names that don't match the surrounding roads",
+      "blurb": "Nodes with mismatched addr:street names",
+      "instruction": "Open your favorite editor and edit the node street names",
+      "difficulty": "HARD"
+    },
   "ApproximateWayCheck": {
     "deviation.minimum.meters": 35.0,
     "angle.minimum": 100.0,

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -67,6 +67,7 @@ This document is a list of tables with a description and link to documentation f
 ## Ways
 | Check Name | Check Description |
 | :--------- | :---------------- |
+| [ApproximateWayCheck](checks/approximateWayCheck.md) | The purpose of this check is to identify ways that are crudely drawn, there is a discrepancy between the drawing and the real way, especially for curves. |
 | [BuildingRoadIntersectionCheck](checks/buildingRoadIntersectionCheck.md) | The purpose of this check is to identify buildings that intersect/overlap roads. |
 | [~~DuplicateWaysCheck~~ (Deprecated)](checks/duplicateWaysCheck.md) | The purpose of this check is to identify Ways that have either had their entire length or a segment of their length duplicated or drawn multiple times. **This check has been deprecated and is no longer active.** |
 | [GeneralizedCoastlineCheck](checks/generalizedCoastlineCheck.md) | The purpose of this check is to identify coastlines whose nodes are too far apart, have angles that are too sharp, and/or have _source=PGS_ Tag values. |

--- a/docs/checks/approximateWayCheck.md
+++ b/docs/checks/approximateWayCheck.md
@@ -1,0 +1,10 @@
+# ApproximateWayCheck
+
+#### Description
+
+The purpose of this check is to identify ways that are crudely drawn, there is a discrepancy between the drawing and the real way, especially for curves.
+
+#### Code Review
+
+To learn more about the code, please look at the comments in the source code for the check.  
+[ApproximateWayCheck.java﻿](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java)

--- a/docs/checks/approximateWayCheck.md
+++ b/docs/checks/approximateWayCheck.md
@@ -2,9 +2,107 @@
 
 #### Description
 
-The purpose of this check is to identify ways that are crudely drawn, there is a discrepancy between the drawing and the real way, especially for curves.
+The purpose of this check is to identify ways that are crudely drawn, there is a discrepancy between the drawing 
+and the real way, especially for curves.
+
+#### Live Examples
+
+Crudely drawn ways
+1. The way [id:168490775](https://www.openstreetmap.org/way/168490775) is crudely drawn and could use more nodes 
+and some rearrangement of current nodes.
 
 #### Code Review
+
+This check evaluates [Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java)
+, it attempts to find crudely drawn edges especially those that are curves.
+
+We first validate that the incoming object is: 
+* An Edge
+* A Master edge
+* The Edge is Car Navigable
+* The Edge is of a specified minimum highway type
+```java
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
+                && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object);
+    }
+```
+
+Next we split the edge into segments. If there is less than two segments we don't flag the edge. 
+Otherwise, we will go through adjacent pairs of segments, first checking that the angle between 
+them are within a configurable angle. We get the minimum distance that the middle point is from a bezier curve based 
+points from the segments. We then check if the distance is greater than the minDeviationLength and if the ratio between 
+the distance and the length of both segments is greater than the configured maxDeviationRatio.
+
+If the angle, and the distance/deviation are both found as valid, the Edge will be flagged.  
+```java
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final List<Segment> segments = ((Edge) object).asPolyLine().segments();
+
+        if (segments.size() < 2)
+        {
+            return Optional.empty();
+        }
+
+        final boolean isCrude = IntStream.range(0, segments.size() - 1).anyMatch(index ->
+        {
+            final Segment seg1 = segments.get(index);
+            final Segment seg2 = segments.get(index + 1);
+            final double angle = findAngle(seg1, seg2);
+            // ignore sharp turns and almost straightaways
+            if (angle < minAngle || angle > maxAngle)
+            {
+                return false;
+            }
+            final double distance = quadraticBezier(seg1.first(), seg2.first(), seg2.end());
+            final double legsLength = seg1.length().asMeters() + seg2.length().asMeters();
+            return distance > this.minDeviationLength.asMeters()
+                    && distance / legsLength > maxDeviationRatio;
+        });
+
+        if (isCrude)
+        {
+            return Optional.of(
+                    createFlag(object, this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+
+        return Optional.empty();
+    }
+```
+
+We build a quadratic bezier curve using the first node of the first segment, the node that joins both segments (anchor), 
+and the last node of the second segment. During the creation of the curve we calculate at each step how close the 
+curve gets to the anchor, the closest value is returned as the distance (or deviation).
+```java
+private double quadraticBezier(final Location start, final Location anchor, final Location end)
+    {
+        final double startX = start.getLongitude().onEarth().asMeters();
+        final double startY = start.getLatitude().onEarth().asMeters();
+        final double anchorX = anchor.getLongitude().onEarth().asMeters();
+        final double anchorY = anchor.getLatitude().onEarth().asMeters();
+        final double endX = end.getLongitude().onEarth().asMeters();
+        final double endY = end.getLatitude().onEarth().asMeters();
+
+        double min = Double.POSITIVE_INFINITY;
+        for (double step = 0; step <= 1; step += bezierStep)
+        {
+            // https://stackoverflow.com/questions/5634460/quadratic-b%C3%A9zier-curve-calculate-points
+            final double pointX = (pow(1 - step, 2) * startX)
+                    + (2 * step * (1 - step) * anchorX + pow(step, 2) * endX);
+            final double pointY = (pow(1 - step, 2) * startY)
+                    + (2 * step * (1 - step) * anchorY + pow(step, 2) * endY);
+            // distance from point on bezier curve to anchor
+            final double distance = distance(pointX, pointY, anchorX, anchorY);
+            if (distance < min)
+            {
+                min = distance;
+            }
+        }
+        return min;
+    }
+```
 
 To learn more about the code, please look at the comments in the source code for the check.  
 [ApproximateWayCheck.java﻿](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java)

--- a/docs/checks/approximateWayCheck.md
+++ b/docs/checks/approximateWayCheck.md
@@ -26,7 +26,7 @@ We first validate that the incoming object is:
 ##### Flagging the Edge
 We split the edge into it's segments. If there is less than two segments we don't flag the edge. 
 Otherwise, we will go through adjacent pairs of segments, first checking that the angle between 
-them are within a configurable angle. We get the minimum distance that the middle point is from a bezier curve using points from the 
+them are within a configurable angle. We get the minimum distance that the middle point is from a bezier curve using 
 points from the segments. We then check if the distance is greater than the minDeviationLength and if the ratio between 
 the distance and the length of both segments is greater than the configured maxDeviationRatio.
 

--- a/docs/checks/approximateWayCheck.md
+++ b/docs/checks/approximateWayCheck.md
@@ -16,93 +16,26 @@ and some rearrangement of current nodes.
 This check evaluates [Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java)
 , it attempts to find crudely drawn edges especially those that are curves.
 
+##### Validating the Object
 We first validate that the incoming object is: 
 * An Edge
 * A Master edge
 * The Edge is Car Navigable
 * The Edge is of a specified minimum highway type
-```java
-    public boolean validCheckForObject(final AtlasObject object)
-    {
-        return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
-                && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object);
-    }
-```
 
-Next we split the edge into segments. If there is less than two segments we don't flag the edge. 
+##### Flagging the Edge
+We split the edge into it's segments. If there is less than two segments we don't flag the edge. 
 Otherwise, we will go through adjacent pairs of segments, first checking that the angle between 
-them are within a configurable angle. We get the minimum distance that the middle point is from a bezier curve based 
+them are within a configurable angle. We get the minimum distance that the middle point is from a bezier curve using points from the 
 points from the segments. We then check if the distance is greater than the minDeviationLength and if the ratio between 
 the distance and the length of both segments is greater than the configured maxDeviationRatio.
 
 If the angle, and the distance/deviation are both found as valid, the Edge will be flagged.  
-```java
-    protected Optional<CheckFlag> flag(final AtlasObject object)
-    {
-        final List<Segment> segments = ((Edge) object).asPolyLine().segments();
 
-        if (segments.size() < 2)
-        {
-            return Optional.empty();
-        }
-
-        final boolean isCrude = IntStream.range(0, segments.size() - 1).anyMatch(index ->
-        {
-            final Segment seg1 = segments.get(index);
-            final Segment seg2 = segments.get(index + 1);
-            final double angle = findAngle(seg1, seg2);
-            // ignore sharp turns and almost straightaways
-            if (angle < minAngle || angle > maxAngle)
-            {
-                return false;
-            }
-            final double distance = quadraticBezier(seg1.first(), seg2.first(), seg2.end());
-            final double legsLength = seg1.length().asMeters() + seg2.length().asMeters();
-            return distance > this.minDeviationLength.asMeters()
-                    && distance / legsLength > maxDeviationRatio;
-        });
-
-        if (isCrude)
-        {
-            return Optional.of(
-                    createFlag(object, this.getLocalizedInstruction(0, object.getOsmIdentifier())));
-        }
-
-        return Optional.empty();
-    }
-```
-
+##### How the quadratic bezier curve is built and distance/deviation is found
 We build a quadratic bezier curve using the first node of the first segment, the node that joins both segments (anchor), 
 and the last node of the second segment. During the creation of the curve we calculate at each step how close the 
 curve gets to the anchor, the closest value is returned as the distance (or deviation).
-```java
-private double quadraticBezier(final Location start, final Location anchor, final Location end)
-    {
-        final double startX = start.getLongitude().onEarth().asMeters();
-        final double startY = start.getLatitude().onEarth().asMeters();
-        final double anchorX = anchor.getLongitude().onEarth().asMeters();
-        final double anchorY = anchor.getLatitude().onEarth().asMeters();
-        final double endX = end.getLongitude().onEarth().asMeters();
-        final double endY = end.getLatitude().onEarth().asMeters();
-
-        double min = Double.POSITIVE_INFINITY;
-        for (double step = 0; step <= 1; step += bezierStep)
-        {
-            // https://stackoverflow.com/questions/5634460/quadratic-b%C3%A9zier-curve-calculate-points
-            final double pointX = (pow(1 - step, 2) * startX)
-                    + (2 * step * (1 - step) * anchorX + pow(step, 2) * endX);
-            final double pointY = (pow(1 - step, 2) * startY)
-                    + (2 * step * (1 - step) * anchorY + pow(step, 2) * endY);
-            // distance from point on bezier curve to anchor
-            final double distance = distance(pointX, pointY, anchorX, anchorY);
-            if (distance < min)
-            {
-                min = distance;
-            }
-        }
-        return min;
-    }
-```
 
 To learn more about the code, please look at the comments in the source code for the check.  
 [ApproximateWayCheck.java﻿](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -1,25 +1,21 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
+import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Segment;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.stream.IntStream;
-import java.util.stream.StreamSupport;
-
-import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
-import org.openstreetmap.atlas.checks.base.BaseCheck;
-import org.openstreetmap.atlas.checks.flag.CheckFlag;
-import org.openstreetmap.atlas.geography.Latitude;
-import org.openstreetmap.atlas.geography.Location;
-import org.openstreetmap.atlas.geography.Segment;
-import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
-import org.openstreetmap.atlas.geography.atlas.items.Edge;
-import org.openstreetmap.atlas.tags.AerowayTag;
-import org.openstreetmap.atlas.tags.HighwayTag;
-import org.openstreetmap.atlas.tags.annotations.validation.Validators;
-import org.openstreetmap.atlas.utilities.configuration.Configuration;
-import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 import static java.lang.Math.pow;
 import static java.lang.Math.sqrt;
@@ -136,7 +132,6 @@ public class ApproximateWayCheck extends BaseCheck<Long>
 
     /**
      * Calculates the angle between the two segments.
-     * This assumes that s1 and s2 are connected at one end in the same location (s1.end == s2.start)
      */
     private double findAngle(Segment s1, Segment s2) {
         double a = s1.length().asMeters();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -29,7 +29,7 @@ public class ApproximateWayCheck extends BaseCheck<Long>
 {
 
     private static final long serialVersionUID = 125449616392217396L;
-    private static final String EDGE_DEVIATION_INSTRUCTION = "Way {0,number,#} is crude";
+    private static final String EDGE_DEVIATION_INSTRUCTION = "Way {0,number,#} is crude. Please add more nodes/rearrange current nodes to more closely match the road from imagery";
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections
             .singletonList(EDGE_DEVIATION_INSTRUCTION);
     public static final double DEVIATION_MAXIMUM_RATIO_DEFAULT = 0.04;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -145,6 +145,7 @@ public class ApproximateWayCheck extends BaseCheck<Long>
     /**
      * Calculates the angle between the two segments. Uses the Law of Cosines to find the angle.
      * Assumes that the segments connect at an end point.
+     * 
      * @return the angle between the two segments <= 180 degrees
      */
     private double findAngle(final Segment seg1, final Segment seg2)
@@ -175,9 +176,8 @@ public class ApproximateWayCheck extends BaseCheck<Long>
 
     /**
      * Constructs a quadratic bezier curve. This give us a way that is a smooth curve that
-     * approximates the real way. We then find the closest distance of the curve to the anchor
-     * and return that value.
-     * https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Quadratic_curves
+     * approximates the real way. We then find the closest distance of the curve to the anchor and
+     * return that value. https://en.wikipedia.org/wiki/B%C3%A9zier_curve#Quadratic_curves
      * 
      * @param start
      *            start point of bezier curve

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -28,7 +28,7 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 public class ApproximateWayCheck extends BaseCheck<Long>
 {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 125449616392217396L;
     private static final String EDGE_DEVIATION_INSTRUCTION = "Way {0,number,#} is crude";
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections
             .singletonList(EDGE_DEVIATION_INSTRUCTION);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -1,0 +1,199 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Latitude;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Segment;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.AerowayTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+import static java.lang.Math.pow;
+import static java.lang.Math.sqrt;
+
+/**
+ * This check flags edges that deviate from the assumed curve of a road by at least
+ * {@value DEVIATION_MINIMUM_METERS_DEFAULT} meters.
+ *
+ * @author v-brjor
+ */
+public class ApproximateWayCheck extends BaseCheck<Long>
+{
+
+    // You can use serialver to regenerate the serial UID.
+    private static final long serialVersionUID = 1L;
+    private static final String EDGE_DEVIATION_INSTRUCTION = "Way {0,number,#} deviates by {1,number,#} meters";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Collections
+            .singletonList(EDGE_DEVIATION_INSTRUCTION);
+    public static final double DEVIATION_MINIMUM_METERS_DEFAULT = 35.0;
+    private static final String HIGHWAY_MINIMUM_DEFAULT = HighwayTag.SERVICE.toString();
+    public static final double MINIMUM_ANGLE_DEFAULT = 100.0;
+    public static final double BEZIER_STEP_DEFAULT = 0.01;
+
+    private final Distance minimumDeviation;
+    private final HighwayTag highwayMinimum;
+    private final double minimumAngle;
+    private final double bezierStep;
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public ApproximateWayCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.minimumDeviation = configurationValue(configuration, "deviation.minimum.meters",
+                DEVIATION_MINIMUM_METERS_DEFAULT, Distance::meters);
+        final String highwayType = this.configurationValue(configuration, "highway.minimum",
+            HIGHWAY_MINIMUM_DEFAULT);
+        this.highwayMinimum = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
+        this.minimumAngle = configurationValue(configuration, "angle.minimum",
+            MINIMUM_ANGLE_DEFAULT);
+        this.bezierStep = configurationValue(configuration, "bezierStep",
+            BEZIER_STEP_DEFAULT);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
+            && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object);
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * A majority of flagged edges were those that contained correctly mapped ~90 degree angles,
+     * we also don't want to worry about sharp angles as those are flagged in {@link SharpAngleCheck}
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        List<Segment> segments = ((Edge) object).asPolyLine().segments();
+
+        if (segments.size() < 2) {
+            return Optional.empty();
+        }
+
+        OptionalDouble max = IntStream.range(1, segments.size() - 1)
+                .mapToDouble(index -> {
+                    Segment s1 = segments.get(index);
+                    Segment s2 = segments.get(index + 1);
+                    if (findAngle(s1 , s2) < minimumAngle) {
+                        return 0;
+                    }
+                    return quadraticBezier(
+                        s1.first(),
+                        s2.first(), // could also be s1.end()
+                        s2.end()
+                    );
+                })
+                .reduce(Math::max);
+
+        if (max.isPresent() && max.getAsDouble() > minimumDeviation.asMeters()) {
+            return Optional.of(
+                createFlag(
+                    object,
+                    this.getLocalizedInstruction(
+                        0,
+                        object.getOsmIdentifier(),
+                        max.getAsDouble()
+                    )
+                )
+            );
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Calculates the angle between the two segments.
+     * This assumes that s1 and s2 are connected at one end in the same location (s1.end == s2.start)
+     */
+    private double findAngle(Segment s1, Segment s2) {
+        double a = s1.length().asMeters();
+        double b = s2.length().asMeters();
+        double c = new Segment(s1.start(), s2.end()).length().asMeters();
+        return Math.toDegrees(Math.acos((pow(a,2) + pow(b, 2) - pow(c, 2))/(2*a*b)));
+    }
+
+    /**
+     * Constructs a quadratic bezier curve and finds the closest distance of the curve to the anchor.
+     * @param start start point of bezier curve
+     * @param anchor anchor for the curve
+     * @param end end point of bezier curve
+     * @return distance in meters from closest point on bezier curve
+     */
+    private double quadraticBezier(Location start, Location anchor, Location end) {
+        double x0 = start.getLongitude().onEarth().asMeters();
+        double y0 = start.getLatitude().onEarth().asMeters();
+        double x1 = anchor.getLongitude().onEarth().asMeters();
+        double y1 = anchor.getLatitude().onEarth().asMeters();
+        double x2 = end.getLongitude().onEarth().asMeters();
+        double y2 = end.getLatitude().onEarth().asMeters();
+
+        double min = Double.POSITIVE_INFINITY;
+        for (double i = 0; i <= 1; i += bezierStep) {
+            double x = (pow(1 - i, 2) * x0) + (2 * i * (1 - i) * x1 + pow(i, 2) * x2);
+            double y = (pow(1 - i, 2) * y0) + (2 * i * (1 - i) * y1 + pow(i, 2) * y2);
+            // distance from point on bezier curve to anchor
+            double d = distance(x, y, x1, y1);
+            if (d < min) {
+                min = d;
+            }
+        }
+        return min;
+    }
+
+    private double distance(double x0, double y0, double x1, double y1) {
+        return sqrt(pow(x1 - x0, 2) + pow(y1 - y0, 2));
+    }
+
+    /**
+     * Checks if highway tag of given {@link AtlasObject} is of greater or equal priority than the
+     * minimum highway type given in the configurable. If no value is given in configurable, the
+     * default highway type of "SERVICE" will be set as minimum.
+     *
+     * @param object
+     *            an {@link AtlasObject}
+     * @return {@code true} if the highway tag of this object is greater than or equal to the
+     *         minimum type
+     */
+    private boolean isMinimumHighwayType(final AtlasObject object)
+    {
+        final Optional<HighwayTag> highwayTagOfObject = HighwayTag.highwayTag(object);
+        return highwayTagOfObject.isPresent()
+            && highwayTagOfObject.get().isMoreImportantThanOrEqualTo(this.highwayMinimum);
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions() { return FALLBACK_INSTRUCTIONS; }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -57,12 +57,11 @@ public class ApproximateWayCheck extends BaseCheck<Long>
         this.minimumDeviation = configurationValue(configuration, "deviation.minimum.meters",
                 DEVIATION_MINIMUM_METERS_DEFAULT, Distance::meters);
         final String highwayType = this.configurationValue(configuration, "highway.minimum",
-            HIGHWAY_MINIMUM_DEFAULT);
+                HIGHWAY_MINIMUM_DEFAULT);
         this.highwayMinimum = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
         this.minimumAngle = configurationValue(configuration, "angle.minimum",
-            MINIMUM_ANGLE_DEFAULT);
-        this.bezierStep = configurationValue(configuration, "bezierStep",
-            BEZIER_STEP_DEFAULT);
+                MINIMUM_ANGLE_DEFAULT);
+        this.bezierStep = configurationValue(configuration, "bezierStep", BEZIER_STEP_DEFAULT);
     }
 
     /**
@@ -76,14 +75,13 @@ public class ApproximateWayCheck extends BaseCheck<Long>
     public boolean validCheckForObject(final AtlasObject object)
     {
         return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMasterEdge()
-            && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object);
+                && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object);
     }
 
     /**
-     * This is the actual function that will check to see whether the object needs to be flagged.
-     *
-     * A majority of flagged edges were those that contained correctly mapped ~90 degree angles,
-     * we also don't want to worry about sharp angles as those are flagged in {@link SharpAngleCheck}
+     * This is the actual function that will check to see whether the object needs to be flagged. A
+     * majority of flagged edges were those that contained correctly mapped ~90 degree angles, we
+     * also don't want to worry about sharp angles as those are flagged in {@link SharpAngleCheck}
      *
      * @param object
      *            the atlas object supplied by the Atlas-Checks framework for evaluation
@@ -99,36 +97,21 @@ public class ApproximateWayCheck extends BaseCheck<Long>
             return Optional.empty();
         }
 
-        final OptionalDouble max = IntStream.range(0, segments.size() - 1)
-                .mapToDouble(index ->
-                {
-                    final Segment seg1 = segments.get(index);
-                    final Segment seg2 = segments.get(index + 1);
-                    if (findAngle(seg1 , seg2) < minimumAngle)
-                    {
-                        return 0;
-                    }
-                    return quadraticBezier(
-                        seg1.first(),
-                        // vvv could also be s1.end()
-                        seg2.first(),
-                        seg2.end()
-                    );
-                })
-                .reduce(Math::max);
+        final OptionalDouble max = IntStream.range(0, segments.size() - 1).mapToDouble(index ->
+        {
+            final Segment seg1 = segments.get(index);
+            final Segment seg2 = segments.get(index + 1);
+            if (findAngle(seg1, seg2) < minimumAngle)
+            {
+                return 0;
+            }
+            return quadraticBezier(seg1.first(), seg2.first(), seg2.end());
+        }).reduce(Math::max);
 
         if (max.isPresent() && max.getAsDouble() > this.minimumDeviation.asMeters())
         {
-            return Optional.of(
-                createFlag(
-                    object,
-                    this.getLocalizedInstruction(
-                        0,
-                        object.getOsmIdentifier(),
-                        max.getAsDouble()
-                    )
-                )
-            );
+            return Optional.of(createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier(), max.getAsDouble())));
         }
 
         return Optional.empty();
@@ -140,7 +123,8 @@ public class ApproximateWayCheck extends BaseCheck<Long>
         return FALLBACK_INSTRUCTIONS;
     }
 
-    private double distance(final double startX, final double startY, final double endX, final double endY)
+    private double distance(final double startX, final double startY, final double endX,
+            final double endY)
     {
         return sqrt(pow(endX - startX, 2) + pow(endY - startY, 2));
     }
@@ -153,7 +137,8 @@ public class ApproximateWayCheck extends BaseCheck<Long>
         final double aLength = seg1.length().asMeters();
         final double bLength = seg2.length().asMeters();
         final double cLength = new Segment(seg1.start(), seg2.end()).length().asMeters();
-        return Math.toDegrees(Math.acos((pow(aLength,2) + pow(bLength, 2) - pow(cLength, 2))/(2*aLength*bLength)));
+        return Math.toDegrees(Math.acos(
+                (pow(aLength, 2) + pow(bLength, 2) - pow(cLength, 2)) / (2 * aLength * bLength)));
     }
 
     /**
@@ -170,14 +155,19 @@ public class ApproximateWayCheck extends BaseCheck<Long>
     {
         final Optional<HighwayTag> highwayTagOfObject = HighwayTag.highwayTag(object);
         return highwayTagOfObject.isPresent()
-            && highwayTagOfObject.get().isMoreImportantThanOrEqualTo(this.highwayMinimum);
+                && highwayTagOfObject.get().isMoreImportantThanOrEqualTo(this.highwayMinimum);
     }
 
     /**
-     * Constructs a quadratic bezier curve and finds the closest distance of the curve to the anchor.
-     * @param start start point of bezier curve
-     * @param anchor anchor for the curve
-     * @param end end point of bezier curve
+     * Constructs a quadratic bezier curve and finds the closest distance of the curve to the
+     * anchor.
+     * 
+     * @param start
+     *            start point of bezier curve
+     * @param anchor
+     *            anchor for the curve
+     * @param end
+     *            end point of bezier curve
      * @return distance in meters from closest point on bezier curve
      */
     private double quadraticBezier(final Location start, final Location anchor, final Location end)
@@ -192,8 +182,10 @@ public class ApproximateWayCheck extends BaseCheck<Long>
         double min = Double.POSITIVE_INFINITY;
         for (double i = 0; i <= 1; i += bezierStep)
         {
-            final double pointX = (pow(1 - i, 2) * startX) + (2 * i * (1 - i) * anchorX + pow(i, 2) * endX);
-            final double pointY = (pow(1 - i, 2) * startY) + (2 * i * (1 - i) * anchorY + pow(i, 2) * endY);
+            final double pointX = (pow(1 - i, 2) * startX)
+                    + (2 * i * (1 - i) * anchorX + pow(i, 2) * endX);
+            final double pointY = (pow(1 - i, 2) * startY)
+                    + (2 * i * (1 - i) * anchorY + pow(i, 2) * endY);
             // distance from point on bezier curve to anchor
             final double distance = distance(pointX, pointY, anchorX, anchorY);
             if (distance < min)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -180,12 +180,12 @@ public class ApproximateWayCheck extends BaseCheck<Long>
         final double endY = end.getLatitude().onEarth().asMeters();
 
         double min = Double.POSITIVE_INFINITY;
-        for (double i = 0; i <= 1; i += bezierStep)
+        for (double step = 0; step <= 1; step += bezierStep)
         {
-            final double pointX = (pow(1 - i, 2) * startX)
-                    + (2 * i * (1 - i) * anchorX + pow(i, 2) * endX);
-            final double pointY = (pow(1 - i, 2) * startY)
-                    + (2 * i * (1 - i) * anchorY + pow(i, 2) * endY);
+            final double pointX = (pow(1 - step, 2) * startX)
+                    + (2 * step * (1 - step) * anchorX + pow(step, 2) * endX);
+            final double pointY = (pow(1 - step, 2) * startY)
+                    + (2 * step * (1 - step) * anchorY + pow(step, 2) * endY);
             // distance from point on bezier curve to anchor
             final double distance = distance(pointX, pointY, anchorX, anchorY);
             if (distance < min)

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
@@ -18,9 +18,11 @@ public class ApproximateWayCheckTest
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
-    private final ApproximateWayCheck check = new ApproximateWayCheck(
-            ConfigurationResolver.inlineConfiguration(
-                    "{\"ApproximateWayCheck\":{\"deviation.minimum.meters\": 35.0,\"angle.minimum\": 100.0,\"bezierStep\": 0.01,\"highway.minimum\": \"service\"}}"));
+    private final ApproximateWayCheck check = new ApproximateWayCheck(ConfigurationResolver
+            .inlineConfiguration("{\"ApproximateWayCheck\":{" + "\"deviation\": {"
+                    + "\"minimum.meters\": 10.0," + "\"ratio\": {" + "\"max\": 0.04" + "}" + "},"
+                    + "\"angle\": {" + "\"min\": 60.0," + "\"max\": 160.0" + "},"
+                    + "\"bezierStep\": 0.01," + "\"highway.minimum\": \"service\"" + "}}"));
 
     @Test
     public void testInvalidApproximateWay()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
@@ -1,0 +1,46 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link ApproximateWayCheck}
+ *
+ * @author v-brjor
+ */
+public class ApproximateWayCheckTest
+{
+    @Rule
+    public ApproximateWayCheckTestRule setup = new ApproximateWayCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final ApproximateWayCheck check = new ApproximateWayCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"ApproximateWayCheck\":{\"deviation.minimum.meters\": 35.0,\"angle.minimum\": 100.0,\"bezierStep\": 0.01,\"highway.minimum\": \"service\"}}"));
+
+    @Test
+    public void testInvalidApproximateWay()
+    {
+        this.verifier.actual(this.setup.invalidApproximateWayAtlas(), this.check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testRightAngle()
+    {
+        this.verifier.actual(this.setup.rightAngleAtlas(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testValidApproximateWay()
+    {
+        this.verifier.actual(this.setup.validApproximateWayAtlas(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
@@ -25,17 +25,17 @@ public class ApproximateWayCheckTest
                     + "\"bezierStep\": 0.01," + "\"highway.minimum\": \"service\"" + "}}"));
 
     @Test
+    public void testSingleSegmentAtlas()
+    {
+        this.verifier.actual(this.setup.singleSegmentAtlas(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testInvalidApproximateWay()
     {
         this.verifier.actual(this.setup.invalidApproximateWayAtlas(), this.check);
         this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void testRightAngle()
-    {
-        this.verifier.actual(this.setup.rightAngleAtlas(), this.check);
-        this.verifier.verifyEmpty();
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTest.java
@@ -25,17 +25,17 @@ public class ApproximateWayCheckTest
                     + "\"bezierStep\": 0.01," + "\"highway.minimum\": \"service\"" + "}}"));
 
     @Test
-    public void testSingleSegmentAtlas()
-    {
-        this.verifier.actual(this.setup.singleSegmentAtlas(), this.check);
-        this.verifier.verifyEmpty();
-    }
-
-    @Test
     public void testInvalidApproximateWay()
     {
         this.verifier.actual(this.setup.invalidApproximateWayAtlas(), this.check);
         this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testSingleSegmentAtlas()
+    {
+        this.verifier.actual(this.setup.singleSegmentAtlas(), this.check);
+        this.verifier.verifyEmpty();
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTestRule.java
@@ -28,12 +28,10 @@ public class ApproximateWayCheckTestRule extends CoreTestRule
     private static final String TEST_10 = "-45.9275439, 168.2805558";
     private static final String TEST_11 = "-45.9272734, 168.2805397";
 
-    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
-            @Node(coordinates = @Loc(value = TEST_2)),
-            @Node(coordinates = @Loc(value = TEST_3)) }, edges = {
-                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
-                            @Loc(value = TEST_3) }, tags = "highway=SECONDARY") })
-    private Atlas rightAngleAtlas;
+    @TestAtlas(nodes = {@Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2))}, edges = {
+                @Edge(coordinates = {@Loc(value = TEST_1), @Loc(value = TEST_2)}) })
+    private Atlas singleSegmentAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_4)),
             @Node(coordinates = @Loc(value = TEST_5)),
@@ -50,14 +48,14 @@ public class ApproximateWayCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_10), @Loc(value = TEST_11) }, tags = "highway=SECONDARY") })
     private Atlas validApproximateWayAtlas;
 
+    public Atlas singleSegmentAtlas()
+    {
+        return this.singleSegmentAtlas;
+    }
+
     public Atlas invalidApproximateWayAtlas()
     {
         return this.invalidApproximateWayAtlas;
-    }
-
-    public Atlas rightAngleAtlas()
-    {
-        return this.rightAngleAtlas;
     }
 
     public Atlas validApproximateWayAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTestRule.java
@@ -1,0 +1,67 @@
+package org.openstreetmap.atlas.checks.validation.linear.edges;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Tests for {@link ApproximateWayCheck}
+ *
+ * @author v-brjor
+ */
+public class ApproximateWayCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "1, 0";
+    private static final String TEST_2 = "0, 0";
+    private static final String TEST_3 = "0, 1";
+
+    private static final String TEST_4 = "-46.1827, 168.47972";
+    private static final String TEST_5 = "-46.181988, 168.4833022";
+    private static final String TEST_6 = "-46.17616, 168.49038";
+
+    private static final String TEST_7 = "-45.927904, 168.2816058";
+    private static final String TEST_8 = "-45.927667, 168.2806711";
+    private static final String TEST_9 = "-45.9276148, 168.280596";
+    private static final String TEST_10 = "-45.9275439, 168.2805558";
+    private static final String TEST_11 = "-45.9272734, 168.2805397";
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)),
+            @Node(coordinates = @Loc(value = TEST_3)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = "highway=SECONDARY") })
+    private Atlas rightAngleAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_4)),
+            @Node(coordinates = @Loc(value = TEST_5)),
+            @Node(coordinates = @Loc(value = TEST_6)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5),
+                            @Loc(value = TEST_6) }, tags = "highway=SECONDARY") })
+    private Atlas invalidApproximateWayAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_7)),
+            @Node(coordinates = @Loc(value = TEST_8)), @Node(coordinates = @Loc(value = TEST_9)),
+            @Node(coordinates = @Loc(value = TEST_10)),
+            @Node(coordinates = @Loc(value = TEST_11)), }, edges = { @Edge(coordinates = {
+                    @Loc(value = TEST_7), @Loc(value = TEST_8), @Loc(value = TEST_9),
+                    @Loc(value = TEST_10), @Loc(value = TEST_11) }, tags = "highway=SECONDARY") })
+    private Atlas validApproximateWayAtlas;
+
+    public Atlas invalidApproximateWayAtlas()
+    {
+        return this.invalidApproximateWayAtlas;
+    }
+
+    public Atlas rightAngleAtlas()
+    {
+        return this.rightAngleAtlas;
+    }
+
+    public Atlas validApproximateWayAtlas()
+    {
+        return this.validApproximateWayAtlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheckTestRule.java
@@ -28,17 +28,17 @@ public class ApproximateWayCheckTestRule extends CoreTestRule
     private static final String TEST_10 = "-45.9275439, 168.2805558";
     private static final String TEST_11 = "-45.9272734, 168.2805397";
 
-    @TestAtlas(nodes = {@Node(coordinates = @Loc(value = TEST_1)),
-            @Node(coordinates = @Loc(value = TEST_2))}, edges = {
-                @Edge(coordinates = {@Loc(value = TEST_1), @Loc(value = TEST_2)}) })
-    private Atlas singleSegmentAtlas;
-
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_4)),
             @Node(coordinates = @Loc(value = TEST_5)),
             @Node(coordinates = @Loc(value = TEST_6)) }, edges = {
                     @Edge(coordinates = { @Loc(value = TEST_4), @Loc(value = TEST_5),
                             @Loc(value = TEST_6) }, tags = "highway=SECONDARY") })
     private Atlas invalidApproximateWayAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+            @Node(coordinates = @Loc(value = TEST_2)) }, edges = {
+                    @Edge(coordinates = { @Loc(value = TEST_1), @Loc(value = TEST_2) }) })
+    private Atlas singleSegmentAtlas;
 
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_7)),
             @Node(coordinates = @Loc(value = TEST_8)), @Node(coordinates = @Loc(value = TEST_9)),
@@ -48,14 +48,14 @@ public class ApproximateWayCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_10), @Loc(value = TEST_11) }, tags = "highway=SECONDARY") })
     private Atlas validApproximateWayAtlas;
 
-    public Atlas singleSegmentAtlas()
-    {
-        return this.singleSegmentAtlas;
-    }
-
     public Atlas invalidApproximateWayAtlas()
     {
         return this.invalidApproximateWayAtlas;
+    }
+
+    public Atlas singleSegmentAtlas()
+    {
+        return this.singleSegmentAtlas;
     }
 
     public Atlas validApproximateWayAtlas()


### PR DESCRIPTION
### Description
This checks for ways that were done crudely, there is a discrepancy between the drawing and the real way especially in the curve. Roads are expected to be smooth and consistent, large changes in directions are suspect of poor drawing. Fixing these visually improves the map.

### Requirements
* Is an Edge
* Has a highway tag that is car navigable
* Edge has more than one segment

### Use Cases
Case 1: False Positive (US)

* This gets flagged due to the sharp angle in the edge, this edge is the same road throughout and matches the imagery
* https://www.openstreetmap.org/way/608161473

![image](https://user-images.githubusercontent.com/22751140/84070818-942bdf80-a981-11ea-832c-dc6d8ac5ea0b.png)


Case 2: True Positive (US)

* Curves are not smooth, poorly drawn
* https://www.openstreetmap.org/way/40195903

![image](https://user-images.githubusercontent.com/22751140/84070839-9b52ed80-a981-11ea-989c-7cbe47039a4a.png)

### Test Results
| Country | Total Ways Checked | False Positives | FP % |
|----------|:---------------------:|:---------------:|:-------:|
|   AUS     |              261            |           24         |  9.2%  |
|  TUR      |              274            |           29         | 10.6% |

Also tested on AIA, CYM,SMR but no flags

### Supported regions
All Countries

### References
https://wiki.openstreetmap.org/wiki/Osmose/issues#1190
