### PR TITLE
InvalidMultiPolygonRelationCheck Flag Features Marked By Atlas

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '6.1.9',
+    atlas: '6.2.1',
     commons:'2.6',
     atlas_generator: '5.0.3',
     atlas_checkstyle: '5.6.9',

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
@@ -64,6 +64,7 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
     public static final int SINGLE_MEMBER_RELATION_INSTRUCTION_FORMAT_INDEX;
     public static final int INVALID_OVERLAP_INSTRUCTION_FORMAT_INDEX;
     public static final int INNER_MISSING_OUTER_INSTRUCTION_FORMAT_INDEX;
+    public static final int GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT_INDEX;
     private static final String CLOSED_LOOP_INSTRUCTION_FORMAT = "The Multipolygon relation {0,number,#} with members : {1} is not closed at some locations : {2}";
     private static final String INVALID_OSM_TYPE_INSTRUCTION_FORMAT = "{0} relation member(s) are an invalid type in relation {1,number,#}. Multipolygon relations can only have ways as members. The first object id(s) are {2}";
     private static final String INVALID_ROLE_INSTRUCTION_FORMAT = "{0} ways have an invalid or missing role in multipolygon relation {1,number,#}. The role must be either outer or inner. The way id(s) are {2}";
@@ -71,11 +72,12 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
     private static final String INNER_MISSING_OUTER_INSTRUCTION_FORMAT = "Relation {0,number,#} has an inner member that is not contained by an outer member.";
     private static final String MISSING_OUTER_INSTRUCTION_FORMAT = "Multipolygon relation {0,number,#} has no outer member(s). Must have 1 or more.";
     private static final String SINGLE_MEMBER_RELATION_INSTRUCTION_FORMAT = "Multipolygon relation {0,number,#} has only one member.";
+    private static final String GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT = "Multipolygon relation {0,number,#} has invalid geometry.";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
             CLOSED_LOOP_INSTRUCTION_FORMAT, SINGLE_MEMBER_RELATION_INSTRUCTION_FORMAT,
             MISSING_OUTER_INSTRUCTION_FORMAT, INVALID_ROLE_INSTRUCTION_FORMAT,
             INVALID_OSM_TYPE_INSTRUCTION_FORMAT, INVALID_OVERLAP_INSTRUCTION_FORMAT,
-            INNER_MISSING_OUTER_INSTRUCTION_FORMAT);
+            INNER_MISSING_OUTER_INSTRUCTION_FORMAT, GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT);
     private static final RelationOrAreaToMultiPolygonConverter RELATION_OR_AREA_TO_MULTI_POLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter();
     private static final EnumMap<ItemType, String> atlasToOsmType = new EnumMap<>(ItemType.class);
     private static final Logger logger = LoggerFactory
@@ -101,6 +103,8 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
                 .indexOf(INVALID_OVERLAP_INSTRUCTION_FORMAT);
         INNER_MISSING_OUTER_INSTRUCTION_FORMAT_INDEX = FALLBACK_INSTRUCTIONS
                 .indexOf(INNER_MISSING_OUTER_INSTRUCTION_FORMAT);
+        GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT_INDEX = FALLBACK_INSTRUCTIONS
+                .indexOf(GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT);
         atlasToOsmType.put(ItemType.EDGE, "way");
         atlasToOsmType.put(ItemType.AREA, "way");
         atlasToOsmType.put(ItemType.LINE, "way");
@@ -138,6 +142,13 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
         final Relation multipolygonRelation = (Relation) object;
         final List<String> instructions = new ArrayList<>();
         final Set<Location> issueLocations = new HashSet<>();
+
+        if (object.getTag("synthetic_invalid_geometry").isPresent())
+        {
+            instructions.add(
+                    this.getLocalizedInstruction(GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT_INDEX,
+                            multipolygonRelation.getOsmIdentifier()));
+        }
 
         this.checkGeometry(multipolygonRelation).ifPresent(tuple ->
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
@@ -28,6 +28,7 @@ import org.openstreetmap.atlas.geography.atlas.items.complex.RelationOrAreaToMul
 import org.openstreetmap.atlas.geography.converters.MultiplePolyLineToPolygonsConverter;
 import org.openstreetmap.atlas.geography.converters.jts.JtsPolygonConverter;
 import org.openstreetmap.atlas.tags.RelationTypeTag;
+import org.openstreetmap.atlas.tags.SyntheticInvalidGeometryTag;
 import org.openstreetmap.atlas.tags.SyntheticRelationMemberAdded;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
@@ -143,7 +144,7 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
         final List<String> instructions = new ArrayList<>();
         final Set<Location> issueLocations = new HashSet<>();
 
-        if (object.getTag("synthetic_invalid_geometry").isPresent())
+        if (Validators.hasValuesFor(object, SyntheticInvalidGeometryTag.class))
         {
             instructions.add(
                     this.getLocalizedInstruction(GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT_INDEX,

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTest.java
@@ -64,6 +64,17 @@ public class InvalidMultiPolygonRelationCheckTest
     }
 
     @Test
+    public void innerTouchSyntheticInvalidTest()
+    {
+        this.verifyCheck(this.setup.innerTouchSyntheticInvalidAtlas(),
+                ConfigurationResolver.emptyConfiguration(), 1,
+                Collections.singletonList(
+                        String.format(referenceDefaultLocaleCheck.getLocalizedInstruction(
+                                InvalidMultiPolygonRelationCheck.GENERIC_INVALID_GEOMETRY_INSTRUCTION_FORMAT_INDEX,
+                                1), "1")));
+    }
+
+    @Test
     public void innerTouchTest()
     {
         this.verifyCheck(this.setup.innerTouchAtlas(), ConfigurationResolver.emptyConfiguration(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTestRule.java
@@ -565,6 +565,29 @@ public class InvalidMultiPolygonRelationCheckTestRule extends CoreTestRule
                     @Member(id = "2000000", type = "area", role = "inner") }, tags = "type=multipolygon") })
     private Atlas innerOutsideOuterAtlas;
 
+    @TestAtlas(
+            // Areas
+            areas = { @Area(id = "1000000", coordinates = { @Loc(value = TEST_VALIDRELATION_10),
+                    @Loc(value = TEST_VALIDRELATION_11), @Loc(value = TEST_VALIDRELATION_14),
+                    @Loc(value = TEST_VALIDRELATION_6), @Loc(value = TEST_VALIDRELATION_10) }),
+                    @Area(id = "2000000", coordinates = {
+                            @Loc(value = TEST_VALIDRELATIONTWONOROLE_1),
+                            @Loc(value = TEST_VALIDRELATIONTWONOROLE_8),
+                            @Loc(value = TEST_INVALIDMEMBERTYPE_6),
+                            @Loc(value = TEST_VALIDRELATIONTWONOROLE_1) }),
+                    @Area(id = "3000000", coordinates = {
+                            @Loc(value = TEST_VALIDRELATIONTWONOROLE_15),
+                            @Loc(value = TEST_VALIDRELATIONTWONOROLE_8),
+                            @Loc(value = TEST_INVALIDMEMBERTYPE_6),
+                            @Loc(value = TEST_VALIDRELATIONTWONOROLE_15) }) },
+            // Relations
+            relations = { @Relation(id = "1000000", members = {
+                    @Member(id = "1000000", type = "area", role = "outer"),
+                    @Member(id = "2000000", type = "area", role = "inner"),
+                    @Member(id = "3000000", type = "area", role = "inner") }, tags = {
+                            "type=multipolygon", "synthetic_invalid_geometry=yes" }) })
+    private Atlas innerTouchSyntheticInvalidAtlas;
+
     public Atlas getAtlas()
     {
         return this.atlas;
@@ -623,6 +646,11 @@ public class InvalidMultiPolygonRelationCheckTestRule extends CoreTestRule
     public Atlas innerTouchAtlas()
     {
         return this.innerTouchAtlas;
+    }
+
+    public Atlas innerTouchSyntheticInvalidAtlas()
+    {
+        return this.innerTouchSyntheticInvalidAtlas;
     }
 
     public Atlas outerInHoleAtlas()


### PR DESCRIPTION
### Description:

This update InvalidMultiPolygonRelationCheck to flag features that have the new SyntheticInvalidGeometryTag. This tag is used by Atlas to mark features that were found to have invalid geometries, during the country slicing process. 

This PR bumps the atlas version to 6.2.1, to access the new tag.

### Potential Impact:

Will add a few flags.

### Unit Test Approach:
Added a unit test for a feature with the tag. 

### Test Results:
Tested on several countries and sampled the added flags. All the sampled features had the new tag and invalid geometries in OSM. 

