### PR TITLE
Basic waterway checks

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1091,12 +1091,18 @@
     }
   },
   "WaterWayCheck": {
-    "ocean.boundary": "natural->coastline",
-    "ocean.valid": "natural->strait,channel,fjord,sound,bay|harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock",
-    "waterway.elevation.distance.min.start.end": 450.0,
-    "waterway.elevation.resolution.min.uphill": 1.0,
-    "waterway.sink.tags.filters": "natural->sinkhole|waterway->tidal_channel,drain|manhole->drain",
-    "waterway.tags.filters": "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised",
+    "ocean": {
+      "boundary": "natural->coastline",
+      "valid": "natural->strait,channel,fjord,sound,bay|harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock"
+    },
+    "waterway": {
+      "elevation": {
+        "distance.min.start.end": 450.0,
+        "resolution.min.uphill": 1.0
+      },
+      "sink.tags.filters": "natural->sinkhole|waterway->tidal_channel,drain|manhole->drain",
+      "tags.filters": "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised"
+    },
     "challenge": {
       "description": "Waterways that have circular flows, are crossing, do not have a sink, or are going uphill (if elevation data was provided)",
       "blurb": "Fix waterways such that they make physical sense",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1096,6 +1096,13 @@
     "waterway.elevation.distance.min.start.end": 450.0,
     "waterway.elevation.resolution.min.uphill": 1.0,
     "waterway.sink.tags.filters": "natural->sinkhole|waterway->tidal_channel,drain|manhole->drain",
-    "waterway.tags.filters": "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised"
+    "waterway.tags.filters": "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised",
+    "challenge": {
+      "description": "Waterways that have circular flows, are crossing, do not have a sink, or are going uphill (if elevation data was provided)",
+      "blurb": "Fix waterways such that they make physical sense",
+      "instruction": "Open your favorite editor and edit the waterways",
+      "difficulty": "NORMAL",
+      "defaultPriority": "LOW"
+    }
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1089,5 +1089,13 @@
       "instruction": "Open your favorite editor and edit the features overlapping the ocean so they either validly overlap or do not overlap.",
       "difficulty": "MEDIUM"
     }
+  },
+  "WaterWayCheck": {
+    "ocean.boundary": "natural->coastline",
+    "ocean.valid": "natural->strait,channel,fjord,sound,bay|harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock",
+    "waterway.elevation.distance.min.start.end": 450.0,
+    "waterway.elevation.resolution.min.uphill": 1.0,
+    "waterway.sink.tags.filters": "natural->sinkhole|waterway->tidal_channel,drain|manhole->drain",
+    "waterway.tags.filters": "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised"
   }
 }

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -99,4 +99,4 @@ This document is a list of tables with a description and link to documentation f
 | LineCrossingWaterBodyCheck | The purpose of this check is to identify line items (edges or lines) and optionally buildings, that cross water bodies invalidly. |
 | MalformedPolyLineCheck | This check identifies lines that have only one point, or none, and the ones that are too long. |
 | [SelfIntersectingPolylineCheck](checks/selfIntersectingPolylineCheck.md) | The purpose of this check is to identify all edges/lines/areas in Atlas that have self-intersecting polylines, or geometries that intersects itself in some form. |
-| [WaterWayCheck](checks/waterWayCheck.md) | This check finds closed waterways (circular water motion), waterways without a place for water to go (a "sink"), and waterways that go uphill (requires elevation data). |
+| [WaterWayCheck](checks/waterWayCheck.md) | This check finds closed waterways (circular water motion), waterways without a place for water to go (a "sink"), crossing waterways, and waterways that go uphill (requires elevation data). |

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -99,3 +99,4 @@ This document is a list of tables with a description and link to documentation f
 | LineCrossingWaterBodyCheck | The purpose of this check is to identify line items (edges or lines) and optionally buildings, that cross water bodies invalidly. |
 | MalformedPolyLineCheck | This check identifies lines that have only one point, or none, and the ones that are too long. |
 | [SelfIntersectingPolylineCheck](checks/selfIntersectingPolylineCheck.md) | The purpose of this check is to identify all edges/lines/areas in Atlas that have self-intersecting polylines, or geometries that intersects itself in some form. |
+| [WaterWayCheck](checks/waterWayCheck.md) | This check finds closed waterways (circular water motion), waterways without a place for water to go (a "sink"), and waterways that go uphill (requires elevation data). |

--- a/docs/checks/waterWayChecks.md
+++ b/docs/checks/waterWayChecks.md
@@ -1,7 +1,7 @@
 # WaterWay Checks
 
 #### Description
-This check identifies waterways that are closed (i.e., would have a circular water flow), waterways that do not have a place for the water to go (a "sink"), and waterways crossing waterways.
+This check identifies waterways that are closed (i.e., would have a circular water flow), waterways that do not have a place for the water to go (a "sink"), and waterways crossing waterways. It also looks for ways that may be going uphill (requires elevation data, see [ElevationUtilities](../elevationUtilities.md))
 
 #### Live Example
 1) This canal ([osm id: 46115760 version 5](https://www.openstreetmap.org/way/46115760)) is a closed waterway, which makes no semantic sense without a pump somewhere in the waterway. In this case, it should be tagged `natural=water` + `water=canal`.

--- a/docs/checks/waterWayChecks.md
+++ b/docs/checks/waterWayChecks.md
@@ -47,7 +47,7 @@ the following conditions:
     }
 ```
 
-After the preliminary filtering, each object goes through a series of `if` statements. The first checks if the line is closed, as this is a very cheap check. The second checks if the waterway is going uphill (requires elevation data), and if the resolution of the elevation data is good enough to determine that the waterway goes uphill, the object is flagged. At this point, we check to see if the waterway ends in a sink, for this check, we attempt ensure that the waterway ends inside the boundaries, and not in a neighboring area. Furthermore, we reuse the check for uphill ways to help improve the error message. Once all of those checks have finished, if no flag has yet been found, we check for waterway intersections.
+After the preliminary filtering, each object goes through a series of `if` statements. The first checks if the line is closed. The second checks if the waterway is going uphill (requires elevation data), and if the resolution of the elevation data is good enough to determine that the waterway goes uphill, the object is flagged. At this point, we check to see if the waterway ends in a sink, for this check, we attempt ensure that the waterway ends inside the boundaries, and not in a neighboring area. Furthermore, we reuse the check for uphill ways to help improve the error message. Once all of those checks have finished, we check for waterway intersections. If more than one check flags the object, instructions and offending objects are appended to the CheckFlag.
 
 
 To learn more about the code, please look at the comments in the source code for the check.

--- a/docs/checks/waterWayChecks.md
+++ b/docs/checks/waterWayChecks.md
@@ -1,0 +1,54 @@
+# WaterWay Checks
+
+#### Description
+This check identifies waterways that are closed (i.e., would have a circular water flow), waterways that do not have a place for the water to go (a "sink"), and waterways crossing waterways.
+
+#### Live Example
+1) This canal ([osm id: 46115760 version 5](https://www.openstreetmap.org/way/46115760)) is a closed waterway, which makes no semantic sense without a pump somewhere in the waterway. In this case, it should be tagged `natural=water` + `water=canal`.
+
+2) The waterways at ([osm id: 500672157](https://www.openstreetmap.org/node/500672157) on 2020-08-20) cross each other, when they should be connected.
+
+#### Useful configuration variables:
+```json
+{
+    "WaterWayCheck": {
+        "waterway.sink.tags.filters": "natural->sinkhole|waterway->tidal_channel,drain|manhole->drain",
+        "waterway.tags.filters": "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised",
+        "ocean.valid": "natural->strait,channel,fjord,sound,bay|harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock",
+        "ocean.boundary": "natural->coastline",
+        "waterway.elevation.resolution.min.uphill": "1" (meter),
+        "waterway.elevation.resolution.min.start.end": "457.2" (meters)
+    }
+}
+```
+You may also want to look at [ElevationUtilities](../utilities/elevationUtilities.md).
+
+#### Code Review
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines,
+Nodes & Relations; in our case, we’re are looking at [LineItems](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/LineItem.java), which Lines and Edges are specific subtypes of. This is due to the fact that a waterway may either be a _navigable_ way or a _non-navigable_ way (rivers are generally considered _navigable_, while streams may or may not be _navigable_).
+
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy
+the following conditions:
+* Must be an LineItem with one of the following tags:
+    * `waterway=RIVER`
+    * `waterway=STREAM`
+    * `waterway=TIDAL_CHANNEL`
+    * `waterway=CANAL`
+    * `waterway=DRAIN`
+    * `waterway=DITCH`
+    * `waterway=PRESSURISED`
+
+```java
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return !isFlagged(object.getOsmIdentifier()) && object instanceof LineItem
+                && this.waterwayTagFilter.test(object);
+    }
+```
+
+After the preliminary filtering, each object goes through a series of `if` statements. The first checks if the line is closed, as this is a very cheap check. The second checks if the waterway is going uphill (requires elevation data), and if the resolution of the elevation data is good enough to determine that the waterway goes uphill, the object is flagged. At this point, we check to see if the waterway ends in a sink, for this check, we attempt ensure that the waterway ends inside the boundaries, and not in a neighboring area. Furthermore, we reuse the check for uphill ways to help improve the error message. Once all of those checks have finished, if no flag has yet been found, we check for waterway intersections.
+
+
+To learn more about the code, please look at the comments in the source code for the check.
+[WaterWayCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java)

--- a/docs/utilities/elevationUtilities.md
+++ b/docs/utilities/elevationUtilities.md
@@ -1,0 +1,16 @@
+# ElevationUtilities
+
+#### Description
+This is a general utilities class that allows checks to get elevation data. The class currently only understands HGT files, which by specification are 1 degree by 1 degree tiles. There is a [script](../../../scripts/elevationData) which can be used to get NASA SRTM elevation data (~90m accuracy throughout the world, some locations have no data).
+
+#### Configuration
+
+```json
+{
+    "elevationutilities": {
+        "elevation.srtm_extent": "1" (degree),
+        "elevation.srtm_ext": "hgt" (file extension),
+        "elevation.path": "elevation"
+    }
+}
+```

--- a/docs/utilities/elevationUtilities.md
+++ b/docs/utilities/elevationUtilities.md
@@ -7,8 +7,8 @@ This is a general utilities class that allows checks to get elevation data. The 
 
 ```json
 {
-    "elevationutilities": {
-        "elevation.srtm_extent": "1" (degree),
+    "ElevationUtilities": {
+        "elevation.srtm_extent": 1.0 (degree),
         "elevation.srtm_ext": "hgt" (file extension),
         "elevation.path": "elevation"
     }

--- a/scripts/elevationData/requirements.txt
+++ b/scripts/elevationData/requirements.txt
@@ -1,0 +1,9 @@
+certifi>=2020.6.20
+chardet>=3.0.4
+defusedxml>=0.6.0
+idna>=2.10
+python-dateutil>=2.8.1
+requests>=2.24.0
+six>=1.15.0
+tqdm>=4.48.2
+urllib3>=1.25.10

--- a/scripts/elevationData/srtm-hgt.py
+++ b/scripts/elevationData/srtm-hgt.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Get SRTM (HGT) files from the Nasa SRTM mission via USGS in a server-friendly
+way.
+
+There is a pause of 10 seconds between downloads, and if a file is already
+downloaded, it is not redownloaded. This also looks at timestamps, although
+it is unlikely that the SRTM files will be significantly updated.
+"""
+from defusedxml import ElementTree as ET
+from tqdm import tqdm
+import argparse
+import dateutil.parser
+import os
+import requests
+import time
+import typing
+
+url = "https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/"
+def download_file(url: str, output_dir: str="elevation"):
+    name = url.split("/")[-1]
+    with requests.get(url, stream=True) as response:
+        response.raise_for_status()
+        with open(os.path.join(output_dir, name), "wb") as fh:
+            for content in tqdm(response.iter_content(chunk_size=4096)):
+                fh.write(content)
+
+def file_needs_download(url: str, output_dir: str="elevation") -> bool:
+    name = url.split("/")[-1]
+    filepath = os.path.join(output_dir, name)
+    if os.path.isfile(filepath):
+        head = requests.head(url)
+        head.raise_for_status()
+        last_modified = dateutil.parser.parse(head.headers.get('Last-Modified')).timestamp()
+        content_length = int(head.headers.get('Content-Length'))
+
+        creation = os.path.getctime(filepath)
+        modification = os.path.getmtime(filepath)
+
+        return modification < last_modified or creation < last_modified or content_length != os.path.getsize(filepath)
+    return True
+
+def get_sub_url(url: str) -> typing.List[str]:
+    response = requests.get(url)
+    sub_url = []
+    for line in response.iter_lines():
+        try:
+            tree = ET.fromstring(line)
+            for child in tree.findall("a"):
+                sub_url.append(child.attrib.get("href"))
+        except ET.ParseError as e:
+            pass
+    return sub_url
+
+def download_url(url: str, output_dir: str="elevation") -> None:
+    for sub_url in tqdm(get_sub_url(url)):
+        for sub_sub_url in tqdm(get_sub_url(url + sub_url)):
+            if file_needs_download(url + sub_url + sub_sub_url, output_dir = output_dir):
+                tqdm.write("Downloading " + url + sub_url + sub_sub_url)
+                download_file(url + sub_url + sub_sub_url, output_dir = output_dir)
+                time.sleep(10)
+            else:
+                tqdm.write(url + sub_url + sub_sub_url + " not downloaded")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download SRTM files")
+    parser.add_argument("directory", nargs='?', default="elevation", help="The directory to save files to")
+    args = parser.parse_args()
+    download_url(url, output_dir = args.directory)

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonTagFilters.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonTagFilters.java
@@ -1,0 +1,15 @@
+package org.openstreetmap.atlas.checks.utility;
+
+/**
+ * Hold common tag filters (should be used in more than one check)
+ * 
+ * @author Taylor Smock
+ */
+public class CommonTagFilters
+{
+    /** Boundary filter for ocean boundaries */
+    public static final String DEFAULT_OCEAN_BOUNDARY_TAGS = "natural->coastline";
+    /** Tag filter for oceans (without coastline) */
+    public static final String DEFAULT_VALID_OCEAN_TAGS = "natural->strait,channel,fjord,sound,bay|"
+            + "harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock";
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonTagFilters.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonTagFilters.java
@@ -5,8 +5,13 @@ package org.openstreetmap.atlas.checks.utility;
  * 
  * @author Taylor Smock
  */
-public class CommonTagFilters
+public final class CommonTagFilters
 {
+    private CommonTagFilters()
+    {
+        // Hide constructor
+    }
+
     /** Boundary filter for ocean boundaries */
     public static final String DEFAULT_OCEAN_BOUNDARY_TAGS = "natural->coastline";
     /** Tag filter for oceans (without coastline) */

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CompressionUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CompressionUtilities.java
@@ -70,15 +70,16 @@ public final class CompressionUtilities
     {
         final InputStream uncompressed = new CompressorStreamFactory()
                 .createCompressorInputStream(inputStream);
+        final BufferedInputStream buffered = new BufferedInputStream(uncompressed);
         try
         {
-            return unarchivedInputStream(uncompressed);
+            return unarchivedInputStream(buffered);
         }
         catch (final ArchiveException | IOException e)
         {
-            // OK. Not archived.
-            return uncompressed;
+            // OK. Probably not archived.
         }
+        return buffered;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CompressionUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CompressionUtilities.java
@@ -1,0 +1,115 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utilities that are useful for compressed or archived streams.
+ *
+ * @author Taylor Smock
+ */
+public final class CompressionUtilities
+{
+    private static final Logger logger = LoggerFactory.getLogger(CompressionUtilities.class);
+
+    /**
+     * Get an uncompressed and unarchived input stream
+     *
+     * @param inputStream
+     *            The inputstream to make unarchived/uncompressed
+     * @return A usuable inputstream (if unarchived, it will be at the first entry)
+     * @throws IOException
+     *             If the inputstream cannot be read
+     */
+    public static InputStream getUncompressedInputStream(final InputStream inputStream)
+            throws IOException
+    {
+        final BufferedInputStream bufferedInput = new BufferedInputStream(inputStream);
+        try
+        {
+            return decompressedInputStream(bufferedInput);
+        }
+        catch (final CompressorException | IOException e)
+        {
+            // OK. Not compressed.
+        }
+        try
+        {
+            return unarchivedInputStream(bufferedInput);
+        }
+        catch (final ArchiveException | IOException e)
+        {
+            // OK. Not archived or compressed. Just return it.
+            return bufferedInput;
+        }
+    }
+
+    /**
+     * Decompress an inputstream
+     *
+     * @param inputStream
+     *            The inputstream to decompress
+     * @return The decompressed (and potentially unarchived) inputstream. If unarchived, the
+     *         position will be at the first entry.
+     * @throws IOException
+     *             If there is a problem reading the stream
+     * @throws CompressorException
+     *             If there is a problem decompressing, or if it is not a compressed file
+     */
+    private static InputStream decompressedInputStream(final InputStream inputStream)
+            throws IOException, CompressorException
+    {
+        final InputStream uncompressed = new CompressorStreamFactory()
+                .createCompressorInputStream(inputStream);
+        try
+        {
+            return unarchivedInputStream(uncompressed);
+        }
+        catch (final ArchiveException | IOException e)
+        {
+            // OK. Not archived.
+            return uncompressed;
+        }
+    }
+
+    /**
+     * Try to unarchive an inputstream
+     *
+     * @param inputStream
+     *            The inputstream to unarchive
+     * @return The unarchived input stream
+     * @throws IOException
+     *             If there is an IOException
+     * @throws ArchiveException
+     *             If there is a problem with the archive (or it isn't one)
+     */
+    private static InputStream unarchivedInputStream(final InputStream inputStream)
+            throws IOException, ArchiveException
+    {
+        final ArchiveInputStream toRead = new ArchiveStreamFactory()
+                .createArchiveInputStream(inputStream);
+        try
+        {
+            toRead.getNextEntry();
+        }
+        catch (final IOException e)
+        {
+            logger.trace(e.getLocalizedMessage());
+        }
+        return toRead;
+    }
+
+    private CompressionUtilities()
+    {
+        // Hide constructor
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -43,6 +43,8 @@ public final class ElevationUtilities implements Serializable
      */
     public static final short NO_ELEVATION = Short.MIN_VALUE;
 
+    private static final short[][] EMPTY_MAP = new short[][] {};
+
     /** Just an int for converting a decimal to a percentage */
     private static final int DECIMAL_TO_PERCENTAGE = 100;
 
@@ -102,7 +104,7 @@ public final class ElevationUtilities implements Serializable
     public short getElevation(final Location location)
     {
         final short[][] map = getMap(location);
-        if (map == null)
+        if (Arrays.equals(EMPTY_MAP, map))
         {
             return NO_ELEVATION;
         }
@@ -138,11 +140,15 @@ public final class ElevationUtilities implements Serializable
      *
      * @param location
      *            The location to get the resolution of
-     * @return The resolution of the data
+     * @return The resolution of the data, or {@link Distance#MAXIMUM} if there is no data.
      */
     public Distance getResolution(final Location location)
     {
         final short[][] map = getMap(location);
+        if (Arrays.equals(EMPTY_MAP, map))
+        {
+            return Distance.MAXIMUM;
+        }
         final float difference = ((float) this.srtmExtent) / map.length;
         final Location temp = new Location(location.getLatitude(),
                 Longitude.degrees(location.getLongitude().asDegrees() + difference));
@@ -162,7 +168,7 @@ public final class ElevationUtilities implements Serializable
     {
         final short[][] mapOne = getMap(one);
         final short[][] mapTwo = getMap(two);
-        if (Arrays.equals(mapOne, mapTwo))
+        if (Arrays.equals(mapOne, mapTwo) && !Arrays.equals(EMPTY_MAP, mapOne))
         {
             final int[] indexOne = getIndex(one, mapOne.length);
             final int[] indexTwo = getIndex(two, mapTwo.length);
@@ -268,7 +274,7 @@ public final class ElevationUtilities implements Serializable
         }
         if (!path.toFile().isFile())
         {
-            return null;
+            return EMPTY_MAP;
         }
         try (InputStream is = CompressionUtilities
                 .getUncompressedInputStream(Files.newInputStream(path)))
@@ -277,7 +283,7 @@ public final class ElevationUtilities implements Serializable
         }
         catch (final IOException e)
         {
-            return null;
+            return EMPTY_MAP;
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -66,7 +66,7 @@ public final class ElevationUtilities implements Serializable
      */
     private static String configurationKey(final String key)
     {
-        return formatKey("elevationutilities", key);
+        return formatKey(ElevationUtilities.class.getSimpleName(), key);
     }
 
     private static <U, V> V configurationValue(final Configuration configuration, final String key,

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -36,7 +36,7 @@ public final class ElevationUtilities implements Serializable
     /**
      * The assumed extent of a HGT SRTM file (lat/lon) in degrees
      */
-    private static final int SRTM_EXTENT = 1;
+    private static final double SRTM_EXTENT = 1;
     /**
      * A non-number when there is no elevation data available. This is currently returns
      * {@link Short#MIN_VALUE}.
@@ -51,7 +51,7 @@ public final class ElevationUtilities implements Serializable
     /** A map of {lat, lon} pairs with a loaded srtm in a byte array */
     private final Map<Pair<Integer, Integer>, short[][]> loadedSrtm = new HashMap<>();
 
-    private final int srtmExtent;
+    private final double srtmExtent;
 
     private final String srtmExtension;
 
@@ -88,11 +88,28 @@ public final class ElevationUtilities implements Serializable
      */
     public ElevationUtilities(final Configuration configuration)
     {
-        this.srtmExtent = configurationValue(configuration, "elevation.srtm_extent", SRTM_EXTENT,
-                i -> i);
-        this.srtmExtension = configurationValue(configuration, "elevation.srtm_ext", SRTM_EXTENSION,
-                i -> i);
-        this.srtmPath = configurationValue(configuration, "elevation.path", "elevation", i -> i);
+        this(configurationValue(configuration, "elevation.srtm_extent", SRTM_EXTENT, i -> i),
+                configurationValue(configuration, "elevation.srtm_ext", SRTM_EXTENSION, i -> i),
+                configurationValue(configuration, "elevation.path", "elevation", i -> i));
+    }
+
+    /**
+     * Create a configured ElevationUtilities
+     *
+     * @param srtmExtent
+     *            The extent of the files. The units are in degrees, and the default is 1 degree.
+     * @param srtmExtension
+     *            The extension of the files. Archive/compression file endings are not required
+     *            (they will be automatically detected).
+     * @param srtmPath
+     *            The path for the files.
+     */
+    public ElevationUtilities(final double srtmExtent, final String srtmExtension,
+            final String srtmPath)
+    {
+        this.srtmExtension = srtmExtension;
+        this.srtmExtent = srtmExtent;
+        this.srtmPath = srtmPath;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -88,9 +88,13 @@ public final class ElevationUtilities implements Serializable
      */
     public ElevationUtilities(final Configuration configuration)
     {
-        this(configurationValue(configuration, "elevation.srtm_extent", SRTM_EXTENT, i -> i),
-                configurationValue(configuration, "elevation.srtm_ext", SRTM_EXTENSION, i -> i),
-                configurationValue(configuration, "elevation.path", "elevation", i -> i));
+        this(configurationValue(configuration, "elevation.srtm_extent", SRTM_EXTENT,
+                Function.identity()),
+                configurationValue(configuration, "elevation.srtm_ext", SRTM_EXTENSION,
+                        Function.identity()),
+                configurationValue(configuration, "elevation.path", "elevation",
+                        Function.identity()));
+
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -1,0 +1,346 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Longitude;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * Used to determine assumed direction for some features (e.g. waterways). Assumptions are that any
+ * SRTM file follows the specification here:
+ * https://dds.cr.usgs.gov/srtm/version2_1/Documentation/Quickstart.pdf
+ *
+ * @author Taylor Smock
+ */
+public final class ElevationUtilities implements Serializable
+{
+    private static final long serialVersionUID = -5929570973909280629L;
+    /**
+     * The assumed file extension
+     */
+    private static String SRTM_EXT = "hgt";
+    /**
+     * The assumed extent of a HGT SRTM file (lat/lon) in degrees
+     */
+    private static int SRTM_EXTENT = 1;
+    /**
+     * A non-number when there is no elevation data available. This is currently returns
+     * {@link Short#MIN_VALUE}.
+     */
+    public static final short NO_ELEVATION = Short.MIN_VALUE;
+
+    /** Just an int for converting a decimal to a percentage */
+    private static final int DECIMAL_TO_PERCENTAGE = 100;
+
+    /** A map of {lat, lon} pairs with a loaded srtm in a byte array */
+    private final Map<Pair<Integer, Integer>, short[][]> loadedSrtm = new HashMap<>();
+
+    private final int srtmExtent;
+
+    private final String srtmExt;
+
+    private final String srtmPath;
+
+    /**
+     * Configuration Keys in the Integrity Framework are based on the check simple classname.
+     *
+     * @param key
+     *            key part for a specific configuration item defined for this class
+     * @return complete key for lookup
+     */
+    private static String configurationKey(final String key)
+    {
+        return formatKey("elevationutilities", key);
+    }
+
+    private static <U, V> V configurationValue(final Configuration configuration, final String key,
+            final U defaultValue, final Function<U, V> transform)
+    {
+        return configuration.get(configurationKey(key), defaultValue, transform).value();
+    }
+
+    private static String formatKey(final String name, final String key)
+    {
+        return String.format("%s.%s", name, key);
+    }
+
+    /**
+     * Create a configured ElevationUtilities
+     *
+     * @param configuration
+     *            A configuration which should (at a minimum) have a file path for elevation files.
+     */
+    public ElevationUtilities(final Configuration configuration)
+    {
+        this.srtmExtent = configurationValue(configuration, "elevation.srtm_extent", SRTM_EXTENT,
+                i -> i);
+        this.srtmExt = configurationValue(configuration, "elevation.srtm_ext", SRTM_EXT, i -> i);
+        this.srtmPath = configurationValue(configuration, "elevation.path", "elevation", i -> i);
+    }
+
+    /**
+     * Get the elevation of a location
+     *
+     * @param location
+     *            The location to get the elevation of
+     * @return The meters of the elevation (does not show fractions of meters)
+     */
+    public short getElevation(final Location location)
+    {
+        final short[][] map = getMap(location);
+        if (map == null)
+        {
+            return NO_ELEVATION;
+        }
+        final int[] index = getIndex(location, map.length);
+        return map[index[0]][index[1]];
+    }
+
+    /**
+     * Get the incline between two points
+     *
+     * @param start
+     *            The start of the slope
+     * @param end
+     *            The end of the slope
+     * @return The incline from the start to the end (may be negative). May also return
+     *         {@link Double#NaN} if one of the elevations cannot be obtained.
+     * @see <a href="https://wiki.openstreetmap.org/wiki/Key:incline">OSM Wiki Incline</a>
+     */
+    public double getIncline(final Location start, final Location end)
+    {
+        final short startElevation = getElevation(start);
+        final short endElevation = getElevation(end);
+        if (startElevation == NO_ELEVATION || endElevation == NO_ELEVATION)
+        {
+            return Double.NaN;
+        }
+        final double distance = end.distanceTo(start).asMeters();
+        return ((endElevation - startElevation) / distance) * DECIMAL_TO_PERCENTAGE;
+    }
+
+    /**
+     * Get the resolution of the data at the location.
+     *
+     * @param location
+     *            The location to get the resolution of
+     * @return The resolution of the data
+     */
+    public Distance getResolution(final Location location)
+    {
+        final short[][] map = getMap(location);
+        final float difference = ((float) this.srtmExtent) / map.length;
+        final Location temp = new Location(location.getLatitude(),
+                Longitude.degrees(location.getLongitude().asDegrees() + difference));
+        return temp.distanceTo(location);
+    }
+
+    /**
+     * Check if two locations are in the same data point (i.e., same pixel in a HGT)
+     *
+     * @param one
+     *            A location to check
+     * @param two
+     *            Another location to check
+     * @return {@code true} if they are in the same grid and location
+     */
+    public boolean inSameDataPoint(final Location one, final Location two)
+    {
+        final short[][] mapOne = getMap(one);
+        final short[][] mapTwo = getMap(two);
+        if (Arrays.equals(mapOne, mapTwo))
+        {
+            final int[] indexOne = getIndex(one, mapOne.length);
+            final int[] indexTwo = getIndex(two, mapTwo.length);
+            if (Arrays.equals(indexOne, indexTwo))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Get the index to use for a short[latitude][longitude] = height in meters array
+     *
+     * @param location
+     *            The location to get the index for
+     * @param mapSize
+     *            The size of the map
+     * @return A [latitude, longitude] = int (index) array.
+     */
+    private int[] getIndex(final Location location, final int mapSize)
+    {
+        final double latDegrees = location.getLatitude().asDegrees();
+        final double lonDegrees = location.getLongitude().asDegrees();
+
+        final float fraction = ((float) this.srtmExtent) / mapSize;
+        int latitude = (int) Math.floor(Math.abs(latDegrees - (int) latDegrees) / fraction);
+        int longitude = (int) Math.floor(Math.abs(lonDegrees - (int) lonDegrees) / fraction);
+        if (latDegrees >= 0)
+        {
+            latitude = mapSize - 1 - latitude;
+        }
+        if (lonDegrees < 0)
+        {
+            longitude = mapSize - 1 - longitude;
+        }
+        return new int[] { latitude, longitude };
+    }
+
+    /**
+     * Get the map for a specified location
+     *
+     * @param location
+     *            The location to get the height map for
+     * @return A short[latitude][longitude] = height in meters array
+     */
+    private short[][] getMap(final Location location)
+    {
+        final double latDegrees = location.getLatitude().asDegrees();
+        final double lonDegrees = location.getLongitude().asDegrees();
+        final int lat = (int) Math.floor(latDegrees);
+        final int lon = (int) Math.floor(lonDegrees);
+        return this.loadedSrtm.computeIfAbsent(Pair.of(lat, lon),
+                pair -> loadMap(pair.getLeft(), pair.getRight()));
+    }
+
+    /**
+     * The lower-left corner of each file is the file name.
+     *
+     * @param latitude
+     *            The latitude (lower left)
+     * @param longitude
+     *            The longitude (lower left)
+     * @return The expected filename for the location. You should also check for zip archives.
+     */
+    private String getSrtmFileName(final int latitude, final int longitude)
+    {
+        int lat = latitude;
+        int lon = longitude;
+        String latPrefix = "N";
+        if (lat < 0)
+        {
+            lat = Math.abs(lat);
+            latPrefix = "S";
+        }
+
+        String lonPrefix = "E";
+        if (lon < 0)
+        {
+            lon = Math.abs(lon);
+            lonPrefix = "W";
+        }
+
+        return String.format("%s%02d%s%03d.%s", latPrefix, lat, lonPrefix, lon, this.srtmExt);
+    }
+
+    /**
+     * Load a map for a specified latitude and longitude
+     *
+     * @param lat
+     *            The latitude to use
+     * @param lon
+     *            The longitude to use
+     * @return A short[latitude][longitude] = height in meters array
+     */
+    private synchronized short[][] loadMap(final int lat, final int lon)
+    {
+        final String filename = getSrtmFileName(lat, lon);
+        Path path = Paths.get(this.srtmPath, filename);
+        if (!path.toFile().isFile())
+        {
+            path = Paths.get(this.srtmPath, filename + ".zip");
+        }
+        if (!path.toFile().isFile())
+        {
+            return null;
+        }
+        try (InputStream is = new FileInputStream(path.toFile()))
+        {
+            InputStream toRead = is;
+            try
+            {
+                if (path.toString().endsWith(".zip"))
+                {
+                    final BufferedInputStream bis = new BufferedInputStream(is);
+                    final ZipInputStream zis = new ZipInputStream(bis);
+                    ZipEntry zipEntry;
+                    while ((zipEntry = zis.getNextEntry()) != null)
+                    {
+                        if (zipEntry.getName().endsWith(this.srtmExt))
+                        {
+                            toRead = zis;
+                            break;
+                        }
+                    }
+                }
+                return readStream(toRead);
+            }
+            finally
+            {
+                toRead.close();
+            }
+        }
+        catch (final IOException e)
+        {
+            return null;
+        }
+    }
+
+    /**
+     * Read an input stream into a short[][]
+     *
+     * @param inputStream
+     *            The inputstream to read
+     * @return A short[][] where short[latitude][longitude] = height in meters
+     * @throws IOException
+     *             If the inputstream throws an IOException
+     */
+    private short[][] readStream(final InputStream inputStream) throws IOException
+    {
+        int squareSize = 1;
+        short[] data = new short[(int) Math.pow(squareSize, 2)];
+        // srtm (hgt) is in big-endian
+        int index = 0;
+        final ByteBuffer byteBuffer = ByteBuffer.wrap(inputStream.readAllBytes());
+        byteBuffer.order(ByteOrder.BIG_ENDIAN);
+        while (byteBuffer.hasRemaining())
+        {
+            data[index] = byteBuffer.getShort();
+            index++;
+            if (index >= data.length && byteBuffer.hasRemaining())
+            {
+                squareSize += 1;
+                data = Arrays.copyOf(data, (int) Math.pow(squareSize, 2));
+            }
+        }
+
+        final short[][] realData = new short[squareSize][squareSize];
+        for (int latitude = 0; latitude < squareSize; latitude++)
+        {
+            for (int longitude = 0; longitude < squareSize; longitude++)
+            {
+                realData[latitude][longitude] = data[latitude * squareSize + longitude];
+            }
+        }
+        return realData;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -32,11 +32,11 @@ public final class ElevationUtilities implements Serializable
     /**
      * The assumed file extension
      */
-    private static String SRTM_EXT = "hgt";
+    private static final String SRTM_EXT = "hgt";
     /**
      * The assumed extent of a HGT SRTM file (lat/lon) in degrees
      */
-    private static int SRTM_EXTENT = 1;
+    private static final int SRTM_EXTENT = 1;
     /**
      * A non-number when there is no elevation data available. This is currently returns
      * {@link Short#MIN_VALUE}.

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -32,7 +32,7 @@ public final class ElevationUtilities implements Serializable
     /**
      * The assumed file extension
      */
-    private static final String SRTM_EXT = "hgt";
+    private static final String SRTM_EXTENSION = "hgt";
     /**
      * The assumed extent of a HGT SRTM file (lat/lon) in degrees
      */
@@ -53,7 +53,7 @@ public final class ElevationUtilities implements Serializable
 
     private final int srtmExtent;
 
-    private final String srtmExt;
+    private final String srtmExtension;
 
     private final String srtmPath;
 
@@ -90,7 +90,8 @@ public final class ElevationUtilities implements Serializable
     {
         this.srtmExtent = configurationValue(configuration, "elevation.srtm_extent", SRTM_EXTENT,
                 i -> i);
-        this.srtmExt = configurationValue(configuration, "elevation.srtm_ext", SRTM_EXT, i -> i);
+        this.srtmExtension = configurationValue(configuration, "elevation.srtm_ext", SRTM_EXTENSION,
+                i -> i);
         this.srtmPath = configurationValue(configuration, "elevation.path", "elevation", i -> i);
     }
 
@@ -234,7 +235,7 @@ public final class ElevationUtilities implements Serializable
             lonPrefix = "W";
         }
 
-        return String.format("%s%02d%s%03d.%s", latPrefix, lat, lonPrefix, lon, this.srtmExt);
+        return String.format("%s%02d%s%03d.%s", latPrefix, lat, lonPrefix, lon, this.srtmExtension);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -1,20 +1,17 @@
 package org.openstreetmap.atlas.checks.utility;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.openstreetmap.atlas.geography.Location;
@@ -273,31 +270,10 @@ public final class ElevationUtilities implements Serializable
         {
             return null;
         }
-        try (InputStream is = new FileInputStream(path.toFile()))
+        try (InputStream is = CompressionUtilities
+                .getUncompressedInputStream(Files.newInputStream(path)))
         {
-            InputStream toRead = is;
-            try
-            {
-                if (path.toString().endsWith(".zip"))
-                {
-                    final BufferedInputStream bis = new BufferedInputStream(is);
-                    final ZipInputStream zis = new ZipInputStream(bis);
-                    ZipEntry zipEntry;
-                    while ((zipEntry = zis.getNextEntry()) != null)
-                    {
-                        if (zipEntry.getName().endsWith(this.srtmExt))
-                        {
-                            toRead = zis;
-                            break;
-                        }
-                    }
-                }
-                return readStream(toRead);
-            }
-            finally
-            {
-                toRead.close();
-            }
+            return readStream(is);
         }
         catch (final IOException e)
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/OceanBleedingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/OceanBleedingCheck.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.checks.utility.CommonTagFilters;
 import org.openstreetmap.atlas.checks.utility.IntersectionUtilities;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
@@ -37,15 +38,12 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class OceanBleedingCheck extends BaseCheck<Long>
 {
-    private static final String DEFAULT_VALID_OCEAN_TAGS = "natural->strait,channel,fjord,sound,bay|"
-            + "harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock";
     private final TaggableFilter validOceanTags;
     private static final String DEFAULT_INVALID_OCEAN_TAGS = "man_made->breakwater,pier"
             + "|natural->beach,marsh,swamp" + "|water->marsh"
             + "|wetland->bog,fen,mangrove,marsh,saltern,saltmarsh,string_bog,swamp,wet_meadow"
             + "|landuse->*";
     private final TaggableFilter invalidOceanTags;
-    private static final String DEFAULT_OCEAN_BOUNDARY_TAGS = "natural->coastline";
     private final TaggableFilter oceanBoundaryTags;
     private static final String DEFAULT_OFFENDING_MISCELLANEOUS_LINEITEMS = "railway->rail,narrow_gauge,preserved,subway,disused,monorail,tram,light_rail,funicular,construction,miniature";
     private final TaggableFilter defaultOffendingLineitems;
@@ -71,8 +69,8 @@ public class OceanBleedingCheck extends BaseCheck<Long>
     public OceanBleedingCheck(final Configuration configuration)
     {
         super(configuration);
-        this.validOceanTags = TaggableFilter.forDefinition(
-                this.configurationValue(configuration, "ocean.valid", DEFAULT_VALID_OCEAN_TAGS));
+        this.validOceanTags = TaggableFilter.forDefinition(this.configurationValue(configuration,
+                "ocean.valid", CommonTagFilters.DEFAULT_VALID_OCEAN_TAGS));
         this.invalidOceanTags = TaggableFilter.forDefinition(this.configurationValue(configuration,
                 "ocean.invalid", DEFAULT_INVALID_OCEAN_TAGS));
         this.defaultOffendingLineitems = TaggableFilter.forDefinition(this.configurationValue(
@@ -85,7 +83,7 @@ public class OceanBleedingCheck extends BaseCheck<Long>
                 .stream().map(element -> Enum.valueOf(HighwayTag.class, element.toUpperCase()))
                 .collect(Collectors.toList());
         this.oceanBoundaryTags = TaggableFilter.forDefinition(this.configurationValue(configuration,
-                "ocean.boundary", DEFAULT_OCEAN_BOUNDARY_TAGS));
+                "ocean.boundary", CommonTagFilters.DEFAULT_OCEAN_BOUNDARY_TAGS));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -288,9 +288,7 @@ public class WaterWayCheck extends BaseCheck<Long>
     public boolean doesLineEndOnWaterway(final LineItem line)
     {
         final List<LineItem> waterways = new ArrayList<>();
-        line.getAtlas()
-                .lineItemsIntersecting(line.asPolyLine().last().boxAround(Distance.ONE_METER),
-                        this.waterwayTagFilter::test)
+        line.getAtlas().lineItemsContaining(line.asPolyLine().last(), this.waterwayTagFilter::test)
                 .forEach(waterways::add);
 
         waterways.removeIf(line::equals);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.checks.utility.CommonTagFilters;
 import org.openstreetmap.atlas.checks.utility.ElevationUtilities;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
@@ -85,10 +86,6 @@ public class WaterWayCheck extends BaseCheck<Long>
     private static final String WATERWAY_SINK_TAG_FILTER_DEFAULT = "natural->sinkhole|waterway->tidal_channel,drain|manhole->drain";
     private static final String WATERWAY_TAG_FILTER_DEFAULT = "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised";
 
-    private static final String DEFAULT_VALID_OCEAN_TAGS = "natural->strait,channel,fjord,sound,bay|"
-            + "harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock";
-
-    private static final String DEFAULT_OCEAN_BOUNDARY_TAGS = "natural->coastline";
     private static final String DOES_NOT_END_IN_SINK = "The waterway {0} does not end in a sink (ocean/sinkhole/waterway/drain).";
     private static final String DOES_NOT_END_IN_SINK_BUT_CROSSING_OCEAN = DOES_NOT_END_IN_SINK
             + "\nThe waterway crosses a coastline, which means it is possible for the coastline to have an incorrect direction.\nLand should be to the LEFT of the coastline and the ocean should be to the RIGHT of the coastline (for more information, see https://wiki.osm.org/Tag:natural=coastline).";
@@ -174,10 +171,10 @@ public class WaterWayCheck extends BaseCheck<Long>
                 WATERWAY_TAG_FILTER_DEFAULT, TaggableFilter::forDefinition);
 
         /* Ocean data */
-        this.validOceanTags = TaggableFilter.forDefinition(
-                this.configurationValue(configuration, "ocean.valid", DEFAULT_VALID_OCEAN_TAGS));
+        this.validOceanTags = TaggableFilter.forDefinition(this.configurationValue(configuration,
+                "ocean.valid", CommonTagFilters.DEFAULT_VALID_OCEAN_TAGS));
         this.oceanBoundaryTags = TaggableFilter.forDefinition(this.configurationValue(configuration,
-                "ocean.boundary", DEFAULT_OCEAN_BOUNDARY_TAGS));
+                "ocean.boundary", CommonTagFilters.DEFAULT_OCEAN_BOUNDARY_TAGS));
 
         /* End ocean data */
         /* Elevation settings */

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -440,20 +440,40 @@ public class WaterWayCheck extends BaseCheck<Long>
         return FALLBACK_INSTRUCTIONS;
     }
 
+    /**
+     * Create a flag for an object that goes uphill
+     *
+     * @param flag
+     *            The flag to create/modify. May be {@code null}.
+     * @param object
+     *            The object to flag
+     * @param first
+     *            The first node of the way
+     * @return The new CheckFlag (if the passed flag was {@code null}) or the modified CheckFlag.
+     */
     private CheckFlag createUphillFlag(final CheckFlag flag, final AtlasObject object,
             final Location first)
     {
+        CheckFlag returnFlag = flag;
         final String instruction = this.getLocalizedInstruction(
                 FALLBACK_INSTRUCTIONS.indexOf(GOES_UPHILL), object.getOsmIdentifier(),
                 this.elevationUtils.getResolution(first).asMeters());
-        if (flag == null)
+        if (returnFlag == null)
         {
             return createFlag(object, instruction);
         }
-        flag.addInstruction(instruction);
-        return flag;
+        returnFlag.addInstruction(instruction);
+        return returnFlag;
     }
 
+    /**
+     * Check if the waterway ends in a sink (i.e., a location that can reasonably expected to have
+     * no outflow).
+     *
+     * @param line
+     *            The waterway item to check
+     * @return {@code true} if the waterway ends in a sink.
+     */
     private boolean doesWaterwayEndInSink(final LineItem line)
     {
         return doesLineEndOnWaterway(line) || doesLineEndInSink(line) || doesLineEndInOcean(line);
@@ -482,6 +502,15 @@ public class WaterWayCheck extends BaseCheck<Long>
         return sameLayerWays.iterator().next();
     }
 
+    /**
+     * Check if two waterways are connected
+     *
+     * @param line
+     *            A waterway
+     * @param potential
+     *            Another waterway which may connect
+     * @return {@code true} if both waterways share a location
+     */
     private boolean waterwayConnects(final LineItem line, final LineItem potential)
     {
         final PolyLine linePoly = line.asPolyLine();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -40,7 +40,8 @@ import org.openstreetmap.atlas.utilities.scalars.Distance;
 /**
  * This check flags waterways that do not have a sink (i.e., are not connected to another waterway),
  * are circular (so first node and last node are the same), or cross another waterway with the same
- * layer.
+ * layer. It also looks for ways that may be going uphill (requires elevation data, see
+ * {@link ElevationUtilities}
  *
  * @author Taylor Smock
  */

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -103,9 +103,7 @@ public class WaterWayCheck extends BaseCheck<Long>
 
     private final TaggableFilter waterwaySinkTagFilter;
     private final TaggableFilter waterwayTagFilter;
-
     private final TaggableFilter validOceanTags;
-
     private final TaggableFilter oceanBoundaryTags;
     private final ElevationUtilities elevationUtils;
     private final Distance minResolutionDistance;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -422,9 +422,9 @@ public class WaterWayCheck extends BaseCheck<Long>
     private LineItem intersectsAnotherWaterWay(final LineItem line)
     {
         final Atlas atlas = line.getAtlas();
-        final Iterable<LineItem> intersectinWaterways = atlas.lineItemsIntersecting(line.bounds(),
+        final Iterable<LineItem> intersectingWaterways = atlas.lineItemsIntersecting(line.bounds(),
                 this.waterwayTagFilter::test);
-        final Set<LineItem> sameLayerWays = Iterables.stream(intersectinWaterways)
+        final Set<LineItem> sameLayerWays = Iterables.stream(intersectingWaterways)
                 .filter(potential -> LayerTag.areOnSameLayer(line, potential)
                         && !waterwayConnects(line, potential))
                 .collectToSet();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -242,11 +242,13 @@ public class WaterWayCheck extends BaseCheck<Long>
             final Segment max = segs.stream().map(Pair::getKey).distinct().max(segmentComparator)
                     .orElse(null);
             // Get the crossing segments of the coastline (probably just one)
-            final Collection<Segment> crosses = segs.stream().filter(p -> p.getLeft().equals(max))
-                    .map(Pair::getValue).collect(Collectors.toSet());
+            final Collection<Segment> crosses = segs.stream()
+                    .filter(pair -> pair.getLeft().equals(max)).map(Pair::getValue)
+                    .collect(Collectors.toSet());
             // Create a shortened coastline to use to check if the waterway ends inside the ocean
-            final PolyLine coast = new PolyLine(crosses.stream()
-                    .flatMap(c -> Stream.of(c.first(), c.last())).toArray(Location[]::new));
+            final PolyLine coast = new PolyLine(
+                    crosses.stream().flatMap(pCoast -> Stream.of(pCoast.first(), pCoast.last()))
+                            .toArray(Location[]::new));
             // If the waterway ends to the right of the coastline, it ended in an ocean.
             // If the waterway ends on the coastline, it ended in an ocean.
             if (isRightOf(coast, linePolyline.last())
@@ -312,8 +314,8 @@ public class WaterWayCheck extends BaseCheck<Long>
 
         waterways.removeIf(line::equals);
         final Location last = line.asPolyLine().last();
-        return waterways.stream().anyMatch(
-                l -> l.asPolyLine().contains(last) && !last.equals(l.asPolyLine().last()));
+        return waterways.stream().anyMatch(tLine -> tLine.asPolyLine().contains(last)
+                && !last.equals(tLine.asPolyLine().last()));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -189,22 +189,6 @@ public class WaterWayCheck extends BaseCheck<Long>
     }
 
     /**
-     * Check if a line crosses an coastline line
-     *
-     * @param line
-     *            The line to check
-     * @return {@code true} if the line crosses a coastline
-     */
-    private boolean doesLineCrossCoast(final LineItem line)
-    {
-        final List<LineItem> lines = new ArrayList<>();
-        line.getAtlas()
-                .lineItemsIntersecting(line.asPolyLine().bounds(), this.oceanBoundaryTags::test)
-                .forEach(lines::add);
-        return !lines.isEmpty();
-    }
-
-    /**
      * Check if a line ends in an ocean
      *
      * @param line
@@ -451,7 +435,7 @@ public class WaterWayCheck extends BaseCheck<Long>
     private CheckFlag createUphillFlag(final CheckFlag flag, final AtlasObject object,
             final Location first)
     {
-        CheckFlag returnFlag = flag;
+        final CheckFlag returnFlag = flag;
         final String instruction = this.getLocalizedInstruction(
                 FALLBACK_INSTRUCTIONS.indexOf(GOES_UPHILL), object.getOsmIdentifier(),
                 this.elevationUtils.getResolution(first).asMeters());
@@ -461,6 +445,22 @@ public class WaterWayCheck extends BaseCheck<Long>
         }
         returnFlag.addInstruction(instruction);
         return returnFlag;
+    }
+
+    /**
+     * Check if a line crosses an coastline line
+     *
+     * @param line
+     *            The line to check
+     * @return {@code true} if the line crosses a coastline
+     */
+    private boolean doesLineCrossCoast(final LineItem line)
+    {
+        final List<LineItem> lines = new ArrayList<>();
+        line.getAtlas()
+                .lineItemsIntersecting(line.asPolyLine().bounds(), this.oceanBoundaryTags::test)
+                .forEach(lines::add);
+        return !lines.isEmpty();
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -476,8 +476,10 @@ public class WaterWayCheck extends BaseCheck<Long>
      */
     private Collection<LineItem> getIntersectingWaterways(final Atlas atlas, final LineItem line)
     {
+        final PolyLine linePoly = line.asPolyLine();
         final Iterable<LineItem> intersectingWaterways = atlas.lineItemsIntersecting(line.bounds(),
-                this.waterwayTagFilter::test);
+                lineItem -> this.waterwayTagFilter.test(lineItem)
+                        && lineItem.asPolyLine().intersects(linePoly));
         final Set<LineItem> sameLayerWays = Iterables.stream(intersectingWaterways)
                 .filter(potential -> LayerTag.areOnSameLayer(line, potential)
                         && !waterwayConnects(line, potential))

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -1,0 +1,383 @@
+package org.openstreetmap.atlas.checks.validation.linear.lines;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Segment;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Line;
+import org.openstreetmap.atlas.geography.atlas.items.LineItem;
+import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
+import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.collections.Sets;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Angle;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * This check flags waterways that do not have a sink (i.e., are not connected to another waterway),
+ * are circular (so first node and last node are the same), or cross another waterway with the same
+ * layer.
+ *
+ * @author Taylor Smock
+ */
+public class WaterWayCheck extends BaseCheck<Long>
+{
+    /**
+     * This comparator takes a polyline and segments, and compares the segments based off of the
+     * location of the segment in the line.
+     *
+     * @author Taylor Smock
+     */
+    private static class SegmentIndexComparator implements Comparator<Segment>
+    {
+        private final List<Segment> lineSegments;
+
+        /**
+         * Initialize with a specific polyline to check
+         *
+         * @param line
+         *            The line to check the index of segments against
+         */
+        SegmentIndexComparator(final PolyLine line)
+        {
+            this.lineSegments = line.segments();
+        }
+
+        @Override
+        public int compare(final Segment segment1, final Segment segment2)
+        {
+            final Segment segment1real = this.lineSegments.stream().filter(segment1::equals)
+                    .findFirst().orElse(null);
+            final Segment segment2real = this.lineSegments.stream().filter(segment2::equals)
+                    .findFirst().orElse(null);
+            final int segment1index = this.lineSegments.indexOf(segment1real);
+            final int segment2index = this.lineSegments.indexOf(segment2real);
+            return segment1index - segment2index;
+        }
+    }
+
+    private static final long serialVersionUID = 2877101774578564205L;
+    private static final String WATERWAY_SINK_TAG_FILTER_DEFAULT = "natural->sinkhole|waterway->tidal_channel,drain|manhole->drain";
+    private static final String WATERWAY_TAG_FILTER_DEFAULT = "waterway->river,stream,tidal_channel,canal,drain,ditch,pressurised";
+
+    private static final String DEFAULT_VALID_OCEAN_TAGS = "natural->strait,channel,fjord,sound,bay|"
+            + "harbour->*&harbour->!no|estuary->*&estuary->!no|bay->*&bay->!no|place->sea|seamark:type->harbour,harbour_basin,sea_area|water->bay,cove,harbour|waterway->artificial,dock";
+
+    private static final String DEFAULT_OCEAN_BOUNDARY_TAGS = "natural->coastline";
+    private static final String DOES_NOT_END_IN_SINK = "The waterway {0} does not end in a sink (ocean/sinkhole/waterway/drain)";
+    private static final String CIRCULAR_WATERWAY = "The waterway {0} loops back on itself. This is typically impossible.";
+    private static final String CROSSES_WATERWAY = "The waterway {0} crosses the waterway {1}.";
+
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(DOES_NOT_END_IN_SINK,
+            CIRCULAR_WATERWAY, CROSSES_WATERWAY);
+
+    private final TaggableFilter waterwaySinkTagFilter;
+    private final TaggableFilter waterwayTagFilter;
+
+    private final TaggableFilter validOceanTags;
+
+    private final TaggableFilter oceanBoundaryTags;
+
+    /**
+     * Get intersecting segments of two polylines
+     *
+     * @param left
+     *            The polyline whose segments will go in the key/left side of the pair
+     * @param right
+     *            The polyline whose segments will go in the value/right side of the pair
+     * @return A collection of segments intersecting other segments. A segment *may* appear more
+     *         than once.
+     */
+    public static Collection<Pair<Segment, Segment>> getIntersectingSegments(final PolyLine left,
+            final PolyLine right)
+    {
+        final Collection<Pair<Segment, Segment>> intersectingSegments = new HashSet<>();
+        for (final Segment leftSegment : left.segments())
+        {
+            for (final Segment rightSegment : right.segments())
+            {
+                if (leftSegment.intersects(rightSegment))
+                {
+                    intersectingSegments.add(Pair.of(leftSegment, rightSegment));
+                }
+            }
+        }
+        return intersectingSegments;
+    }
+
+    /**
+     * Default constructor
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public WaterWayCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.waterwaySinkTagFilter = this.configurationValue(configuration,
+                "waterway.sink.tags.filters", WATERWAY_SINK_TAG_FILTER_DEFAULT,
+                TaggableFilter::forDefinition);
+        this.waterwayTagFilter = this.configurationValue(configuration, "waterway.tags.filters",
+                WATERWAY_TAG_FILTER_DEFAULT, TaggableFilter::forDefinition);
+
+        /* Ocean data */
+        this.validOceanTags = TaggableFilter.forDefinition(
+                this.configurationValue(configuration, "ocean.valid", DEFAULT_VALID_OCEAN_TAGS));
+        this.oceanBoundaryTags = TaggableFilter.forDefinition(this.configurationValue(configuration,
+                "ocean.boundary", DEFAULT_OCEAN_BOUNDARY_TAGS));
+        /* End ocean data */
+
+    }
+
+    /**
+     * Check if a line ends in an ocean
+     *
+     * @param line
+     *            The line to check
+     * @return {@code true} if the line ends in an ocean
+     */
+    public boolean doesLineEndInOcean(final LineItem line)
+    {
+        final Atlas atlas = line.getAtlas();
+        final PolyLine linePolyline = line.asPolyLine();
+        final Location last = linePolyline.last();
+        if (atlas.areasCovering(last, this.validOceanTags::test).iterator().hasNext()
+                || atlas.areasCovering(last, this.oceanBoundaryTags::test).iterator().hasNext())
+        {
+            return true;
+        }
+        final List<LineItem> lines = new ArrayList<>();
+        atlas.lineItemsIntersecting(line.asPolyLine().bounds(), this.oceanBoundaryTags::test)
+                .forEach(lines::add);
+        final LineItem[] intersecting = lines.stream()
+                .filter(l -> l.asPolyLine().intersects(linePolyline)).toArray(LineItem[]::new);
+        final SegmentIndexComparator segmentComparator = new SegmentIndexComparator(linePolyline);
+        for (final LineItem lineItem : intersecting)
+        {
+            final Collection<Pair<Segment, Segment>> segs = getIntersectingSegments(linePolyline,
+                    lineItem.asPolyLine());
+            final Segment max = segs.stream().map(Pair::getKey).distinct().max(segmentComparator)
+                    .orElse(null);
+            final Collection<Segment> crosses = segs.stream().filter(p -> p.getLeft().equals(max))
+                    .map(Pair::getValue).collect(Collectors.toSet());
+            final PolyLine coast = new PolyLine(crosses.stream()
+                    .flatMap(c -> Stream.of(c.first(), c.last())).toArray(Location[]::new));
+            if (isRightOf(coast, linePolyline.last())
+                    || lineItem.asPolyLine().contains(linePolyline.last()))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if a line ends in a waterway sink
+     *
+     * @param lineItem
+     *            The LineItem to check
+     * @return {@code true} if the waterway can reasonably be expected to end
+     */
+    public boolean doesLineEndInSink(final LineItem lineItem)
+    {
+        // If the way is a sink, it obviously ends in a sink...
+        if (this.waterwaySinkTagFilter.test(lineItem))
+        {
+            return true;
+        }
+        if (lineItem instanceof Line)
+        {
+            final Line line = (Line) lineItem;
+            final Location last = line.asPolyLine().last();
+            final Set<LocationItem> one = Iterables.stream(line.getAtlas().nodesAt(last))
+                    .filter(LocationItem.class::isInstance).map(LocationItem.class::cast)
+                    .collectToSet();
+            final Set<LocationItem> two = Iterables.stream(line.getAtlas().pointsAt(last))
+                    .filter(LocationItem.class::isInstance).map(LocationItem.class::cast)
+                    .collectToSet();
+            if (Stream.concat(one.stream(), two.stream())
+                    .anyMatch(this.waterwaySinkTagFilter::test))
+            {
+                return true;
+            }
+        }
+        else if (lineItem instanceof Edge)
+        {
+            return this.waterwaySinkTagFilter.test(((Edge) lineItem).end());
+        }
+        return lineItem.getAtlas()
+                .areasCovering(lineItem.asPolyLine().last(), this.waterwaySinkTagFilter::test)
+                .iterator().hasNext();
+    }
+
+    /**
+     * Check if the last location on a line also happens to be connected to a waterway.
+     *
+     * @param line
+     *            The line to check
+     * @return {@code true} if the line ends on a waterway (the last node is part of a waterway)
+     */
+    public boolean doesLineEndOnWaterway(final LineItem line)
+    {
+        final List<LineItem> waterways = new ArrayList<>();
+        line.getAtlas()
+                .lineItemsIntersecting(line.asPolyLine().last().boxAround(Distance.ONE_METER),
+                        this.waterwayTagFilter::test)
+                .forEach(waterways::add);
+
+        waterways.removeIf(line::equals);
+        final Location last = line.asPolyLine().last();
+        return waterways.stream().anyMatch(
+                l -> l.asPolyLine().contains(last) && !last.equals(l.asPolyLine().last()));
+    }
+
+    /**
+     * Check if a location is to the right of a line (e.g., kerbs, cliffs, and oceans)
+     *
+     * @param line
+     *            The line to compare the location to
+     * @param location
+     *            The location
+     * @return {@code true} if the location is to the right of the line. If the location is on the
+     *         line, or to the left of the line, we return {@code false}.
+     */
+    public boolean isRightOf(final PolyLine line, final Location location)
+    {
+        final PolyLine tLine = new PolyLine(location);
+        final Segment closest = line.segments().stream()
+                .min(Comparator.comparingDouble(s -> s.shortestDistanceTo(tLine).asMeters()))
+                .orElse(null);
+        if (closest != null)
+        {
+            final PolyLine testLine = new PolyLine(closest.first(), closest.last(), location);
+            final Angle difference = testLine.headingDifference().orElse(null);
+            if (difference != null && difference.asDegrees() > 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if a location is inside an atlas bounds
+     *
+     * @param atlas
+     *            The atlas
+     * @param location
+     *            The location to check
+     * @return {@code true} if the atlas contains the location inside its bounds
+     */
+    public boolean isValidEndToCheck(final Atlas atlas, final Location location)
+    {
+        return atlas.bounds().fullyGeometricallyEncloses(location);
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return !isFlagged(object.getOsmIdentifier()) && object instanceof LineItem
+                && this.waterwayTagFilter.test(object);
+    }
+
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final LineItem line = (LineItem) object;
+        final Location last = line.asPolyLine().last();
+        CheckFlag flag = null;
+        if (line.isClosed())
+        {
+            flag = createFlag(object, this.getLocalizedInstruction(1, object.getOsmIdentifier()),
+                    Collections.singletonList(line.asPolyLine().first()));
+        }
+        else if (isValidEndToCheck(line.getAtlas(), last) && !doesWaterwayEndInSink(line))
+        {
+            flag = createFlag(object, this.getLocalizedInstruction(0, object.getOsmIdentifier()),
+                    Collections.singletonList(last));
+        }
+        final LineItem crossed = intersectsAnotherWaterWay(line);
+        if (flag == null && crossed != null)
+        {
+            final Iterator<Location> intersections = crossed.asPolyLine()
+                    .intersections(line.asPolyLine()).iterator();
+            if (intersections.hasNext())
+            {
+                flag = createFlag(
+                        Sets.hashSet(object, crossed), this.getLocalizedInstruction(2,
+                                object.getOsmIdentifier(), crossed.getOsmIdentifier()),
+                        Arrays.asList(intersections.next()));
+            }
+        }
+        if (flag == null)
+        {
+            return Optional.empty();
+        }
+        super.markAsFlagged(object.getOsmIdentifier());
+        return Optional.of(flag);
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    private boolean doesWaterwayEndInSink(final LineItem line)
+    {
+        return doesLineEndOnWaterway(line) || doesLineEndInSink(line) || doesLineEndInOcean(line);
+    }
+
+    private LineItem intersectsAnotherWaterWay(final LineItem line)
+    {
+        final Atlas atlas = line.getAtlas();
+        final Iterable<LineItem> intersectinWaterways = atlas.lineItemsIntersecting(line.bounds(),
+                this.waterwayTagFilter::test);
+        final Set<LineItem> sameLayerWays = Iterables.stream(intersectinWaterways)
+                .filter(potential -> LayerTag.areOnSameLayer(line, potential)
+                        && !waterwayConnects(line, potential))
+                .collectToSet();
+        sameLayerWays.removeIf(line::equals);
+        if (sameLayerWays.isEmpty())
+        {
+            return null;
+        }
+        return sameLayerWays.iterator().next();
+    }
+
+    private boolean waterwayConnects(final LineItem line, final LineItem potential)
+    {
+        final PolyLine linePoly = line.asPolyLine();
+        final PolyLine potentialPoly = potential.asPolyLine();
+        final Set<Location> locations = linePoly.intersections(potentialPoly);
+        for (final Location location : locations)
+        {
+            if (!linePoly.contains(location) || !potentialPoly.contains(location))
+            {
+                return false;
+            }
+        }
+        return !locations.isEmpty();
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -475,6 +475,13 @@ public class WaterWayCheck extends BaseCheck<Long>
     private CheckFlag flagIncline(final CheckFlag flag, final LineItem line, final Location first,
             final Location last)
     {
+        /*
+         * While this could be modified to check the incline between each node in the way, it
+         * currently isn't realistic (the NASA SRTM mission has a max resolution of ~30m). If better
+         * resolution datasets become available, it may be worthwhile to check each node in the way.
+         * I would expect the resolution of the dataset to be ~1m, but good results may be had with
+         * more than 1m resolution.
+         */
         final double incline = this.elevationUtils.getIncline(first, last);
         final boolean uphill = !Double.isNaN(incline) && incline > 0
                 && last.distanceTo(first).isGreaterThan(this.minDistanceStartEndElevationUphill);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -371,6 +371,7 @@ public class WaterWayCheck extends BaseCheck<Long>
         final LineItem line = (LineItem) object;
         final Location last = line.asPolyLine().last();
         final Location first = line.asPolyLine().first();
+        final Atlas atlas = line.getAtlas();
         CheckFlag flag = null;
         if (line.isClosed())
         {
@@ -404,7 +405,7 @@ public class WaterWayCheck extends BaseCheck<Long>
             }
 
         }
-        final LineItem crossed = intersectsAnotherWaterWay(line);
+        final LineItem crossed = intersectsAnotherWaterWay(atlas, line);
         if (crossed != null)
         {
             final Iterator<Location> intersections = crossed.asPolyLine()
@@ -458,9 +459,15 @@ public class WaterWayCheck extends BaseCheck<Long>
         return doesLineEndOnWaterway(line) || doesLineEndInSink(line) || doesLineEndInOcean(line);
     }
 
-    private LineItem intersectsAnotherWaterWay(final LineItem line)
+    /**
+     * Get an intersecting waterway, if one exists.
+     *
+     * @param line
+     *            The waterway to look for intersections for.
+     * @return A crossing waterway, or {@code null} if no crossing waterway exists.
+     */
+    private LineItem intersectsAnotherWaterWay(final Atlas atlas, final LineItem line)
     {
-        final Atlas atlas = line.getAtlas();
         final Iterable<LineItem> intersectingWaterways = atlas.lineItemsIntersecting(line.bounds(),
                 this.waterwayTagFilter::test);
         final Set<LineItem> sameLayerWays = Iterables.stream(intersectingWaterways)

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CompressionUtilitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CompressionUtilitiesTest.java
@@ -1,0 +1,83 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Test class for {@link CompressionUtilities}.
+ *
+ * @author Taylor Smock
+ */
+@RunWith(Parameterized.class)
+public class CompressionUtilitiesTest
+{
+    private static final String TESTING_STREAM = "Testing stream\n";
+
+    private final String name;
+    private final byte[] byteInput;
+
+    /**
+     * Get parameters for the test
+     *
+     * @return The parameters for the test in an array ({Name string, data byte[]})
+     */
+    @Parameters(name = "{index} - {0}")
+    public static Collection<Object[]> parameters()
+    {
+        return Arrays.asList(new Object[][] { { "Standard", TESTING_STREAM.getBytes() },
+                { "GZipped",
+                        Base64.getDecoder().decode(
+                                "H4sICIADNF8AA3RoaXMAC0ktLsnMS1coLilKTczlAgBqt7NlDwAAAA==") },
+                { "Zip", Base64.getDecoder()
+                        .decode("UEsDBAoAAAAAAFFIDFFqt7NlDwAAAA8AAAAEABwA"
+                                + "dGhpc1VUCQADigQ0XwcFNF91eAsAAQT1AQAABAAAAABUZXN0aW5nIHN0cm"
+                                + "VhbQpQSwECHgMKAAAAAABRSAxRarezZQ8AAAAPAAAABAAYAAAAAAABAAAA"
+                                + "pIEAAAAAdGhpc1VUBQADigQ0X3V4CwABBPUBAAAEAAAAAFBLBQYAAAAAAQ"
+                                + "ABAEoAAABNAAAAAAA=") },
+                { "GZipped Zip",
+                        Base64.getDecoder().decode("H4sICDcFNF8AA3RoaXMuemlwAAvwZmbhYgCBQA+e"
+                                + "wKztm1P5gWwQZmGQYSjJyCwODeFkYO5iMYlnZzWJL63gZmBk+coIkgaCkN"
+                                + "Tiksy8dIXikqLUxFyuAG9GJjlmXMZJgMWBWhmWNIJYEMNZIYajGRzgzcoG"
+                                + "Uc3I4AWkfcF6AYUTZeOtAAAA") } });
+    }
+
+    /**
+     * Initialize the test for parameterized testing
+     *
+     * @param name
+     *            The name of the test
+     * @param byteInput
+     *            The byte input to use for the test
+     */
+    public CompressionUtilitiesTest(final String name, final byte[] byteInput)
+    {
+        this.name = name;
+        this.byteInput = byteInput;
+    }
+
+    /**
+     * Test method for {@link CompressionUtilities#getUncompressedInputStream(InputStream)} where
+     * the stream is already uncompressed and unarchived.
+     *
+     * @throws IOException
+     *             If something happens (it shouldn't -- we aren't even reading a file!)
+     */
+    @Test
+    public void testUnknownStream() throws IOException
+    {
+        final InputStream uncompressed = CompressionUtilities
+                .getUncompressedInputStream(new ByteArrayInputStream(this.byteInput));
+        assertEquals(TESTING_STREAM, new String(uncompressed.readAllBytes()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
@@ -1,0 +1,144 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.geography.Latitude;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.Longitude;
+
+/**
+ * Test class for {@link ElevationUtilities}.
+ *
+ * @author Taylor Smock
+ */
+public class ElevationUtilitiesTest
+{
+
+    private static ElevationUtilities elevationUtilities;
+
+    /**
+     * Perform initial setup of the test
+     */
+    @BeforeClass
+    public static void setUp()
+    {
+        elevationUtilities = new ElevationUtilities(ConfigurationResolver.emptyConfiguration());
+        prefillData();
+    }
+
+    private static void prefillData()
+    {
+        // 4x4 array of shorts
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(32);
+        byteBuffer.order(ByteOrder.BIG_ENDIAN);
+        for (short i = 0; i < 16; i++)
+        {
+            byteBuffer.putShort(i);
+        }
+        try (InputStream inputStream = new ByteArrayInputStream(byteBuffer.array()))
+        {
+            final Method readStream = ElevationUtilities.class.getDeclaredMethod("readStream",
+                    InputStream.class);
+            readStream.setAccessible(true);
+            short[][] data = (short[][]) readStream.invoke(elevationUtilities, inputStream);
+
+            final Field loadedSrtmField = ElevationUtilities.class.getDeclaredField("loadedSrtm");
+            loadedSrtmField.setAccessible(true);
+            // This is the return value. If it changes, this needs to change.
+            @SuppressWarnings("unchecked")
+            final Map<Pair<Integer, Integer>, short[][]> loadedSrtm = (Map<Pair<Integer, Integer>, short[][]>) loadedSrtmField
+                    .get(elevationUtilities);
+            data[0][0] = 2;
+            loadedSrtm.put(Pair.of(-1, 0), data);
+            data = Arrays.copyOf(data, data.length);
+            data[0][0] = 1;
+            loadedSrtm.put(Pair.of(0, 0), data);
+            data = Arrays.copyOf(data, data.length);
+            data[0][0] = 3;
+            loadedSrtm.put(Pair.of(-1, -1), data);
+            data = Arrays.copyOf(data, data.length);
+            data[0][0] = 4;
+            loadedSrtm.put(Pair.of(0, -1), data);
+        }
+        catch (IOException | NoSuchMethodException | SecurityException | IllegalAccessException
+                | IllegalArgumentException | InvocationTargetException | NoSuchFieldException e)
+        {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Test method for {@link ElevationUtilities#getElevation(Location)}.
+     */
+    @Test
+    public void testGetElevation()
+    {
+        // 4x4 on 1 degree grids
+        // 0..0.25..0.5..0.75..1
+        // 0..1..2..3
+        // 4..5..6..7
+        // 8..9..10.11
+        // 12.13.14.15
+
+        final double degrees = 0.33;
+        assertEquals(9, elevationUtilities
+                .getElevation(new Location(Latitude.degrees(degrees), Longitude.degrees(degrees))));
+        assertEquals(5, elevationUtilities.getElevation(
+                new Location(Latitude.degrees(-degrees), Longitude.degrees(degrees))));
+        assertEquals(10, elevationUtilities.getElevation(
+                new Location(Latitude.degrees(degrees), Longitude.degrees(-degrees))));
+        assertEquals(6, elevationUtilities.getElevation(
+                new Location(Latitude.degrees(-degrees), Longitude.degrees(-degrees))));
+
+    }
+
+    /**
+     * Test method for {@link ElevationUtilities#getIncline(Location, Location)}.
+     */
+    @Test
+    public void testGetIncline()
+    {
+        final Location one = new Location(Latitude.degrees(0.75), Longitude.degrees(0.75));
+        final Location two = new Location(Latitude.degrees(0.74), Longitude.degrees(0.74));
+        final double incline = elevationUtilities.getIncline(one, two);
+        assertEquals(incline,
+                100 * (elevationUtilities.getElevation(two) - elevationUtilities.getElevation(one))
+                        / two.distanceTo(one).asMeters(),
+                0.001);
+    }
+
+    /**
+     * Test method for {@link ElevationUtilities#inSameDataPoint(Location, Location)}.
+     */
+    @Test
+    public void testInSameDataPoint()
+    {
+        // 4x4 on 1 degree grids
+        // 0...0.25...0.5...0.75...1
+        Location one = new Location(Latitude.degrees(0.75), Longitude.degrees(0.75));
+        Location two = new Location(Latitude.degrees(0.76), Longitude.degrees(0.76));
+        assertTrue(elevationUtilities.inSameDataPoint(one, two));
+        two = new Location(Latitude.degrees(0.74), Longitude.degrees(0.74));
+        assertFalse(elevationUtilities.inSameDataPoint(one, two));
+        one = new Location(Latitude.degrees(-0.74), Longitude.degrees(0.74));
+        assertFalse(elevationUtilities.inSameDataPoint(one, two));
+    }
+
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
@@ -139,6 +139,8 @@ public class ElevationUtilitiesTest
         final Distance resolution = elevationUtilities.getResolution(Location.CENTER);
         // 2 * pi * 6371 / (360 * 4) -- 6371 is the average earths radius used by Atlas
         assertEquals(27798.73166, resolution.asMeters(), 0.001);
+
+        assertEquals(Distance.MAXIMUM, elevationUtilities.getResolution(Location.CROSSING_85_280));
     }
 
     /**
@@ -156,6 +158,10 @@ public class ElevationUtilitiesTest
         assertFalse(elevationUtilities.inSameDataPoint(one, two));
         one = new Location(Latitude.degrees(-0.74), Longitude.degrees(0.74));
         assertFalse(elevationUtilities.inSameDataPoint(one, two));
+
+        assertFalse(elevationUtilities.inSameDataPoint(Location.CROSSING_85_17,
+                Location.CROSSING_85_280));
+        assertFalse(elevationUtilities.inSameDataPoint(one, Location.CROSSING_85_280));
     }
 
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
@@ -12,6 +12,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -82,6 +83,42 @@ public class ElevationUtilitiesTest
                 | IllegalArgumentException | InvocationTargetException | NoSuchFieldException e)
         {
             throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Test method for {@link ElevationUtilities#ElevationUtilities}
+     * 
+     * @throws ReflectiveOperationException
+     *             when something goes wrong with reflection
+     */
+    @Test
+    public void testConstructors() throws ReflectiveOperationException
+    {
+        final double expectedSrtmExtent = 2;
+        final String expectedSrtmExtension = "srtm";
+        final String expectedSrtmPath = "/tmp";
+        final String configuration = MessageFormat.format(
+                "'{'\"ElevationUtilities\":'{'\"elevation.srtm_extent\": {0}, \"elevation.srtm_ext\": \"{1}\", \"elevation.path\": \"{2}\"'}}'",
+                Double.toString(expectedSrtmExtent), expectedSrtmExtension, expectedSrtmPath);
+        final ElevationUtilities config = new ElevationUtilities(
+                ConfigurationResolver.inlineConfiguration(configuration));
+        final ElevationUtilities custom = new ElevationUtilities(expectedSrtmExtent,
+                expectedSrtmExtension, expectedSrtmPath);
+        final Field srtmExtentField = ElevationUtilities.class.getDeclaredField("srtmExtent");
+        final Field srtmExtensionField = ElevationUtilities.class.getDeclaredField("srtmExtension");
+        final Field srtmPathField = ElevationUtilities.class.getDeclaredField("srtmPath");
+        for (final Field field : Arrays.asList(srtmExtentField, srtmExtensionField, srtmPathField))
+        {
+            field.setAccessible(true);
+        }
+        for (final ElevationUtilities elevationUtility : Arrays.asList(config, custom))
+        {
+            assertEquals(expectedSrtmExtent, srtmExtentField.getDouble(elevationUtility), 0.001);
+            assertEquals(expectedSrtmExtension,
+                    srtmExtensionField.get(elevationUtility).toString());
+            assertEquals(expectedSrtmPath, srtmPathField.get(elevationUtility).toString());
+
         }
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTest.java
@@ -22,6 +22,7 @@ import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.geography.Latitude;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.Longitude;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
 
 /**
  * Test class for {@link ElevationUtilities}.
@@ -106,7 +107,8 @@ public class ElevationUtilitiesTest
                 new Location(Latitude.degrees(degrees), Longitude.degrees(-degrees))));
         assertEquals(6, elevationUtilities.getElevation(
                 new Location(Latitude.degrees(-degrees), Longitude.degrees(-degrees))));
-
+        assertEquals(ElevationUtilities.NO_ELEVATION, elevationUtilities
+                .getElevation(new Location(Latitude.degrees(89), Longitude.degrees(0))));
     }
 
     /**
@@ -122,6 +124,21 @@ public class ElevationUtilitiesTest
                 100 * (elevationUtilities.getElevation(two) - elevationUtilities.getElevation(one))
                         / two.distanceTo(one).asMeters(),
                 0.001);
+        final Location fakeLocation = new Location(Latitude.degrees(89), Longitude.degrees(0));
+        assertTrue(Double.isNaN(elevationUtilities.getIncline(fakeLocation, two)));
+        assertTrue(Double.isNaN(elevationUtilities.getIncline(two, fakeLocation)));
+
+    }
+
+    /**
+     * Test method for {@link ElevationUtilities#getResolution(Location)}.
+     */
+    @Test
+    public void testGetResolution()
+    {
+        final Distance resolution = elevationUtilities.getResolution(Location.CENTER);
+        // 2 * pi * 6371 / (360 * 4) -- 6371 is the average earths radius used by Atlas
+        assertEquals(27798.73166, resolution.asMeters(), 0.001);
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
@@ -1,9 +1,13 @@
 package org.openstreetmap.atlas.checks.validation.linear.lines;
 
+import java.lang.reflect.Field;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.utility.ElevationUtilities;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.geography.Location;
 
 /**
  * WaterWayCheck test
@@ -12,6 +16,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  */
 public class WaterWayCheckTest
 {
+
     /** The rule to get atlases from */
     @Rule
     public WaterWayCheckTestRule atlases = new WaterWayCheckTestRule();
@@ -50,7 +55,74 @@ public class WaterWayCheckTest
         this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(),
                 new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.verifyEmpty();
+    }
 
+    @Test
+    public void testCoastWaterwayConnectedElevation() throws ReflectiveOperationException
+    {
+        final short[][] map = new short[][] { { 15, 14, 13, 12 }, { 11, 10, 9, 8 }, { 7, 6, 5, 4 },
+                { 3, 2, 1, 0 } };
+        final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.inlineConfiguration(
+                "{\"WaterWayCheck.waterway.elevation.resolution.min.uphill\": 30000.0}"));
+        final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
+        elevationUtilsField.setAccessible(true);
+        final ElevationUtilities elevationUtils = (ElevationUtilities) elevationUtilsField
+                .get(check);
+        elevationUtils.putMap(Location.forString("16.9906416,-88.3188021"), map);
+        this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testCoastWaterwayConnectedElevationReversed() throws ReflectiveOperationException
+    {
+        final short[][] map = new short[][] { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 8, 9, 10, 11 },
+                { 12, 13, 14, 15 } };
+        final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.inlineConfiguration(
+                "{\"WaterWayCheck.waterway.elevation.resolution.min.uphill\": 30000.0}"));
+
+        final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
+        elevationUtilsField.setAccessible(true);
+        final ElevationUtilities elevationUtils = (ElevationUtilities) elevationUtilsField
+                .get(check);
+        elevationUtils.putMap(Location.forString("16.9906416,-88.3188021"), map);
+        this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testCoastWaterwayConnectedElevationReversedLongDistance()
+            throws ReflectiveOperationException
+    {
+        final short[][] map = new short[][] { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 8, 9, 10, 11 },
+                { 12, 13, 14, 15 } };
+        final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.inlineConfiguration(
+                "{\"WaterWayCheck\": {\"waterway.elevation.resolution.min.uphill\": 30000.0, \"waterway.elevation.distance.min.start.end\": 1.0}}"));
+
+        final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
+        elevationUtilsField.setAccessible(true);
+        final ElevationUtilities elevationUtils = (ElevationUtilities) elevationUtilsField
+                .get(check);
+        elevationUtils.putMap(Location.forString("16.9906416,-88.3188021"), map);
+        this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testCoastWaterwayConnectedElevationReversedLowResolution()
+            throws ReflectiveOperationException
+    {
+        final short[][] map = new short[][] { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 8, 9, 10, 11 },
+                { 12, 13, 14, 15 } };
+        final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.emptyConfiguration());
+
+        final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
+        elevationUtilsField.setAccessible(true);
+        final ElevationUtilities elevationUtils = (ElevationUtilities) elevationUtilsField
+                .get(check);
+        elevationUtils.putMap(Location.forString("16.9906416,-88.3188021"), map);
+        this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(), check);
+        this.verifier.verifyEmpty();
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
@@ -1,0 +1,176 @@
+package org.openstreetmap.atlas.checks.validation.linear.lines;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * WaterWayCheck test
+ *
+ * @author Taylor Smock
+ */
+public class WaterWayCheckTest
+{
+    /** The rule to get atlases from */
+    @Rule
+    public WaterWayCheckTestRule atlases = new WaterWayCheckTestRule();
+    /** The verifier that actually runs the checks */
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    /**
+     * Look for waterways that connect with themselves
+     */
+    @Test
+    public void testCircularWaterway()
+    {
+        this.verifier.actual(this.atlases.getCircularWaterway(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    /**
+     * Ensure that waterways that end inside oceans are not flagged
+     */
+    @Test
+    public void testCoastWaterway()
+    {
+        this.verifier.actual(this.atlases.getCoastlineWaterway(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    /**
+     * Ensure that waterways that end on an ocean is not flagged
+     */
+    @Test
+    public void testCoastWaterwayConnected()
+    {
+        this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+
+    }
+
+    /**
+     * Check that a waterway ending in an ocean is not flagged
+     */
+    @Test
+    public void testCoastWaterwayReversed()
+    {
+        this.verifier.actual(this.atlases.getCoastlineWaterwayReversed(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    /**
+     * Check that two crossing waterways are flagged
+     */
+    @Test
+    public void testCrossingWaterway()
+    {
+        this.verifier.actual(this.atlases.getCrossingWaterways(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    /**
+     * Check that two connected crossing waterways are flagged
+     */
+    @Test
+    public void testCrossingWaterwayConnected()
+    {
+        this.verifier.actual(this.atlases.getCrossingWaterwaysConnected(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    /**
+     * Check that two crossing waterways on different layers are not flagged
+     */
+    @Test
+    public void testCrossingWaterwayDifferentLayers()
+    {
+        this.verifier.actual(this.atlases.getCrossingWaterwaysDifferentLayers(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    /**
+     * Check that a dead end waterway is flagged
+     */
+    @Test
+    public void testDeadendWaterway()
+    {
+        this.verifier.actual(this.atlases.getDeadendWaterway(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    /**
+     * Check that two connected dead end waterways are flagged
+     */
+    @Test
+    public void testDeadendWaterways()
+    {
+        this.verifier.actual(this.atlases.getDeadendWaterways(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    /**
+     * Check that a waterway ending inside a sinkhole area is not flagged
+     */
+    @Test
+    public void testSinkholeAreaWaterway()
+    {
+        this.verifier.actual(this.atlases.getSinkholeArea(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    /**
+     * Check that a waterway that ends with a sinkhole point is not flagged
+     */
+    @Test
+    public void testSinkholePointWaterway()
+    {
+        this.verifier.actual(this.atlases.getSinkholePoint(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    /**
+     * Check that a waterway ending in an ocean is not flagged
+     */
+    @Test
+    public void testWaterwayEndingInOceanArea()
+    {
+        this.verifier.actual(this.atlases.getWaterwayEndingInOceanArea(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    /**
+     * Check that a waterway ending in a strait is not flagged
+     */
+    @Test
+    public void testWaterwayEndingInStraitArea()
+    {
+        this.verifier.actual(this.atlases.getWaterwayEndingInStraitArea(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    /**
+     * Test that a waterway that ends on another waterway (edge) is appropriately accounted for
+     */
+    @Test
+    public void testWaterwayEndingOnOtherWaterway()
+    {
+        this.verifier.actual(this.atlases.getWaterwayEndingOnOtherWaterway(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
@@ -120,6 +120,18 @@ public class WaterWayCheckTest
     }
 
     /**
+     * Check that layers are properly accounted for when two waterways connect, but have different
+     * layers
+     */
+    @Test
+    public void testDifferingLayersConnectedWaterway()
+    {
+        this.verifier.actual(this.atlases.getDifferingLayersConnectedWaterway(),
+                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyEmpty();
+    }
+
+    /**
      * Check that a waterway ending inside a sinkhole area is not flagged
      */
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTestRule.java
@@ -174,6 +174,21 @@ public class WaterWayCheckTestRule extends CoreTestRule
     private Atlas deadendWaterways;
 
     @TestAtlas(nodes = {
+            @Node(id = "1286958997", coordinates = @Loc(value = "43.940881,12.5169471"), tags = {
+                    "man_made=manhole", "manhole=drain" }),
+            @Node(id = "1286961206", coordinates = @Loc(value = "43.9228377,12.497902")),
+            @Node(id = "5278469506", coordinates = @Loc(value = "43.9230335,12.497702")),
+            @Node(id = "5548727896", coordinates = @Loc(value = "43.9232093,12.4972691")) }, lines = {
+                    @Line(id = "579368984", coordinates = { @Loc(value = "43.9230335,12.497702"),
+                            @Loc(value = "43.9228377,12.497902"),
+                            @Loc(value = "43.940881,12.5169471") }, tags = { "name=Marano",
+                                    "waterway=stream" }),
+                    @Line(id = "579368987", coordinates = { @Loc(value = "43.9232093,12.4972691"),
+                            @Loc(value = "43.9230335,12.497702") }, tags = { "layer=-1",
+                                    "name=Marano", "tunnel=culvert", "waterway=stream" }) })
+    private Atlas differingLayersConnectedWaterway;
+
+    @TestAtlas(nodes = {
             @Node(id = "5215738262", coordinates = @Loc(value = "39.2176586,-105.4097737")),
             @Node(id = "5215738336", coordinates = @Loc(value = "39.2193545,-105.4093126")),
             @Node(id = "5215738538", coordinates = @Loc(value = "39.2211332,-105.4101387")),
@@ -353,6 +368,16 @@ public class WaterWayCheckTestRule extends CoreTestRule
     public Atlas getDeadendWaterways()
     {
         return this.deadendWaterways;
+    }
+
+    /**
+     * Get two waterways that differ by a layer tag and are connected
+     *
+     * @return An atlas with two connected waterway that have a different layer
+     */
+    public Atlas getDifferingLayersConnectedWaterway()
+    {
+        return this.differingLayersConnectedWaterway;
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTestRule.java
@@ -1,0 +1,407 @@
+package org.openstreetmap.atlas.checks.validation.linear.lines;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * WaterWayCheckTest test rule containing sample test atlases
+ *
+ * @author Taylor Smock
+ */
+public class WaterWayCheckTestRule extends CoreTestRule
+{
+    @TestAtlas(nodes = {
+            @Node(id = "-101752", coordinates = @Loc(value = "28.92414725033,-89.42596868149")),
+            @Node(id = "-101754", coordinates = @Loc(value = "28.93350332367,-89.41806350699")),
+            @Node(id = "-101755", coordinates = @Loc(value = "28.92996541203,-89.40144467423")),
+            @Node(id = "-101756", coordinates = @Loc(value = "28.91942958225,-89.39012590165")),
+            @Node(id = "-101757", coordinates = @Loc(value = "28.91345356126,-89.40234298952")),
+            @Node(id = "-101758", coordinates = @Loc(value = "28.91376809726,-89.43081958402")) }, lines = {
+                    @Line(id = "-101782", coordinates = {
+                            @Loc(value = "28.92414725033,-89.42596868149"),
+                            @Loc(value = "28.93350332367,-89.41806350699"),
+                            @Loc(value = "28.92996541203,-89.40144467423"),
+                            @Loc(value = "28.91942958225,-89.39012590165"),
+                            @Loc(value = "28.91345356126,-89.40234298952"),
+                            @Loc(value = "28.91376809726,-89.43081958402"),
+                            @Loc(value = "28.92414725033,-89.42596868149") }, tags = {
+                                    "waterway=river" }) })
+    private Atlas circularWaterway;
+
+    @TestAtlas(nodes = {
+            @Node(id = "-111085", coordinates = @Loc(value = "28.9290309538,-89.41969873667")),
+            @Node(id = "-111086", coordinates = @Loc(value = "28.93028921782,-89.40553667307")),
+            @Node(id = "-111087", coordinates = @Loc(value = "28.92973990295,-89.41222610235")),
+            @Node(id = "-111098", coordinates = @Loc(value = "28.94326534819,-89.40321924448")),
+            @Node(id = "-111099", coordinates = @Loc(value = "28.92839710691,-89.41269815505")),
+            @Node(id = "5244990585", coordinates = @Loc(value = "28.92957086477,-89.41283769511")),
+            @Node(id = "5244990586", coordinates = @Loc(value = "28.9573101,-89.3934346")) }, lines = {
+                    @Line(id = "-101902", coordinates = {
+                            @Loc(value = "28.9290309538,-89.41969873667"),
+                            @Loc(value = "28.93028921782,-89.40553667307") }, tags = {
+                                    "natural=coastline" }),
+                    @Line(id = "542508006", coordinates = { @Loc(value = "28.9573101,-89.3934346"),
+                            @Loc(value = "28.94326534819,-89.40321924448"),
+                            @Loc(value = "28.92957086477,-89.41283769511"),
+                            @Loc(value = "28.92973990295,-89.41222610235"),
+                            @Loc(value = "28.92839710691,-89.41269815505") }, tags = {
+                                    "name=Southwest Pass", "ref=M 55", "waterway=river",
+                                    "wikidata=Q7571332" }) })
+    private Atlas coastlineWaterway;
+
+    @TestAtlas(nodes = {
+            @Node(id = "233320009", coordinates = @Loc(value = "16.9749207,-88.2220252")),
+            @Node(id = "2372034993", coordinates = @Loc(value = "16.9906416,-88.3188021")),
+            @Node(id = "2598551761", coordinates = @Loc(value = "16.9331377,-88.2363143")),
+            @Node(id = "3545089162", coordinates = @Loc(value = "16.9686766,-88.2187145")) }, lines = {
+                    @Line(id = "130590450", coordinates = { @Loc(value = "16.9906416,-88.3188021"),
+                            @Loc(value = "16.9686766,-88.2187145") }, tags = {
+                                    "alt_name=North Stann Creek", "name=North Stann Creek River",
+                                    "source=Bing", "waterway=river" }),
+                    @Line(id = "254018602", coordinates = { @Loc(value = "16.9331377,-88.2363143"),
+                            @Loc(value = "16.9686766,-88.2187145"),
+                            @Loc(value = "16.9749207,-88.2220252") }, tags = { "natural=coastline",
+                                    "source=PGS" }) })
+    private Atlas coastlineWaterwayConnected;
+
+    @TestAtlas(nodes = {
+            @Node(id = "-111085", coordinates = @Loc(value = "28.9290309538,-89.41969873667")),
+            @Node(id = "-111086", coordinates = @Loc(value = "28.93028921782,-89.40553667307")),
+            @Node(id = "-111087", coordinates = @Loc(value = "28.92973990295,-89.41222610235")),
+            @Node(id = "-111098", coordinates = @Loc(value = "28.94326534819,-89.40321924448")),
+            @Node(id = "-111099", coordinates = @Loc(value = "28.92839710691,-89.41269815505")),
+            @Node(id = "5244990585", coordinates = @Loc(value = "28.92957086477,-89.41283769511")),
+            @Node(id = "5244990586", coordinates = @Loc(value = "28.9573101,-89.3934346")) }, lines = {
+                    @Line(id = "-101902", coordinates = {
+                            @Loc(value = "28.93028921782,-89.40553667307"),
+                            @Loc(value = "28.9290309538,-89.41969873667") }, tags = {
+                                    "natural=coastline" }),
+                    @Line(id = "542508006", coordinates = { @Loc(value = "28.9573101,-89.3934346"),
+                            @Loc(value = "28.94326534819,-89.40321924448"),
+                            @Loc(value = "28.92973990295,-89.41222610235"),
+                            @Loc(value = "28.92957086477,-89.41283769511"),
+                            @Loc(value = "28.92839710691,-89.41269815505") }, tags = {
+                                    "name=Southwest Pass", "ref=M 55", "waterway=river",
+                                    "wikidata=Q7571332" }) })
+    private Atlas coastlineWaterwayReversed;
+
+    @TestAtlas(nodes = {
+            @Node(id = "-111055", coordinates = @Loc(value = "-2.66048072885,3.07273796082")),
+            @Node(id = "-111056", coordinates = @Loc(value = "-2.66048072885,3.60488822937"), tags = {
+                    "natural=sinkhole" }),
+            @Node(id = "-111057", coordinates = @Loc(value = "-2.50751452055,3.34258964539")),
+            @Node(id = "-111058", coordinates = @Loc(value = "-2.8244009971,3.34190299988"), tags = {
+                    "natural=sinkhole" }) }, lines = {
+                            @Line(id = "-101798", coordinates = {
+                                    @Loc(value = "-2.66048072885,3.07273796082"),
+                                    @Loc(value = "-2.66048072885,3.60488822937") }, tags = {
+                                            "waterway=river" }),
+                            @Line(id = "-101799", coordinates = {
+                                    @Loc(value = "-2.50751452055,3.34258964539"),
+                                    @Loc(value = "-2.8244009971,3.34190299988") }, tags = {
+                                            "waterway=river" }) })
+    private Atlas crossingWaterways;
+
+    @TestAtlas(nodes = {
+            @Node(id = "2136293970", coordinates = @Loc(value = "17.0110643,-88.9352064"), tags = {
+                    "natural=sinkhole" }),
+            @Node(id = "2465936419", coordinates = @Loc(value = "16.9968515,-88.9201315")),
+            @Node(id = "2465936434", coordinates = @Loc(value = "17.0032067,-88.9207212")),
+            @Node(id = "2465936435", coordinates = @Loc(value = "17.0037381,-88.9211748")),
+            @Node(id = "2465936502", coordinates = @Loc(value = "17.0033866,-88.9208748")),
+            @Node(id = "2465936503", coordinates = @Loc(value = "17.0033565,-88.9204809")),
+            @Node(id = "2465936534", coordinates = @Loc(value = "16.9983196,-88.9136162")),
+            @Node(id = "5697465816", coordinates = @Loc(value = "17.000438,-88.9223765")),
+            @Node(id = "5697468126", coordinates = @Loc(value = "17.0035288,-88.9212141")),
+            @Node(id = "5697468127", coordinates = @Loc(value = "17.0036881,-88.9211321")) }, lines = {
+                    @Line(id = "203621915", coordinates = { @Loc(value = "16.9968515,-88.9201315"),
+                            @Loc(value = "17.0032067,-88.9207212"),
+                            @Loc(value = "17.0033866,-88.9208748"),
+                            @Loc(value = "17.0036881,-88.9211321"),
+                            @Loc(value = "17.0037381,-88.9211748"),
+                            @Loc(value = "17.0110643,-88.9352064") }, tags = { "waterway=stream" }),
+                    @Line(id = "238797678", coordinates = { @Loc(value = "16.9983196,-88.9136162"),
+                            @Loc(value = "17.0033565,-88.9204809"),
+                            @Loc(value = "17.0033866,-88.9208748"),
+                            @Loc(value = "17.0035288,-88.9212141") }, tags = { "waterway=stream" }),
+                    @Line(id = "598638239", coordinates = { @Loc(value = "17.000438,-88.9223765"),
+                            @Loc(value = "17.0035288,-88.9212141"),
+                            @Loc(value = "17.0036881,-88.9211321") }, tags = {
+                                    "waterway=stream" }) })
+    private Atlas crossingWaterwaysConnected;
+
+    @TestAtlas(nodes = {
+            @Node(id = "-111055", coordinates = @Loc(value = "-2.66048072885,3.07273796082")),
+            @Node(id = "-111056", coordinates = @Loc(value = "-2.66048072885,3.60488822937"), tags = {
+                    "natural=sinkhole" }),
+            @Node(id = "-111057", coordinates = @Loc(value = "-2.50751452055,3.34258964539")),
+            @Node(id = "-111058", coordinates = @Loc(value = "-2.8244009971,3.34190299988"), tags = {
+                    "natural=sinkhole" }) }, lines = {
+                            @Line(id = "-101798", coordinates = {
+                                    @Loc(value = "-2.66048072885,3.07273796082"),
+                                    @Loc(value = "-2.66048072885,3.60488822937") }, tags = {
+                                            "waterway=river" }),
+                            @Line(id = "-101799", coordinates = {
+                                    @Loc(value = "-2.50751452055,3.34258964539"),
+                                    @Loc(value = "-2.8244009971,3.34190299988") }, tags = {
+                                            "layer=1", "waterway=river" }) })
+    private Atlas crossingWaterwaysDifferentLayers;
+
+    @TestAtlas(nodes = {
+            @Node(id = "5215738262", coordinates = @Loc(value = "39.2176586,-105.4097737")),
+            @Node(id = "5215738336", coordinates = @Loc(value = "39.219347,-105.4093051")) }, lines = {
+                    @Line(id = "538934102", coordinates = { @Loc(value = "39.2176586,-105.4097737"),
+                            @Loc(value = "39.219347,-105.4093051") }, tags = {
+                                    "waterway=stream" }) })
+    private Atlas deadendWaterway;
+
+    @TestAtlas(nodes = {
+            @Node(id = "5215738262", coordinates = @Loc(value = "39.2176586,-105.4097737")),
+            @Node(id = "5215738336", coordinates = @Loc(value = "39.219347,-105.4093051")),
+            @Node(id = "5215738538", coordinates = @Loc(value = "39.2211332,-105.4101387")) }, lines = {
+                    @Line(id = "538934084", coordinates = { @Loc(value = "39.2211332,-105.4101387"),
+                            @Loc(value = "39.219347,-105.4093051") }, tags = { "name=Lost Creek",
+                                    "tunnel=yes", "waterway=stream" }),
+                    @Line(id = "538934102", coordinates = { @Loc(value = "39.2176586,-105.4097737"),
+                            @Loc(value = "39.219347,-105.4093051") }, tags = {
+                                    "waterway=stream" }) })
+    private Atlas deadendWaterways;
+
+    @TestAtlas(nodes = {
+            @Node(id = "5215738262", coordinates = @Loc(value = "39.2176586,-105.4097737")),
+            @Node(id = "5215738336", coordinates = @Loc(value = "39.2193545,-105.4093126")),
+            @Node(id = "5215738538", coordinates = @Loc(value = "39.2211332,-105.4101387")),
+            @Node(id = "5215773259", coordinates = @Loc(value = "39.2192406,-105.4074739")),
+            @Node(id = "5215773273", coordinates = @Loc(value = "39.2175753,-105.4095698")),
+            @Node(id = "5215773279", coordinates = @Loc(value = "39.2193873,-105.409484")),
+            @Node(id = "5215773282", coordinates = @Loc(value = "39.2183845,-105.4073667")) }, lines = {
+                    @Line(id = "538934084", coordinates = { @Loc(value = "39.2211332,-105.4101387"),
+                            @Loc(value = "39.2193545,-105.4093126") }, tags = { "name=Lost Creek",
+                                    "tunnel=yes", "waterway=stream" }),
+                    @Line(id = "538934102", coordinates = { @Loc(value = "39.2176586,-105.4097737"),
+                            @Loc(value = "39.2193545,-105.4093126") }, tags = {
+                                    "waterway=stream" }),
+                    @Line(id = "538940188", coordinates = { @Loc(value = "39.2193873,-105.409484"),
+                            @Loc(value = "39.2192406,-105.4074739"),
+                            @Loc(value = "39.2183845,-105.4073667"),
+                            @Loc(value = "39.2175753,-105.4095698"),
+                            @Loc(value = "39.2193873,-105.409484") }, tags = {
+                                    "natural=sinkhole" }) })
+    private Atlas sinkholeArea;
+
+    @TestAtlas(nodes = {
+            @Node(id = "7704038731", coordinates = @Loc(value = "40.7329135,-111.6691476")),
+            @Node(id = "7704038746", coordinates = @Loc(value = "40.7376775,-111.6721463"), tags = {
+                    "description=The waterway stops being a surface feature here. I cannot see if it is being culverted underground to join the waterway north of I-80. Probably so but I do not know for sure.",
+                    "natural=sinkhole" }) }, lines = {
+                            @Line(id = "825077302", coordinates = {
+                                    @Loc(value = "40.7329135,-111.6691476"),
+                                    @Loc(value = "40.7376775,-111.6721463") }, tags = {
+                                            "waterway=stream" }) })
+    private Atlas sinkholePoint;
+
+    @TestAtlas(nodes = {
+            @Node(id = "-105006", coordinates = @Loc(value = "30.92902860424,-80.19023929596")),
+            @Node(id = "-105007", coordinates = @Loc(value = "30.93226809162,-80.02647434235")),
+            @Node(id = "-105008", coordinates = @Loc(value = "30.87276183185,-80.04570041656")),
+            @Node(id = "-105009", coordinates = @Loc(value = "30.96406813792,-80.05462680817")),
+            @Node(id = "-105010", coordinates = @Loc(value = "30.97790374137,-79.96776615143")),
+            @Node(id = "-105011", coordinates = @Loc(value = "30.86893095441,-79.96433292389")) }, lines = {
+                    @Line(id = "-101786", coordinates = {
+                            @Loc(value = "30.92902860424,-80.19023929596"),
+                            @Loc(value = "30.93226809162,-80.02647434235") }, tags = {
+                                    "waterway=river" }) }, areas = {
+                                            @Area(id = "-101787", coordinates = {
+                                                    @Loc(value = "30.87276183185,-80.04570041656"),
+                                                    @Loc(value = "30.96406813792,-80.05462680817"),
+                                                    @Loc(value = "30.97790374137,-79.96776615143"),
+                                                    @Loc(value = "30.86893095441,-79.96433292389"),
+                                                    @Loc(value = "30.87276183185,-80.04570041656") }, tags = {
+                                                            "natural=coastline" }) })
+    private Atlas waterwayEndingInOceanArea;
+
+    @TestAtlas(nodes = {
+            @Node(id = "-105006", coordinates = @Loc(value = "30.92902860424,-80.19023929596")),
+            @Node(id = "-105007", coordinates = @Loc(value = "30.93226809162,-80.02647434235")),
+            @Node(id = "-105008", coordinates = @Loc(value = "30.87276183185,-80.04570041656")),
+            @Node(id = "-105009", coordinates = @Loc(value = "30.96406813792,-80.05462680817")),
+            @Node(id = "-105010", coordinates = @Loc(value = "30.97790374137,-79.96776615143")),
+            @Node(id = "-105011", coordinates = @Loc(value = "30.86893095441,-79.96433292389")) }, lines = {
+                    @Line(id = "-101786", coordinates = {
+                            @Loc(value = "30.92902860424,-80.19023929596"),
+                            @Loc(value = "30.93226809162,-80.02647434235") }, tags = {
+                                    "waterway=river" }) }, areas = {
+                                            @Area(id = "-101787", coordinates = {
+                                                    @Loc(value = "30.87276183185,-80.04570041656"),
+                                                    @Loc(value = "30.96406813792,-80.05462680817"),
+                                                    @Loc(value = "30.97790374137,-79.96776615143"),
+                                                    @Loc(value = "30.86893095441,-79.96433292389"),
+                                                    @Loc(value = "30.87276183185,-80.04570041656") }, tags = {
+                                                            "natural=strait" }) })
+    private Atlas waterwayEndingInStraitArea;
+
+    @TestAtlas(nodes = {
+            @Node(id = "2087680912", coordinates = @Loc(value = "17.1499473,-88.932559"), tags = {
+                    "natural=sinkhole" }),
+            @Node(id = "2829277378", coordinates = @Loc(value = "17.1465963,-88.9271326")),
+            @Node(id = "2829277561", coordinates = @Loc(value = "17.1494322,-88.9299908")),
+            @Node(id = "2829277562", coordinates = @Loc(value = "17.149499,-88.9300777")),
+            @Node(id = "2829394973", coordinates = @Loc(value = "17.1498467,-88.9295127")),
+            @Node(id = "2829394982", coordinates = @Loc(value = "17.1494757,-88.9300148")),
+            @Node(id = "2829394983", coordinates = @Loc(value = "17.149467,-88.930036")) }, edges = {
+                    @Edge(id = "278577221", coordinates = { @Loc(value = "17.1465963,-88.9271326"),
+                            @Loc(value = "17.1494322,-88.9299908"),
+                            @Loc(value = "17.149467,-88.930036"),
+                            @Loc(value = "17.149499,-88.9300777"),
+                            @Loc(value = "17.1499473,-88.932559") }, tags = { "waterway=stream" }),
+                    @Edge(id = "278596089", coordinates = { @Loc(value = "17.1498467,-88.9295127"),
+                            @Loc(value = "17.1494757,-88.9300148"),
+                            @Loc(value = "17.149467,-88.930036") }, tags = { "waterway=stream" }) })
+    private Atlas waterwayEndingOnOtherWaterway;
+
+    /**
+     * Get a circular waterway (not real)
+     *
+     * @return An atlas with a circular waterway
+     */
+    public Atlas getCircularWaterway()
+    {
+        return this.circularWaterway;
+    }
+
+    /**
+     * Get a waterway that goes through a coastline
+     *
+     * @return A waterway that ends in an ocean
+     */
+    public Atlas getCoastlineWaterway()
+    {
+        return this.coastlineWaterway;
+    }
+
+    /**
+     * Get a waterway that is connected to a coastline
+     *
+     * @return A waterway that ends in on an ocean
+     */
+    public Atlas getCoastlineWaterwayConnected()
+    {
+        return this.coastlineWaterwayConnected;
+    }
+
+    /**
+     * Get a waterway that goes through a coastline, in the wrong direction
+     *
+     * @return A waterway that starts in an ocean
+     */
+    public Atlas getCoastlineWaterwayReversed()
+    {
+        return this.coastlineWaterwayReversed;
+    }
+
+    /**
+     * Get two crossing waterways on the same layer (layer=0, so no layer tag)
+     *
+     * @return An invalid crossing waterway example
+     */
+    public Atlas getCrossingWaterways()
+    {
+        return this.crossingWaterways;
+    }
+
+    /**
+     * Get two connected crossing waterways on the same layer (layer=0, so no layer tag)
+     *
+     * @return An valid connected crossing waterway example
+     */
+    public Atlas getCrossingWaterwaysConnected()
+    {
+        return this.crossingWaterwaysConnected;
+    }
+
+    /**
+     * Get two crossing waterways on different layers
+     *
+     * @return A valid crossing waterway example
+     */
+    public Atlas getCrossingWaterwaysDifferentLayers()
+    {
+        return this.crossingWaterwaysDifferentLayers;
+    }
+
+    /**
+     * Get dead-end waterway
+     *
+     * @return An atlas with 1 waterway that deadends
+     */
+    public Atlas getDeadendWaterway()
+    {
+        return this.deadendWaterway;
+    }
+
+    /**
+     * Get dead-end waterways
+     *
+     * @return An atlas with 2 waterways that deadend into each other
+     */
+    public Atlas getDeadendWaterways()
+    {
+        return this.deadendWaterways;
+    }
+
+    /**
+     * Get some waterways that end in a sinkhole area
+     *
+     * @return An atlas with a sinkhole as an area
+     */
+    public Atlas getSinkholeArea()
+    {
+        return this.sinkholeArea;
+    }
+
+    /**
+     * Get a waterway that ends in a sinkhole point
+     *
+     * @return An atlas with a sinkhole as a point
+     */
+    public Atlas getSinkholePoint()
+    {
+        return this.sinkholePoint;
+    }
+
+    /**
+     * Get a waterway that ends in an ocean
+     *
+     * @return A waterway ending in an ocean
+     */
+    public Atlas getWaterwayEndingInOceanArea()
+    {
+        return this.waterwayEndingInOceanArea;
+    }
+
+    /**
+     * Get a waterway that ends in a strait
+     *
+     * @return A waterway ending in a strait
+     */
+    public Atlas getWaterwayEndingInStraitArea()
+    {
+        return this.waterwayEndingInStraitArea;
+    }
+
+    /**
+     * Get a waterway that ends on another waterway
+     *
+     * @return A waterway that ends on another waterway
+     */
+    public Atlas getWaterwayEndingOnOtherWaterway()
+    {
+        return this.waterwayEndingOnOtherWaterway;
+    }
+}


### PR DESCRIPTION
### Description:

This does basic waterway checks (closed waterway, waterway does not end in sink, crossing waterway).
See #331.

There are also two new utility classes, `ElevationUtilities` and `CompressionUtilities`. The `ElevationUtilities` reads HGT files (for example, those provided by the SRTM NASA mission), and when given a point, returns the elevation for the appropriate location (only as accurate as the source data -- it _should_ be able to take arbitrarily accurate HGT files). `ElevationUtilities` reads from `elevation` directory in the directory that the check run is started from. This can be customized. `CompressionUtilities` is used to decompress file streams, so that if a file is in a `tar.gz`, `zip`, `gz`, or isn't compressed at all, the user can be relatively certain that the stream is now usable if the file stream is passed into the utility method. This also helps reduce the size on disk for elevation files (i.e., if there is a high resolution HGT file that takes up 1 GiB uncompressed).

To support usage of SRTM elevation files, there is a script in `scripts/elevationData` called `srtm-hgt.py`. This file fetches the SRTM NASA files at a slow rate, so that the serving USGS servers are not significantly burdened by the download. The script tries to ensure that if it is killed, the appropriate actions are taken upon the next start (skip/restart/continue). These files have (at best) ~90m resolution, which means that they are not useful for short lengths, or any method which requires more precise locations. For these instances, more precise data may be provided manually.

### Potential Impact:

Better waterway navigation will be possible. Closed waterways can be very confusing to data consumers (how does it work?), waterways that don't end in a sink (so an ocean, drain, or sinkhole) may or may not be navigable, but it cannot be determined easily. Crossing waterways may allow navigation between them, but only if they are connected (what happens if one is in a tunnel?).

### Unit Test Approach:

The unit tests primarily test for potential false positives, along with some potential false negatives.

### Test Results:

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
| AIA | 0 | 0 | n/a | n/a | n/a |n/a |
|  BLZ   |    311 |    35      |    11% |   35 | 0 | 0% |
| DMA | 30 | 30 | 100% | 30 | 0 | 0% |
| CYM | 7 | 7 | 100% | 7 | 0 | 0% [1] |
| [NZL](https://maproulette.org/challenge/13975)[2] | 12182 | 40 | 0.3% | 38 | 2 | 5% |
| [NZL](https://maproulette.org/challenge/13975) (second take, same challenge rebuilt) | 12191 | 156 | 1.2% | 132 | 9 | 5.7% |
| SMR | 10 | 10 | 100% | 5 | 5 | 50%[3] |

[1] 3 of the TP detections were difficult to determine (e.g., waterway in wetland -- spec doesn't allow for them to end, but it makes sense, waterway may go multiple directions, etc.). However, the wiki specification does not allow for them. No actual waterway visible (still an issue).
[2] NZL had an import of waterways (and other land cover information). Most of the issues found are waterways without sinks, and much of the time, there are multiple related issues (so a series of waterways may have the wrong direction). In the sample layer, 63 waterways were modified, so ~55 issues were actually fixed (some were crossing waterways, but very few were). If this were to be released publicly, it would be a good idea (tm) to update the MapRoulette task weekly (if people actually used it). A false positive is from a waterway ending on a lake where I was unable to find an outlet for the lake (there is probably one somewhere). Another false positive is from a waterway continuing through a coast and into the ocean a fair ways. I've linked to the MapRoulette challenge I used for the spot checking -- please don't use it for editing at this time.
[3] The false positives can be categorized into two separate categories:
1. Boundary issues (the atlas way appears cut at an administrative boundary in Atlas, 3/5 fp)
2. Layer issues (layer=-1 -> no layer, 2/5 fp). Both issues could also be due to boundaries, since a specific test did not fail with layer issues. Having opened the source atlas file, both are valid detections (the connecting waterways do not appear in the file).


### False Negatives:
[Way 350806025](https://www.openstreetmap.org/way/350806025): This way is not closed, but when taken with other ways, it forms a loop. [Osmose](http://osmose.openstreetmap.fr/en/map/#zoom=17&lat=-43.842208&lon=170.434695&item=xxxx&level=1%2C2%2C3&tags=&fixable=) does not find it either. This may be partially ameliorated by the addition of height data (e.g., from the SRTM Nasa mission).

### Notes
There is an ongoing discussion on the mailing lists about abruptly ending waterways. This test will probably need to be updated once a consensus is reached (i.e., tagging for when the waterway spreads out and is soaked up by the earth).

|branch|time|notes|
|-------|----|------|
|dev| 2h 28m 26s | `./gradlew clean build run` with `AIA,CYM,DMA,NZL,SMR` |
|feature/waterway-check| 2h 34m 2s | `./gradlew clean build run` with `AIA,CYM,DMA,NZL,SMR` |