### PR TITLE
Add a Script to Split Atlas Checks Log Files By Check Name

### DIFF
--- a/scripts/check-log-splitter/README.md
+++ b/scripts/check-log-splitter/README.md
@@ -15,7 +15,7 @@ Atlas Checks logs are found under `atlas-checks/build/flag/ISO3`
 
 ## Output
 
-Lets say my input is `/Users/abc/github/atlas-checks/build/flag/CYP/` and this folder contains:
+Lets say my input is `/Users/abc/github/atlas-checks/build/flag/UNK/` and this folder contains:
  - 1542061154375-135.log
  - 1542090421076-1042.log
  - 1545678119687-135.log

--- a/scripts/check-log-splitter/README.md
+++ b/scripts/check-log-splitter/README.md
@@ -1,0 +1,30 @@
+# Log Splitter
+
+By default, Atlas Checks line delimited geojson output combines all check outputs into timestamped named .log files. This makes it difficult to parse individual check results. This script converts Atlas Checks line delimited json output files into check separated .log files.
+
+## Dependencies
+
+json, os & argparse - all standard python3 libraries 
+
+## How to Run
+
+```bash
+python3 log_splitter.py /path/to/atlas-checks/flag --output /path/to/save/logs/
+```
+Atlas Checks logs are found under `atlas-checks/build/flag/ISO3`
+
+## Output
+
+Lets say my input is `/Users/abc/github/atlas-checks/build/flag/CYP/` and this folder contains:
+ - 1542061154375-135.log
+ - 1542090421076-1042.log
+ - 1545678119687-135.log
+
+This script will output the following in the output path specified (`/Users/abc/github/atlas-checks/scripts/check-log-splitter/output/`_)
+ - DuplicateWaysCheck-56.log               
+ - IntersectingBuildingsCheck-51.log       
+ - InvalidTurnRestrictionCheck-270.log     
+ - SinkIslandCheck-55.log
+ - EdgeCrossingEdgeCheck-322.log           
+ - InvalidLanesTagCheck-522.log            
+ - SelfIntersectingPolylineCheck-36.log

--- a/scripts/check-log-splitter/log_splitter.py
+++ b/scripts/check-log-splitter/log_splitter.py
@@ -1,0 +1,93 @@
+"""
+Purpose: The puspose of this script is to convert Atlas Checks line delimited json output files into check separated .log files.
+Inputs: Path to Atlas Checks flag folder containing .log files
+Outputs: Path to save the check separated .log files
+Original Author: Daniel Baah
+Updates: Micah Nacht
+"""
+
+
+import json
+import argparse
+import os
+import collections
+import gzip
+
+
+def get_log_files(logs_path):
+    """
+    Fetch all line-delimited feature from directory of .log files
+    Parse each feature and create a dictionary of checks & their features
+    :param logs_path: path to directory of log files
+    :return: checks dictionary. {checkName: [features] }
+    """
+    check_names_dict = collections.defaultdict(list)
+    for file in os.listdir(logs_path):
+        name, extension = os.path.splitext(file)
+        if extension == ".log" or (extension == ".gz" and name.endswith(".log")):
+            if extension == ".log":
+                with open(os.path.join(logs_path, file), "r") as line_delimited_geojson:
+                    lines = line_delimited_geojson.readlines()
+            elif extension == ".gz":
+                with gzip.open(os.path.join(logs_path, file), "rt") as line_delimited_geojson:
+                    lines = line_delimited_geojson.readlines()
+            for geojson in lines:
+                parsed_json = json.loads(geojson)
+                check_names_dict[get_check_name(parsed_json)].append(parsed_json)
+
+    return check_names_dict
+
+
+def get_check_name(geojson):
+    """
+    Returns the checkName from a FeatureCollection
+    :param geojson:
+    :return string:
+    """
+    return geojson.get("properties").get("generator")
+
+
+def get_check_data(check_name, line_delimited_geojson):
+    """
+    For a given check, return a filtered list of FeatureCollections
+    :param check_name:
+    :param line_delimited_geojson:
+    :return: filtered list of FeatureCollections
+    """
+    return list(filter(lambda geojson: get_check_name(geojson) == check_name, line_delimited_geojson))
+
+
+def write_split_checks(checks_dict, output_directory):
+    """
+    Write a new, line delimited .log file to disk
+    :param checks_dict:
+    :param output_directory:
+    :return:
+    """
+    for check_name in checks_dict.keys():
+        flag_count = len(checks_dict[check_name])
+        location = os.path.join(output_directory, "{}-{}.log".format(check_name, flag_count))
+        with open(location, 'w') as f:
+            for geojson in checks_dict[check_name]:
+                f.write("%s\n" % json.dumps(geojson))
+        print("Writing - {} to disk".format(location))
+
+
+def main():
+    """
+    Grab arguments from command line
+    Create dictionary of checks
+    Write new file to disk
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("logs", help="path to log directory")
+    parser.add_argument("--output", help="optional path to save log files", default="./output")
+
+    args = parser.parse_args()
+
+    checks_dict = get_log_files(args.logs)
+    write_split_checks(checks_dict, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description:

Atlas Checks line delimited geojson output (flag output) combines all check outputs into timestamped named .log files. This makes it difficult to parse individual check results. This script converts Atlas Checks line delimited json output files into check separated .log files.

### Potential Impact:

None. This script aids in analysis process.

### Unit Test Approach:

NA

### Test Results:

Verified that the script outputs .log files separated by check names by local testing. See README.md for usage and output formats.

