### PR TITLE
[MapRouletteUploadCommand] Various changes to maproulette upload command

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
@@ -42,7 +42,7 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
         final String flagIdentifier = properties.get(IDENTIFIERS) == null
                 ? properties.get(ID).getAsString()
                 // Convert array of ids into comma delimited string
-                : this.parseIdentifiers((JsonArray) properties.get(IDENTIFIERS));
+                : parseIdentifiers((JsonArray) properties.get(IDENTIFIERS));
         final CheckFlag flag = new CheckFlag(flagIdentifier);
         flag.addInstruction(instruction);
         flag.setChallengeName(checkName);
@@ -57,7 +57,7 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
      *            - array of flag identifiers
      * @return - comma delimited string
      */
-    private String parseIdentifiers(final JsonArray identifiers)
+    public static String parseIdentifiers(final JsonArray identifiers)
     {
         return Arrays.stream(new Gson().fromJson(identifiers, String[].class)).sorted()
                 .map(String::toString).collect(Collectors.joining(","));

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
@@ -26,6 +26,19 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
     private static final String ID = "id";
     private static final String IDENTIFIERS = "identifiers";
 
+    /**
+     * Returns a comma delimited string of identifiers.
+     *
+     * @param identifiers
+     *            - array of flag identifiers
+     * @return - comma delimited string
+     */
+    public static String parseIdentifiers(final JsonArray identifiers)
+    {
+        return Arrays.stream(new Gson().fromJson(identifiers, String[].class)).sorted()
+                .map(String::toString).collect(Collectors.joining(","));
+    }
+
     public CheckFlagDeserializer()
     {
         // Default constructor
@@ -48,18 +61,5 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
         flag.setChallengeName(checkName);
 
         return flag;
-    }
-
-    /**
-     * Returns a comma delimited string of identifiers.
-     * 
-     * @param identifiers
-     *            - array of flag identifiers
-     * @return - comma delimited string
-     */
-    public static String parseIdentifiers(final JsonArray identifiers)
-    {
-        return Arrays.stream(new Gson().fromJson(identifiers, String[].class)).sorted()
-                .map(String::toString).collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
+import org.openstreetmap.atlas.checks.maproulette.data.ChallengeStatus;
 import org.openstreetmap.atlas.checks.maproulette.data.Task;
 import org.openstreetmap.atlas.checks.maproulette.serializer.ChallengeDeserializer;
 import org.openstreetmap.atlas.checks.maproulette.serializer.TaskDeserializer;
@@ -189,6 +190,12 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         final String challengeName = String.join(" - ", this.getCountryDisplayName(countryCode),
                 result.getName().isEmpty() ? checkName : result.getName());
         result.setName(challengeName);
+        // Add challenge name to check-in comment
+        result.setCheckinComment(String.format("#maproulette: %s", challengeName));
+        // Set challenge status to ready
+        result.setStatus(ChallengeStatus.READY.intValue());
+        // Set challenged disabled
+        result.setEnabled(false);
         return result;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -59,10 +59,11 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
     private static final Switch<List<String>> CHECKS = new Switch<>("checks",
             "A comma separated list of check names to filter flags by.",
             string -> Arrays.asList(string.split(",")), Optionality.OPTIONAL);
-    private static final Switch<String> CHECKIN_COMMENT_PREFIX = new Switch<>("checkinCommentPrefix",
+    private static final Switch<String> CHECKIN_COMMENT_PREFIX = new Switch<>(
+            "checkinCommentPrefix",
             "MapRoulette checkinComment prefix. This will be prepended to the check name",
             String::toString, Optionality.OPTIONAL, Challenge.DEFAULT_CHECKIN_COMMENT);
-    
+
     private static final String PARAMETER_CHALLENGE = "challenge";
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteUploadCommand.class);
 
@@ -113,7 +114,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                 .getOption(COUNTRIES);
         // Get the checks filter
         final Optional<List<String>> checks = (Optional<List<String>>) commandMap.getOption(CHECKS);
-        final String checkinComment =  (String) commandMap.get(CHECKIN_COMMENT_PREFIX);
+        final String checkinComment = (String) commandMap.get(CHECKIN_COMMENT_PREFIX);
 
         ((File) commandMap.get(INPUT_DIRECTORY)).listFilesRecursively().forEach(logFile ->
         {
@@ -181,10 +182,13 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
      *            the full configuration, which contains challenge parameters for checkName.
      * @param countryCode
      *            the CheckFlag iso3 country code
+     * @param checkinCommentPrefix
+     *            the MapRoulette checkinComment prefix
      * @return the check's challenge parameters, stored as a Challenge object.
      */
     private Challenge getChallenge(final String checkName,
-            final Configuration fallbackConfiguration, final Optional<String> countryCode, String checkinCommentPrefix)
+            final Configuration fallbackConfiguration, final Optional<String> countryCode,
+            final String checkinCommentPrefix)
     {
         final Map<String, String> challengeMap = fallbackConfiguration
                 .get(getChallengeParameter(checkName), Collections.emptyMap()).value();

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -196,6 +196,8 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         result.setStatus(ChallengeStatus.READY.intValue());
         // Set challenged disabled
         result.setEnabled(false);
+        // Set update tasks to false
+        result.setUpdateTasks(false);
         return result;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -162,7 +162,7 @@ public class Challenge implements Serializable
 
     public long getStatus()
     {
-        return status;
+        return this.status;
     }
 
     public String getTags()
@@ -172,7 +172,7 @@ public class Challenge implements Serializable
 
     public boolean isEnabled()
     {
-        return enabled;
+        return this.enabled;
     }
 
     public void setCheckinComment(final String checkinComment)
@@ -180,7 +180,7 @@ public class Challenge implements Serializable
         this.checkinComment = checkinComment;
     }
 
-    public void setEnabled(boolean enabled)
+    public void setEnabled(final boolean enabled)
     {
         this.enabled = enabled;
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -58,6 +58,7 @@ public class Challenge implements Serializable
     private final String lowPriorityRule;
     private long status;
     private boolean enabled;
+    private boolean updateTasks;
 
     public Challenge(final Challenge challenge)
     {
@@ -98,6 +99,7 @@ public class Challenge implements Serializable
         this.lowPriorityRule = lowPriorityRule;
         this.tags = tags;
         this.checkinComment = "#maproulette";
+        this.updateTasks = true;
     }
 
     public String getBlurb()
@@ -175,6 +177,11 @@ public class Challenge implements Serializable
         return this.enabled;
     }
 
+    public boolean isUpdateTasks()
+    {
+        return this.updateTasks;
+    }
+
     public void setCheckinComment(final String checkinComment)
     {
         this.checkinComment = checkinComment;
@@ -205,12 +212,17 @@ public class Challenge implements Serializable
         this.status = status;
     }
 
+    public void setUpdateTasks(final boolean updateTasks)
+    {
+        this.updateTasks = updateTasks;
+    }
+
     public JsonObject toJson(final String challengeName)
     {
         // if the challenge doesn't exist yet then create/update it
         final JsonObject challengeJson = CHALLENGE_GSON.toJsonTree(this).getAsJsonObject();
         challengeJson.add(KEY_ACTIVE, new JsonPrimitive(true));
-        challengeJson.add(KEY_UPDATE_TASKS, new JsonPrimitive(true));
+        challengeJson.add(KEY_UPDATE_TASKS, new JsonPrimitive(this.updateTasks));
 
         // Do not override the name if it's already set
         if (this.name.isEmpty())

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -36,6 +36,7 @@ public class Challenge implements Serializable
     public static final String VALUE_RULE_OPERATOR = "equal";
     public static final String KEY_RULE_VALUE = "value";
     public static final String KEY_TAGS = "tags";
+    public static final String DEFAULT_CHECKIN_COMMENT = "#maproulette";
 
     private static final long serialVersionUID = -8034692909431083341L;
     private static final Gson CHALLENGE_GSON = new GsonBuilder().disableHtmlEscaping()
@@ -98,7 +99,7 @@ public class Challenge implements Serializable
         this.mediumPriorityRule = mediumPriorityRule;
         this.lowPriorityRule = lowPriorityRule;
         this.tags = tags;
-        this.checkinComment = "#maproulette";
+        this.checkinComment = DEFAULT_CHECKIN_COMMENT;
         this.updateTasks = true;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -56,6 +56,8 @@ public class Challenge implements Serializable
     private final String highPriorityRule;
     private final String mediumPriorityRule;
     private final String lowPriorityRule;
+    private long status;
+    private boolean enabled;
 
     public Challenge(final Challenge challenge)
     {
@@ -158,14 +160,29 @@ public class Challenge implements Serializable
         return this.parent;
     }
 
+    public long getStatus()
+    {
+        return status;
+    }
+
     public String getTags()
     {
         return this.tags;
     }
 
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
     public void setCheckinComment(final String checkinComment)
     {
         this.checkinComment = checkinComment;
+    }
+
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
     }
 
     public void setId(final long identifier)
@@ -181,6 +198,11 @@ public class Challenge implements Serializable
     public void setParentIdentifier(final long identifier)
     {
         this.parent = identifier;
+    }
+
+    public void setStatus(final long status)
+    {
+        this.status = status;
     }
 
     public JsonObject toJson(final String challengeName)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeStatus.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeStatus.java
@@ -1,0 +1,39 @@
+package org.openstreetmap.atlas.checks.maproulette.data;
+
+/**
+ * @author danielbaah
+ */
+public enum ChallengeStatus
+{
+    NA(0),
+    BUILDING(1),
+    FAILED(2),
+    READY(3),
+    PARTIALLY_LOADED(4),
+    FINISHED(5),
+    DELETING_TASKS(6);
+
+    private final int value;
+
+    public static ChallengeStatus fromValue(final int value)
+    {
+        for (final ChallengeStatus challengeStatus : ChallengeStatus.values())
+        {
+            if (challengeStatus.intValue() == value)
+            {
+                return challengeStatus;
+            }
+        }
+        return ChallengeStatus.NA;
+    }
+
+    ChallengeStatus(final int value)
+    {
+        this.value = value;
+    }
+
+    public int intValue()
+    {
+        return this.value;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/TaskDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/TaskDeserializer.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.openstreetmap.atlas.checks.flag.serializer.CheckFlagDeserializer;
 import org.openstreetmap.atlas.checks.maproulette.data.Task;
 import org.openstreetmap.atlas.checks.utility.tags.SyntheticHighlightPointTag;
 import org.openstreetmap.atlas.geography.Latitude;
@@ -31,6 +32,7 @@ public class TaskDeserializer implements JsonDeserializer<Task>
     private static final String GENERATOR = "generator";
     private static final String INSTRUCTIONS = "instructions";
     private static final String ID = "id";
+    private static final String IDENTIFIERS = "identifiers";
     private static final String FEATURES = "features";
     private static final String GEOMETRY = "geometry";
     private static final String COORDINATES = "coordinates";
@@ -49,7 +51,9 @@ public class TaskDeserializer implements JsonDeserializer<Task>
         final JsonObject properties = full.get(PROPERTIES).getAsJsonObject();
         final String challengeName = properties.get(GENERATOR).getAsString();
         final String instruction = properties.get(INSTRUCTIONS).getAsString();
-        final String taskID = properties.get(ID).getAsString();
+        final String taskID = properties.get(IDENTIFIERS) == null ? properties.get(ID).getAsString()
+                : CheckFlagDeserializer
+                        .parseIdentifiers(properties.get(IDENTIFIERS).getAsJsonArray());
         final JsonArray geojson = full.get(FEATURES).getAsJsonArray();
         final Task result = new Task();
         result.setChallengeName(challengeName);
@@ -99,7 +103,7 @@ public class TaskDeserializer implements JsonDeserializer<Task>
 
     /**
      * Stream all of the {@link JsonObject}s in a {@link JsonArray}.
-     * 
+     *
      * @param features
      *            a {@link JsonArray} containing only {@link JsonObject}s
      * @return a {@link Stream} containing all {@link JsonObject}s inside features.


### PR DESCRIPTION
### Description:

This brings in the following changes to the command:
* Replaces the Task name with the _new_ CheckFlag identifiers array.
* Sets the challenge to disabled by default
* Adds a `checkinCommentPrefix` switch to create a  check-in comment prefix `[prefix]: [challenge name]`
* Sets the challenge status to ready

### Potential Impact:

List potential impact to downstream libraries here (ex. atlas-checks, atlas-generator)

### Unit Test Approach:

Uploaded challenges to staging maproulette

### Test Results:

- [x] Challenge disabled
- [x] Check-in comment is: "#maproulette: Anguilla - PoolSizeCheck"
- [x] Status set to 3
- [x] Task title set to new identifiers array

<img width="533" alt="Screen Shot 2020-06-23 at 8 37 18 AM" src="https://user-images.githubusercontent.com/1947857/85424462-cf571280-b52c-11ea-87b3-a25633e255a7.png">

<img width="805" alt="Screen Shot 2020-06-23 at 8 39 44 AM" src="https://user-images.githubusercontent.com/1947857/85424760-29f06e80-b52d-11ea-8f9f-696db75c0979.png">


