### PR TITLE
Updates to AtGradeSignPostCheck

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheck.java
@@ -324,10 +324,13 @@ public class AtGradeSignPostCheck extends BaseCheck<String>
     }
 
     /**
-     * This method collects link roads that are the most logically route between the inEdge and the outEdges.
+     * This method collects link roads that are the most logically route between the inEdge and the
+     * outEdges.
      *
-     * @param inEdge any inEdge
-     * @param outEdges set of outEdges
+     * @param inEdge
+     *            any inEdge
+     * @param outEdges
+     *            set of outEdges
      * @return Set of link roads between inEdge and each of the out edges
      */
     private Set<AtlasEntity> getAttachedLinkRoadsForNavigation(final Edge inEdge,

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheck.java
@@ -250,6 +250,28 @@ public class AtGradeSignPostCheck extends BaseCheck<String>
         return FALLBACK_INSTRUCTIONS;
     }
 
+    private Set<AtlasEntity> attachedLinkRoadsForNavigation(final Edge inEdge,
+            final Set<AtlasEntity> outEdges)
+    {
+        final Set<AtlasEntity> validLinkRoads = new HashSet<>();
+        // Find all connected link roads to the start of the inEdge
+        final Set<Edge> connectedLinks = inEdge.start().outEdges().stream()
+                .filter(outEdge -> outEdge.isMasterEdge()
+                        && outEdge.getIdentifier() != inEdge.getIdentifier()
+                        && outEdge.highwayTag().isLink())
+                .collect(Collectors.toSet());
+        // Verify if each of the link road is also connected to any of the outEdges.
+        // Collect all link roads that have a connection between the inEdge and any of the outEdges.
+        connectedLinks.forEach(connectedLink ->
+        {
+            if (connectedLink.end().connectedEdges().stream().anyMatch(outEdges::contains))
+            {
+                validLinkRoads.add(connectedLink);
+            }
+        });
+        return validLinkRoads;
+    }
+
     /**
      * Collects all edges that are not part of a relation
      *
@@ -681,27 +703,5 @@ public class AtGradeSignPostCheck extends BaseCheck<String>
         mapOfMatchingInAndOutEdges.put(ROUNDABOUT_INTERSECTION_MAP, roundAboutInEdgeToOutEdgeMap);
         mapOfMatchingInAndOutEdges.put(NODE_LINK_ROAD_INTERSECTION_MAP, nodeToLinkEdgeMap);
         return mapOfMatchingInAndOutEdges;
-    }
-
-    private Set<AtlasEntity> attachedLinkRoadsForNavigation(final Edge inEdge,
-            final Set<AtlasEntity> outEdges)
-    {
-        final Set<AtlasEntity> validLinkRoads = new HashSet<>();
-        // Find all connected link roads to the start of the inEdge
-        final Set<Edge> connectedLinks = inEdge.start().outEdges().stream()
-                .filter(outEdge -> outEdge.isMasterEdge()
-                        && outEdge.getIdentifier() != inEdge.getIdentifier()
-                        && outEdge.highwayTag().isLink())
-                .collect(Collectors.toSet());
-        // Verify if each of the link road is also connected to any of the outEdges.
-        // Collect all link roads that have a connection between the inEdge and any of the outEdges.
-        connectedLinks.forEach(connectedLink ->
-        {
-            if (connectedLink.end().connectedEdges().stream().anyMatch(outEdges::contains))
-            {
-                validLinkRoads.add(connectedLink);
-            }
-        });
-        return validLinkRoads;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTest.java
@@ -106,4 +106,19 @@ public class AtGradeSignPostCheckTest
         });
     }
 
+    @Test
+    public void testLinkRoadConnectedAtGradeJunctions()
+    {
+        this.verifier.actual(this.setup.getLinkRoadConnectedAtGradeJunctionAtlas(),
+                new AtGradeSignPostCheck(this.inlineConfiguration));
+        this.verifier.verifyNotEmpty();
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions().contains("is the most logical route between the OSM ways connected to this node, but is either not part of a destination sign relation or is missing a destination sign tag."));
+        });
+
+    }
+
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTest.java
@@ -43,6 +43,22 @@ public class AtGradeSignPostCheckTest
     }
 
     @Test
+    public void testLinkRoadConnectedAtGradeJunctions()
+    {
+        this.verifier.actual(this.setup.getLinkRoadConnectedAtGradeJunctionAtlas(),
+                new AtGradeSignPostCheck(this.inlineConfiguration));
+        this.verifier.verifyNotEmpty();
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag ->
+        {
+            Assert.assertTrue(flag.getInstructions().contains(
+                    "is the most logical route between the OSM ways connected to this node, but is either not part of a destination sign relation or is missing a destination sign tag."));
+        });
+
+    }
+
+    @Test
     public void testMissingDestinationSignRelation()
     {
         this.verifier.actual(this.setup.getMissingDestinationSignRelationAtlas(),
@@ -105,20 +121,4 @@ public class AtGradeSignPostCheckTest
                     + "edges"));
         });
     }
-
-    @Test
-    public void testLinkRoadConnectedAtGradeJunctions()
-    {
-        this.verifier.actual(this.setup.getLinkRoadConnectedAtGradeJunctionAtlas(),
-                new AtGradeSignPostCheck(this.inlineConfiguration));
-        this.verifier.verifyNotEmpty();
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
-        this.verifier.verify(flag ->
-        {
-            Assert.assertTrue(flag.getInstructions().contains("is the most logical route between the OSM ways connected to this node, but is either not part of a destination sign relation or is missing a destination sign tag."));
-        });
-
-    }
-
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTestRule.java
@@ -29,6 +29,10 @@ public class AtGradeSignPostCheckTestRule extends CoreTestRule
     private static final String ROUNDABOUT_LOC_FIVE = "43.2095410, 23.5532935";
     private static final String ROUNDABOUT_LOC_SIX = "43.2097333, 23.5533566";
     private static final String ROUNDABOUT_CONNECTOR_LOC_ONE = "43.2100746, 23.5528153";
+    private static final String ATGRADE_LINK_JUNCTION = "2.2293749, 102.2986680";
+    private static final String LINK_JUNCTION_IN_EDGE_START_LOC = "2.2294533, 102.2991744";
+    private static final String LINK_ROAD_END_LOC = "2.2290532, 102.2987598";
+    private static final String LINK_JUNCTION_OUT_EDGE_END = "2.2293645, 102.2985750";
 
     @TestAtlas(
             // Nodes
@@ -188,9 +192,34 @@ public class AtGradeSignPostCheckTestRule extends CoreTestRule
                                     "highway=primary", "oneway=yes" }) })
     private Atlas roundaboutIntersectionMissingDestinationSignRelationAtlas;
 
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "300010000", coordinates = @Loc(value = ATGRADE_LINK_JUNCTION)),
+                    @Node(coordinates = @Loc(value = LINK_JUNCTION_IN_EDGE_START_LOC)),
+                    @Node(coordinates = @Loc(value = LINK_ROAD_END_LOC)),
+                    @Node(coordinates = @Loc(value = LINK_JUNCTION_OUT_EDGE_END)) },
+            // Edges
+            edges = {
+                    @Edge(id = "100010001", coordinates = { @Loc(value = LINK_JUNCTION_IN_EDGE_START_LOC),
+                            @Loc(value = ATGRADE_LINK_JUNCTION) }, tags = { "highway=primary" }),
+                    @Edge(id = "100010002", coordinates = { @Loc(value = LINK_JUNCTION_IN_EDGE_START_LOC),
+                            @Loc(value = LINK_ROAD_END_LOC) }, tags = { "highway=primary_link" }),
+                    @Edge(id = "100010003", coordinates = { @Loc(value = ATGRADE_LINK_JUNCTION),
+                            @Loc(value = LINK_ROAD_END_LOC) }, tags = { "highway=secondary" }),
+                    @Edge(id = "100010004", coordinates = { @Loc(value = ATGRADE_LINK_JUNCTION),
+                            @Loc(value = LINK_JUNCTION_OUT_EDGE_END) }, tags = {
+                            "highway=secondary" }) })
+    private Atlas linkRoadConnectedAtGradeJunctionAtlas;
+
+
     public Atlas getIncompleteDestinationSignRelationAtlas()
     {
         return this.incompleteDestinationSignRelationAtlas;
+    }
+
+    public Atlas getLinkRoadConnectedAtGradeJunctionAtlas()
+    {
+        return this.linkRoadConnectedAtGradeJunctionAtlas;
     }
 
     public Atlas getMissingDestinationSignRelationAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/AtGradeSignPostCheckTestRule.java
@@ -200,17 +200,18 @@ public class AtGradeSignPostCheckTestRule extends CoreTestRule
                     @Node(coordinates = @Loc(value = LINK_JUNCTION_OUT_EDGE_END)) },
             // Edges
             edges = {
-                    @Edge(id = "100010001", coordinates = { @Loc(value = LINK_JUNCTION_IN_EDGE_START_LOC),
+                    @Edge(id = "100010001", coordinates = {
+                            @Loc(value = LINK_JUNCTION_IN_EDGE_START_LOC),
                             @Loc(value = ATGRADE_LINK_JUNCTION) }, tags = { "highway=primary" }),
-                    @Edge(id = "100010002", coordinates = { @Loc(value = LINK_JUNCTION_IN_EDGE_START_LOC),
+                    @Edge(id = "100010002", coordinates = {
+                            @Loc(value = LINK_JUNCTION_IN_EDGE_START_LOC),
                             @Loc(value = LINK_ROAD_END_LOC) }, tags = { "highway=primary_link" }),
                     @Edge(id = "100010003", coordinates = { @Loc(value = ATGRADE_LINK_JUNCTION),
                             @Loc(value = LINK_ROAD_END_LOC) }, tags = { "highway=secondary" }),
                     @Edge(id = "100010004", coordinates = { @Loc(value = ATGRADE_LINK_JUNCTION),
                             @Loc(value = LINK_JUNCTION_OUT_EDGE_END) }, tags = {
-                            "highway=secondary" }) })
+                                    "highway=secondary" }) })
     private Atlas linkRoadConnectedAtGradeJunctionAtlas;
-
 
     public Atlas getIncompleteDestinationSignRelationAtlas()
     {


### PR DESCRIPTION
### Description:

This PR adds following updates to the existing AtGradeSignPostCheck:
1) In case of At-Grade junctions with turn lanes between connected edges, the AtGradeSignPostCheck flags the Link road instead of the connected edges of the at-grade junction. This update is made considering the fact that the destination information should go to these link roads as they are the most logical routes at such junctions.
Example:
![image](https://user-images.githubusercontent.com/42149840/88701781-56b11c00-d0bf-11ea-8d3d-dd4f566164fa.png)

In the above image, the inEdge and outEdge of the at-grade junctions(https://www.openstreetmap.org/node/5992479635) were flagged previously for missing destination_sign relation/ destination_sign tag. The link road https://www.openstreetmap.org/way/611793210 is the most logical route from the flagged inEdge to the flagged outEdge. With this enhancement, the link road will be flagged for missing destination information instead of the inEdge and outEdge.

2) The use of EdgeDirectionComparator was resulting in large FN, mostly for at-grade junctions at roundabouts.  The EdgeDirectionComparator has been omitted for validating the at-grade junctions based on analysis.

### Potential Impact:

Flags more valid cases (mostly associated with roundabouts) that were skipped previously. Changes to existing flags for at-grade junctions with turn lanes. Flag will have lesser features compared to before as only the link road and junction are flagged instead of all connected edges.

### Unit Test Approach:

Added new unit test.

### Test Results:

All tests passing.
TODO
- [ ] Analysis


