### PR TITLE
Fix issue with InvalidTagsCheck configurables

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -427,10 +427,7 @@
     }
   },
   "InvalidTagsCheck": {
-    "filters.resource": {
-      "override": true,
-      "append": false
-    },
+    "filters.resource.override": true,
     "filters.classes.tags": [
       ["area","boundary->protected_area&protect_class->!"],
       ["relation","boundary->protected_area&protect_class->!"]

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheck.java
@@ -57,8 +57,6 @@ public class InvalidTagsCheck extends BaseCheck<String>
     private static final Logger logger = LoggerFactory.getLogger(InvalidTagsCheck.class);
 
     private final List<Tuple<? extends Class<AtlasEntity>, List<TaggableFilter>>> classTagFilters;
-    private final boolean overrideResourceFilters;
-    private final boolean appendToResourceFilters;
 
     /**
      * @return a List of Tuple containing AtlasEntity and a list of TaggableFilters read from the
@@ -148,7 +146,8 @@ public class InvalidTagsCheck extends BaseCheck<String>
     {
         final List<TaggableFilter> filters = new ArrayList<>();
         filters.add(TaggableFilter.forDefinition(tagFilterString));
-        return new Tuple<>(ItemType.valueOf(classString.toUpperCase()).getMemberClass(), filters);
+        return Tuple.createTuple(ItemType.valueOf(classString.toUpperCase()).getMemberClass(),
+                filters);
     }
 
     /**
@@ -162,28 +161,22 @@ public class InvalidTagsCheck extends BaseCheck<String>
     public InvalidTagsCheck(final Configuration configuration)
     {
         super(configuration);
-        this.overrideResourceFilters = this.configurationValue(configuration,
+        final boolean overrideResourceFilters = this.configurationValue(configuration,
                 "filters.resource.override", false);
-        this.appendToResourceFilters = this.configurationValue(configuration,
-                "filters.resource.append", false);
         // If the "filters.resource.override" key in the config is set to true, use only the filters
         // passed through the config,
-        if (this.overrideResourceFilters && !this.appendToResourceFilters)
+        if (overrideResourceFilters)
         {
             this.classTagFilters = this.getFiltersFromConfiguration(configuration);
         }
         // Append filters from config to the default list of filters if "filters.resource.append"
         // is set to true
-        else if (!this.overrideResourceFilters && this.appendToResourceFilters)
+        else
         {
             final List<Tuple<? extends Class<AtlasEntity>, List<TaggableFilter>>> defaultFilters = getDefaultFilters();
             // Add all filters from the config file to the default list of filters
             defaultFilters.addAll(this.getFiltersFromConfiguration(configuration));
             this.classTagFilters = defaultFilters;
-        }
-        else
-        {
-            this.classTagFilters = Collections.emptyList();
         }
     }
 
@@ -264,6 +257,8 @@ public class InvalidTagsCheck extends BaseCheck<String>
                     final List<String> classTagList = (List<String>) classTagValue;
                     if (classTagList.size() > 1)
                     {
+                        System.out.println(
+                                stringsToClassTagFilter(classTagList.get(0), classTagList.get(1)));
                         return Optional.of(
                                 stringsToClassTagFilter(classTagList.get(0), classTagList.get(1)));
                     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheck.java
@@ -257,8 +257,6 @@ public class InvalidTagsCheck extends BaseCheck<String>
                     final List<String> classTagList = (List<String>) classTagValue;
                     if (classTagList.size() > 1)
                     {
-                        System.out.println(
-                                stringsToClassTagFilter(classTagList.get(0), classTagList.get(1)));
                         return Optional.of(
                                 stringsToClassTagFilter(classTagList.get(0), classTagList.get(1)));
                     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheckTest.java
@@ -24,7 +24,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource\": {\"override\": false,\"append\": true},\"filters.classes.tags\":[[\"node\",\"crossing->traffic_signals&highway->!crossing\"],"
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": false,\"filters.classes.tags\":[[\"node\",\"crossing->traffic_signals&highway->!crossing\"],"
                                 + "[\"point\",\"crossing->traffic_signals&highway->!crossing\"]]}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
     }
@@ -34,7 +34,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource\": {\"override\": true,\"append\": false},\"filters.classes.tags\":[[\"area\",\"boundary->protected_area&protect_class->!\"], [\"relation\",\"boundary->protected_area&protect_class->!\"]]}}")));
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"filters.classes.tags\":[[\"area\",\"boundary->protected_area&protect_class->!\"], [\"relation\",\"boundary->protected_area&protect_class->!\"]]}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
     }
 
@@ -43,7 +43,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource\": {\"override\": true,\"append\": false},\"filters.classes.tags\":[[\"edge\",\"route->ferry&highway->*\"], [\"line\",\"route->ferry&highway->*\"],[\"edge\",\"construction->*&highway->!construction\"],"
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"filters.classes.tags\":[[\"edge\",\"route->ferry&highway->*\"], [\"line\",\"route->ferry&highway->*\"],[\"edge\",\"construction->*&highway->!construction\"],"
                                 + "[\"line\",\"construction->*&highway->!construction\"]]}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
     }
@@ -53,7 +53,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource\": {\"override\": true,\"append\": false},\"filters.classes.tags\":[[\"edge\",\"route->ferry&highway->*\"]]}}")));
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"filters.classes.tags\":[[\"edge\",\"route->ferry&highway->*\"]]}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
@@ -62,7 +62,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource\": {\"override\": true,\"append\": false},\"filters.classes.tags\":[[\"line\",\"construction->*&highway->!construction\"],[\"line\",\"water->*&natural->!water\"]]}}")));
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"filters.classes.tags\":[[\"line\",\"construction->*&highway->!construction\"],[\"line\",\"water->*&natural->!water\"]]}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.globallyVerify(flags -> flags.forEach(flag -> Assert.assertEquals(
                 "1. OSM feature 6 has invalid tags.\n"
@@ -76,7 +76,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource\": {\"override\": true,\"append\": false},\"filters.classes.tags\":[[\"node\",\"crossing->traffic_signals&highway->!crossing\"],"
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"append\": false},\"filters.classes.tags\":[[\"node\",\"crossing->traffic_signals&highway->!crossing\"],"
                                 + "[\"point\",\"crossing->traffic_signals&highway->!crossing\"]]}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTagsCheckTest.java
@@ -76,7 +76,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"append\": false},\"filters.classes.tags\":[[\"node\",\"crossing->traffic_signals&highway->!crossing\"],"
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"filters.classes.tags\":[[\"node\",\"crossing->traffic_signals&highway->!crossing\"],"
                                 + "[\"point\",\"crossing->traffic_signals&highway->!crossing\"]]}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
     }
@@ -86,7 +86,7 @@ public class InvalidTagsCheckTest
     {
         this.verifier.actual(this.setup.testAtlas(),
                 new InvalidTagsCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"InvalidTagsCheck\":{\"filters.resource\": {\"override\": true,\"append\": false},\"filters.classes.tags\":[]}}")));
+                        "{\"InvalidTagsCheck\":{\"filters.resource.override\": true,\"filters.classes.tags\":[]}}")));
         this.verifier.verifyEmpty();
     }
 }


### PR DESCRIPTION
### Description:

This PR fixes a bug in InvalidTagsCheck, introduced in PR #[296](https://github.com/osmlab/atlas-checks/pull/296). The config values for Taggable filter passed through the config.json was not initialized properly and was always set to null and so the check did not produce any flags for filters passed through the config.

### Potential Impact:

By this update, the config values in the check will be properly initialized to values passed through config.json.

### Unit Test Approach:

Updated existing unit tests

### Test Results:

Tested locally and verified that the outputs are generated properly for the filters passed through the config.

