### PR TITLE
Disable RoundaboutMissingTagCheck

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -723,6 +723,7 @@
     }
   },
   "RoundaboutMissingTagCheck": {
+    "enabled": false,
     "angle.threshold": {
       "maximum_degree": 40.0,
       "minimum_degree": 10.0


### PR DESCRIPTION
### Description:

This PR disables the newly added RoundaboutMissingTagCheck by default. The analysis of this check is still in progress and should be disabled until it is complete.

### Potential Impact:

Check will be disabled by default and will not be run until it is enabled.

### Unit Test Approach:

NA

### Test Results:

NA

