### PR TITLE
Updating the version for the next release. 6.0.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=6.0.8-SNAPSHOT
+version=6.0.9-SNAPSHOT
 
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
### Description:

Bumping the atlas-checks version in order to do the next release for 6.0.9.

