### PR TITLE
New check: Missing bridge structure (#341)

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
+    "enabled.value.default": false
   },
   "PoolSizeCheck": {
     "surface": {
@@ -1059,6 +1059,14 @@
     }
   },
   "BridgeDetailedInfoCheck": {
-    "bridge.length.minimum.meters": 500.0
+    "enabled": true,
+    "bridge.length.minimum.meters": 500.0,
+    "challenge": {
+      "description": "Bridge is long enough to deserve a more detailed description than just bridge=yes",
+      "blurb": "Bridge without structure",
+      "instruction": "Open your favorite editor and add a more specific 'bridge=*' or 'bridge:structure=*' tag.",
+      "difficulty": "EASY",
+      "defaultPriority": "LOW"
+    }
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1057,5 +1057,8 @@
       "difficulty": "EASY",
       "defaultPriority": "MEDIUM"
     }
+  },
+  "BridgeDetailedInfoCheck": {
+    "bridge.length.minimum.meters": 500.0
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {
@@ -1059,7 +1059,6 @@
     }
   },
   "BridgeDetailedInfoCheck": {
-    "enabled": true,
     "bridge.length.minimum.meters": 500.0,
     "challenge": {
       "description": "Bridge is long enough to deserve a more detailed description than just bridge=yes",

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -68,6 +68,7 @@ This document is a list of tables with a description and link to documentation f
 | Check Name | Check Description |
 | :--------- | :---------------- |
 | AbbreviatedNameCheck |  The purpose of this check is to flag names that have abbreviations in them. |
+| [BridgeDetailedInfoCheck](checks/bridgeDetailedInfoCheck.md) | The purpose of this check is to identify prominent bridges with unspecified type or structure. |
 | [ConflictingAreaTagCombination](checks/conflictingAreaTagCombination.md) | The purpose of this check is to identify Areas with invalid tag combinations. |
 | ConflictingTagCombinationCheck | This check verifies whether an atlas object has a conflicting tag combination or not. |
 | [HighwayToFerryTagCheck](checks/highwayToFerryTagCheck.md) | The purpose of this check is to identify all Edges with route=FERRY and highway=PATH (or higher). |

--- a/docs/checks/bridgeDetailedInfoCheck.md
+++ b/docs/checks/bridgeDetailedInfoCheck.md
@@ -1,0 +1,24 @@
+# Bridge Detailed Info Check
+
+#### Description
+
+This check flags railway and major highway bridges longer than X meters (configurable) which only have a generic 'bridge=yes' tag without any details (bridge type or structure).
+
+The minimum bridge length to qualify for this check is configurable. The default is 500 meters.
+
+This is a port of Osmose check #7012.
+
+#### Live examples
+
+Way [id:4407849](https://www.openstreetmap.org/way/4407849) represents a prominent bridge - it is a section of a motorway and its length is greater than 500m - but it only has a generic `bridge=yes` tag.  
+
+#### Code review
+
+The validation section ensures that the Atlas object being evaluated is an [Edge](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java) with the following tags:
+* `bridge=yes`
+* `railway` -or- `highway` with one of the values: `motorway`, `trunk`, `primary`, `secondary`.
+ 
+The check section flags a valid candidate Edge if it is longer than the configurable minimum but does not have a `bridge:structure` tag.
+ 
+To learn more, please look at the source code for the check:
+[BridgeDetailedInfoCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java)

--- a/docs/checks/bridgeDetailedInfoCheck.md
+++ b/docs/checks/bridgeDetailedInfoCheck.md
@@ -17,6 +17,7 @@ Way [id:4407849](https://www.openstreetmap.org/way/4407849) represents a promine
 The validation section ensures that the Atlas object being evaluated is an [Edge](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java) with the following tags:
 * `bridge=yes`
 * `railway` -or- `highway` with one of the values: `motorway`, `trunk`, `primary`, `secondary`.
+Only _master_ Edges are valid candidates for this check, to avoid duplicate flags on a single bi-directional Way.
  
 The check section flags a valid candidate Edge if it is longer than the configurable minimum but does not have a `bridge:structure` tag.
  

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
@@ -59,7 +59,8 @@ public class BridgeDetailedInfoCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Edge && isGenericBridge(object)
+        // only master edges shall be flagged to avoid duplicate flags on the same OSM Way
+        return object instanceof Edge && ((Edge) object).isMasterEdge() && isGenericBridge(object)
                 && (isRailway(object) || isMajorHighway(object));
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
@@ -1,0 +1,107 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.scalars.Distance;
+
+/**
+ * Flags railway and major highway bridges which are longer than configured minimum and have
+ * unspecified structure. This is a port of Osmose check 7012.
+ * 
+ * @author ladwlo
+ */
+public class BridgeDetailedInfoCheck extends BaseCheck<Long>
+{
+
+    private static final long serialVersionUID = -8915653487119336836L;
+
+    private static final EnumSet<HighwayTag> MAJOR_HIGHWAYS = EnumSet.of(HighwayTag.MOTORWAY,
+            HighwayTag.TRUNK, HighwayTag.PRIMARY, HighwayTag.SECONDARY);
+    private static final Double MINIMUM_LENGTH = 500.0;
+    public static final String RAILWAY_TAG = "railway";
+    public static final String BRIDGE_TAG = "bridge";
+    public static final String BRIDGE_STRUCTURE_TAG = "bridge:structure";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            "The length of this bridge ({0,number,#}) makes it deserve more details than just 'bridge=yes'. Add an appropriate 'bridge=*' or 'bridge:structure=*' tag.");
+    private final Distance minimumLength;
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public BridgeDetailedInfoCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.minimumLength = configurationValue(configuration, "bridge.length.minimum.meters",
+                MINIMUM_LENGTH, Distance::meters);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Edge && isGenericBridge(object)
+                && (isRailway(object) || isMajorHighway(object));
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Optional<String> bridgeStructureTag = object.getTag(BRIDGE_STRUCTURE_TAG);
+        if (((Edge) object).length().isGreaterThan(this.minimumLength)
+                && !bridgeStructureTag.isPresent())
+        {
+            return Optional
+                    .of(createFlag(object, getLocalizedInstruction(0, object.getIdentifier())));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    private boolean isGenericBridge(final AtlasObject object)
+    {
+        final Optional<String> bridgeTag = object.getTag(BRIDGE_TAG);
+        return bridgeTag.isPresent() && "yes".equals(bridgeTag.get());
+    }
+
+    private boolean isMajorHighway(final AtlasObject object)
+    {
+        return MAJOR_HIGHWAYS.contains(((Edge) object).highwayTag());
+    }
+
+    private boolean isRailway(final AtlasObject object)
+    {
+        return object.getTag(RAILWAY_TAG).isPresent();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
@@ -31,7 +31,7 @@ public class BridgeDetailedInfoCheck extends BaseCheck<Long>
     public static final String BRIDGE_TAG = "bridge";
     public static final String BRIDGE_STRUCTURE_TAG = "bridge:structure";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            "The length of this bridge ({0,number,#}) makes it deserve more details than just 'bridge=yes'. Add an appropriate 'bridge=*' or 'bridge:structure=*' tag.");
+            "The length of this bridge (OSM ID: {0,number,#}) makes it deserve more details than just 'bridge=yes'. Add an appropriate 'bridge=*' or 'bridge:structure=*' tag.");
     private final Distance minimumLength;
 
     /**
@@ -79,7 +79,7 @@ public class BridgeDetailedInfoCheck extends BaseCheck<Long>
                 && !bridgeStructureTag.isPresent())
         {
             return Optional
-                    .of(createFlag(object, getLocalizedInstruction(0, object.getIdentifier())));
+                    .of(createFlag(object, getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
         return Optional.empty();
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheck.java
@@ -9,7 +9,10 @@ import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.BridgeTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.RailwayTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 
@@ -27,8 +30,6 @@ public class BridgeDetailedInfoCheck extends BaseCheck<Long>
     private static final EnumSet<HighwayTag> MAJOR_HIGHWAYS = EnumSet.of(HighwayTag.MOTORWAY,
             HighwayTag.TRUNK, HighwayTag.PRIMARY, HighwayTag.SECONDARY);
     private static final Double MINIMUM_LENGTH = 500.0;
-    public static final String RAILWAY_TAG = "railway";
-    public static final String BRIDGE_TAG = "bridge";
     public static final String BRIDGE_STRUCTURE_TAG = "bridge:structure";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
             "The length of this bridge (OSM ID: {0,number,#}) makes it deserve more details than just 'bridge=yes'. Add an appropriate 'bridge=*' or 'bridge:structure=*' tag.");
@@ -92,8 +93,7 @@ public class BridgeDetailedInfoCheck extends BaseCheck<Long>
 
     private boolean isGenericBridge(final AtlasObject object)
     {
-        final Optional<String> bridgeTag = object.getTag(BRIDGE_TAG);
-        return bridgeTag.isPresent() && "yes".equals(bridgeTag.get());
+        return Validators.isOfType(object, BridgeTag.class, BridgeTag.YES);
     }
 
     private boolean isMajorHighway(final AtlasObject object)
@@ -103,6 +103,6 @@ public class BridgeDetailedInfoCheck extends BaseCheck<Long>
 
     private boolean isRailway(final AtlasObject object)
     {
-        return object.getTag(RAILWAY_TAG).isPresent();
+        return Validators.hasValuesFor(object, RailwayTag.class);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTest.java
@@ -1,0 +1,90 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Tests for {@link BridgeDetailedInfoCheck}
+ *
+ * @author ladwlo
+ */
+public class BridgeDetailedInfoCheckTest
+{
+
+    @Rule
+    public BridgeDetailedInfoCheckTestRule setup = new BridgeDetailedInfoCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
+            "{\"BridgeDetailedInfoCheck\":{\"bridge.length.minimum.meters\":500.0}}");
+
+    @Test
+    public void longEdgeThatIsNotABridgeIsIgnored()
+    {
+        this.verifier.actual(this.setup.getLongEdgeThatIsNotABridge(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void longGenericMajorHighwayBridgeIsFlagged()
+    {
+        this.verifier.actual(this.setup.longGenericMajorHighwayBridge(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void longGenericMinorHighwayBridgeIsIgnored()
+    {
+        this.verifier.actual(this.setup.longGenericMinorHighwayBridge(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void longGenericNonRailwayOrHighwayBridgeIsIgnored()
+    {
+        this.verifier.actual(this.setup.longGenericBridge(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void longGenericRailwayBridgeIsFlagged()
+    {
+        this.verifier.actual(this.setup.longGenericRailwayBridge(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void longRailwayBridgeWithStructureIsAccepted()
+    {
+        this.verifier.actual(this.setup.longRailwayBridgeWithStructure(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void longRailwayBridgeWithTypeIsAccepted()
+    {
+        this.verifier.actual(this.setup.longRailwayBridgeWithType(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void shortGenericHighwayBridgeIsIgnored()
+    {
+        this.verifier.actual(this.setup.shortGenericHighwayBridge(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTest.java
@@ -81,6 +81,14 @@ public class BridgeDetailedInfoCheckTest
     }
 
     @Test
+    public void masterAndReversedEdgesAreOnlyFlaggedOnce()
+    {
+        this.verifier.actual(this.setup.masterAndReversedEdges(),
+                new BridgeDetailedInfoCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void shortGenericHighwayBridgeIsIgnored()
     {
         this.verifier.actual(this.setup.shortGenericHighwayBridge(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
@@ -91,6 +91,20 @@ public class BridgeDetailedInfoCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(id = "1000000001", coordinates = {
+                            @TestAtlas.Loc(value = LOC_3), @TestAtlas.Loc(value = LOC_4) }, tags = {
+                                    "railway=yes", "bridge=yes" }),
+                    @TestAtlas.Edge(id = "-1000000001", coordinates = {
+                            @TestAtlas.Loc(value = LOC_4), @TestAtlas.Loc(value = LOC_3) }, tags = {
+                                    "railway=yes", "bridge=yes" }) })
+    private Atlas masterAndReversedEdges;
+
+    @TestAtlas(
+            // nodes
             nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_1)),
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_2)) },
             // edges
@@ -132,6 +146,11 @@ public class BridgeDetailedInfoCheckTestRule extends CoreTestRule
     public Atlas longRailwayBridgeWithType()
     {
         return this.longRailwayBridgeWithType;
+    }
+
+    public Atlas masterAndReversedEdges()
+    {
+        return this.masterAndReversedEdges;
     }
 
     public Atlas shortGenericHighwayBridge()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
@@ -1,0 +1,141 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * Test atlases for {@link BridgeDetailedInfoCheckTest}
+ *
+ * @author ladwlo
+ */
+public class BridgeDetailedInfoCheckTestRule extends CoreTestRule
+{
+
+    // short bridge
+    private static final String LOC_1 = "47.222,-122.444";
+    private static final String LOC_2 = "47.225,-122.441";
+    // long bridge
+    private static final String LOC_3 = "47.111,-122.666";
+    private static final String LOC_4 = "47.115,-122.661";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_3),
+                    @TestAtlas.Loc(value = LOC_4) }, tags = { "railway=yes" }) })
+    private Atlas longEdgeThatIsNotABridge;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_3),
+                    @TestAtlas.Loc(value = LOC_4) }, tags = { "bridge=yes" }) })
+    private Atlas longGenericBridge;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_3),
+                    @TestAtlas.Loc(value = LOC_4) }, tags = { "highway=motorway", "bridge=yes" }) })
+    private Atlas longGenericMajorHighwayBridge;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_3),
+                    @TestAtlas.Loc(value = LOC_4) }, tags = { "highway=tertiary", "bridge=yes" }) })
+    private Atlas longGenericMinorHighwayBridge;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_3),
+                    @TestAtlas.Loc(value = LOC_4) }, tags = { "railway=yes", "bridge=yes" }) })
+    private Atlas longGenericRailwayBridge;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_3), @TestAtlas.Loc(value = LOC_4) }, tags = {
+                            "highway=motorway", "bridge=yes", "bridge:structure=arch" }) })
+    private Atlas longRailwayBridgeWithStructure;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_3), @TestAtlas.Loc(value = LOC_4) }, tags = {
+                            "railway=yes", "bridge=cantilever" }) })
+    private Atlas longRailwayBridgeWithType;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_2)) },
+            // edges
+            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
+                    @TestAtlas.Loc(value = LOC_1),
+                    @TestAtlas.Loc(value = LOC_2) }, tags = { "highway=motorway", "bridge=yes" }) })
+    private Atlas shortGenericHighwayBridge;
+
+    public Atlas getLongEdgeThatIsNotABridge()
+    {
+        return this.longEdgeThatIsNotABridge;
+    }
+
+    public Atlas longGenericBridge()
+    {
+        return this.longGenericBridge;
+    }
+
+    public Atlas longGenericMajorHighwayBridge()
+    {
+        return this.longGenericMajorHighwayBridge;
+    }
+
+    public Atlas longGenericMinorHighwayBridge()
+    {
+        return this.longGenericMinorHighwayBridge;
+    }
+
+    public Atlas longGenericRailwayBridge()
+    {
+        return this.longGenericRailwayBridge;
+    }
+
+    public Atlas longRailwayBridgeWithStructure()
+    {
+        return this.longRailwayBridgeWithStructure;
+    }
+
+    public Atlas longRailwayBridgeWithType()
+    {
+        return this.longRailwayBridgeWithType;
+    }
+
+    public Atlas shortGenericHighwayBridge()
+    {
+        return this.shortGenericHighwayBridge;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
@@ -1,6 +1,8 @@
 package org.openstreetmap.atlas.checks.validation.tag;
 
-import static org.openstreetmap.atlas.utilities.testing.TestAtlas.*;
+import static org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import static org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import static org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
 
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/BridgeDetailedInfoCheckTestRule.java
@@ -1,5 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.tag;
 
+import static org.openstreetmap.atlas.utilities.testing.TestAtlas.*;
+
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas;
@@ -21,96 +23,87 @@ public class BridgeDetailedInfoCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_3),
-                    @TestAtlas.Loc(value = LOC_4) }, tags = { "railway=yes" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                    @Loc(value = LOC_4) }, tags = { "railway=rail" }) })
     private Atlas longEdgeThatIsNotABridge;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_3),
-                    @TestAtlas.Loc(value = LOC_4) }, tags = { "bridge=yes" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                    @Loc(value = LOC_4) }, tags = { "bridge=yes" }) })
     private Atlas longGenericBridge;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_3),
-                    @TestAtlas.Loc(value = LOC_4) }, tags = { "highway=motorway", "bridge=yes" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                    @Loc(value = LOC_4) }, tags = { "highway=motorway", "bridge=yes" }) })
     private Atlas longGenericMajorHighwayBridge;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_3),
-                    @TestAtlas.Loc(value = LOC_4) }, tags = { "highway=tertiary", "bridge=yes" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                    @Loc(value = LOC_4) }, tags = { "highway=tertiary", "bridge=yes" }) })
     private Atlas longGenericMinorHighwayBridge;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_3),
-                    @TestAtlas.Loc(value = LOC_4) }, tags = { "railway=yes", "bridge=yes" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                    @Loc(value = LOC_4) }, tags = { "railway=rail", "bridge=yes" }) })
     private Atlas longGenericRailwayBridge;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_3), @TestAtlas.Loc(value = LOC_4) }, tags = {
-                            "highway=motorway", "bridge=yes", "bridge:structure=arch" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                    @Loc(value = LOC_4) }, tags = { "highway=motorway", "bridge=yes",
+                            "bridge:structure=arch" }) })
     private Atlas longRailwayBridgeWithStructure;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_3), @TestAtlas.Loc(value = LOC_4) }, tags = {
-                            "railway=yes", "bridge=cantilever" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                    @Loc(value = LOC_4) }, tags = { "railway=rail", "bridge=cantilever" }) })
     private Atlas longRailwayBridgeWithType;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_3)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_4)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1000000001", coordinates = {
-                            @TestAtlas.Loc(value = LOC_3), @TestAtlas.Loc(value = LOC_4) }, tags = {
-                                    "railway=yes", "bridge=yes" }),
-                    @TestAtlas.Edge(id = "-1000000001", coordinates = {
-                            @TestAtlas.Loc(value = LOC_4), @TestAtlas.Loc(value = LOC_3) }, tags = {
-                                    "railway=yes", "bridge=yes" }) })
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_3),
+                            @Loc(value = LOC_4) }, tags = { "railway=rail", "bridge=yes" }),
+                    @Edge(id = "-1000000001", coordinates = { @Loc(value = LOC_4),
+                            @Loc(value = LOC_3) }, tags = { "railway=rail", "bridge=yes" }) })
     private Atlas masterAndReversedEdges;
 
     @TestAtlas(
             // nodes
-            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_1)),
-                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOC_2)) },
+            nodes = { @Node(coordinates = @Loc(value = LOC_1)),
+                    @Node(coordinates = @Loc(value = LOC_2)) },
             // edges
-            edges = { @TestAtlas.Edge(id = "1000000001", coordinates = {
-                    @TestAtlas.Loc(value = LOC_1),
-                    @TestAtlas.Loc(value = LOC_2) }, tags = { "highway=motorway", "bridge=yes" }) })
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_1),
+                    @Loc(value = LOC_2) }, tags = { "highway=motorway", "bridge=yes" }) })
     private Atlas shortGenericHighwayBridge;
 
     public Atlas getLongEdgeThatIsNotABridge()


### PR DESCRIPTION
### Description:

Port of Osmose check #7012. Flags long bridges without detailed info (bridge type/structure).
Issue https://github.com/osmlab/atlas-checks/issues/341

### Potential Impact:

None.

### Unit Test Approach:

Unit tests created for two positive scenarios (railway and major-highway bridges that meet all preconditions) and several negative scenarios (when some of the preconditions or check criteria are not met). Tests use local mini-atlases with artificial data.

### Test Results:

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
| NZL | 24 | 24 | 100% | 24 | 0 | 0% |
| ARG | 62 | 20 | 33% | 20 | 0 | 0% |
| BOL | 3 | 3 | 100% | 3 | 0 | 0% |
| COL | 17 | 17 | 100% | 17 | 0 | 0% |
| DMA | 0 | 0 | 100% | 0 | 0 | 0% |
| CYM | 0 | 0 | 100% | 0 | 0 | 0% |
| TUR | 258 | 52 | 20% | 52 | 0 | 0% |
