### PR TITLE
[MapRouletteUploadCommand] Overwrite checkInCommentPrefix with additional switch

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.ChallengeStatus;
 import org.openstreetmap.atlas.checks.maproulette.data.Task;
@@ -61,8 +62,11 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             string -> Arrays.asList(string.split(",")), Optionality.OPTIONAL);
     private static final Switch<String> CHECKIN_COMMENT_PREFIX = new Switch<>(
             "checkinCommentPrefix",
-            "MapRoulette checkinComment prefix. This will be prepended to the check name",
+            "MapRoulette checkinComment prefix. This will be prepended to the check name (e.g. #prefix: [ISO - CheckName] ).",
             String::toString, Optionality.OPTIONAL, Challenge.DEFAULT_CHECKIN_COMMENT);
+    private static final Switch<String> CHECKIN_COMMENT = new Switch<>("checkinComment",
+            "MapRoulette checkinComment prefix. If supplied, this would overwrite the checkinCommentPrefix",
+            String::toString, Optionality.OPTIONAL, StringUtils.EMPTY);
 
     private static final String PARAMETER_CHALLENGE = "challenge";
     private static final Logger logger = LoggerFactory.getLogger(MapRouletteUploadCommand.class);
@@ -99,7 +103,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
     public SwitchList switches()
     {
         return super.switches().with(INPUT_DIRECTORY, OUTPUT_PATH, CONFIG_LOCATION, COUNTRIES,
-                CHECKS, CHECKIN_COMMENT_PREFIX);
+                CHECKS, CHECKIN_COMMENT_PREFIX, CHECKIN_COMMENT);
     }
 
     @Override
@@ -114,7 +118,8 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                 .getOption(COUNTRIES);
         // Get the checks filter
         final Optional<List<String>> checks = (Optional<List<String>>) commandMap.getOption(CHECKS);
-        final String checkinComment = (String) commandMap.get(CHECKIN_COMMENT_PREFIX);
+        final String checkinCommentPrefix = (String) commandMap.get(CHECKIN_COMMENT_PREFIX);
+        final String checkinComment = (String) commandMap.get(CHECKIN_COMMENT);
 
         ((File) commandMap.get(INPUT_DIRECTORY)).listFilesRecursively().forEach(logFile ->
         {
@@ -152,7 +157,8 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                                 final Challenge challenge = countryToChallengeMap.computeIfAbsent(
                                         countryCode.orElse(""),
                                         ignore -> this.getChallenge(task.getChallengeName(),
-                                                instructions, countryCode, checkinComment));
+                                                instructions, countryCode, checkinCommentPrefix,
+                                                checkinComment));
                                 this.addTask(challenge, task);
                             }
                             catch (URISyntaxException | UnsupportedEncodingException error)
@@ -184,11 +190,13 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
      *            the CheckFlag iso3 country code
      * @param checkinCommentPrefix
      *            the MapRoulette checkinComment prefix
+     * @param checkinComment
+     *            the MapRoulette checkinComment
      * @return the check's challenge parameters, stored as a Challenge object.
      */
     private Challenge getChallenge(final String checkName,
             final Configuration fallbackConfiguration, final Optional<String> countryCode,
-            final String checkinCommentPrefix)
+            final String checkinCommentPrefix, final String checkinComment)
     {
         final Map<String, String> challengeMap = fallbackConfiguration
                 .get(getChallengeParameter(checkName), Collections.emptyMap()).value();
@@ -199,8 +207,11 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         final String challengeName = String.join(" - ", this.getCountryDisplayName(countryCode),
                 result.getName().isEmpty() ? checkName : result.getName());
         result.setName(challengeName);
-        // Add challenge name to check-in comment
-        result.setCheckinComment(String.format("%s: %s", checkinCommentPrefix, challengeName));
+        // Set check-in comment to checkinComment if provided, otherwise, set as #prefix: [ISO -
+        // CheckName]
+        result.setCheckinComment(checkinComment.isEmpty()
+                ? String.format("%s: %s", checkinCommentPrefix, challengeName)
+                : checkinComment);
         // Set challenge status to ready
         result.setStatus(ChallengeStatus.READY.intValue());
         // Set challenged disabled


### PR DESCRIPTION
### Description:

Adds a new `checkinComment` switch to the MapRouletteUploadCommand. This allows us to either:
1. Set the `checkinComment` value
2. Set the prefix for the [checkinComment](url) value
The `checkinComment value overwrites the `checkInCommentPrefix` value.

Why do we need both?

This switch is available for users that do not want the check name and iso country code in their check-in comment.

### Potential Impact:

More options for MapRouletteUploadCommand

### Unit Test Approach:

Uploaded some tests to the public staging environment

### Test Results:

Challenge values look good 👍 

