### PR TITLE
New check: TunnelBridgeHeightLimitCheck (#343)

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1110,5 +1110,14 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW"
     }
+  },
+  "TunnelBridgeHeightLimitCheck": {
+    "challenge": {
+      "description": "Tunnels, covered roads and roads crossing with bridges should have a 'maxheight' or 'maxheight:physical' tags.",
+      "blurb": "Missing maxheight tag",
+      "instruction": "Open your favorite editor and check the instruction for the task instructions, then add missing tags to each of the flagged ways.",
+      "difficulty": "NORMAL",
+      "defaultPriority": "LOW"
+    }
   }
 }

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1112,6 +1112,7 @@
     }
   },
   "TunnelBridgeHeightLimitCheck": {
+    "highway.filter":"highway->motorway_link,trunk_link,primary,primary_link,secondary,secondary_link",
     "challenge": {
       "description": "Tunnels, covered roads and roads crossing with bridges should have a 'maxheight' or 'maxheight:physical' tags.",
       "blurb": "Missing maxheight tag",

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -82,6 +82,7 @@ This document is a list of tables with a description and link to documentation f
 | [RoadNameSpellingConsistencyCheck](checks/RoadNameSpellingConsistencyCheck.md) | The purpose of this check is to identify road segments that have a name Tag with a different spelling from that of other segments of the same road. This check is primarily meant to catch small errors in spelling, such as a missing letter, letter accent mixups, or capitalization errors. |
 | ShortNameCheck | The short name check will validate that any and all names contain at least 2 letters in the name. |
 | [StreetNameIntegersOnlyCheck](checks/streetNameIntegersOnlyCheck.md) | The purpose of this check is to identify streets whose names contain integers only. |
+| [TunnelBridgeHeightLimitCheck](checks/tunnelBridgeHeightLimitCheck.md) | The purpose of this check is to identify roads with limited vertical clearance which do not have a maxheight tag. |
 | [UnusualLayerTagsCheck](checks/unusualLayerTagsCheck.md) | The purpose of this check is to identify layer tag values when accompanied by invalid tunnel and bridge tags. |
 | [ConditionalRestrictionCheck](checks/conditionalRestrictionCheck.md) | The purpose of this check is to identify elements that have a :conditional tag that does not respect the established format. |
 

--- a/docs/checks/tunnelBridgeHeightLimitCheck.md
+++ b/docs/checks/tunnelBridgeHeightLimitCheck.md
@@ -1,0 +1,32 @@
+# Tunnel/Bridge Height Limit Check
+
+#### Description
+
+This check identifies roads of limited vertical clearance (tunnels, covered roads, and roads crossed by bridges) that do not have 'maxheight' or 'maxheight:physical' tags set. 
+The valid highway classes for this check are:
+MOTORWAY_LINK, TRUNK_LINK, PRIMARY, PRIMARY_LINK, SECONDARY, SECONDARY_LINK
+
+This is a port of Osmose check #7130.
+
+#### Live Examples
+
+1. Way [id:17659494](https://www.openstreetmap.org/way/17659494) is a tunnel without maxheight tag.
+2. Way [id:601626442](https://www.openstreetmap.org/way/601626442) is a covered road without maxheight tag.
+3. Way [id:174319379](https://www.openstreetmap.org/way/174319379) passes under a pair of bridges:
+[id:11778321](https://www.openstreetmap.org/way/11778321) and [id:11778325](https://www.openstreetmap.org/way/11778325).
+But it does not have a maxheight tag.
+
+#### Code Review
+
+The check ensures that the Atlas object being evaluated is an [Edge](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java)
+which is a _master_ edge (positive ID) and its related OSM Way ID has not yet been flagged. This is done in the validation step.
+Once an edge is found to be valid, the verification step first checks (using standard Validators) if the edge is a _tunnel_ or a _covered_ road,
+it has an expected _highway_ class and no _maxheight_ tags are present. The edge is then flagged.
+If the edge has not been flagged, but it is tagged as a _bridge_, then any edges that intersect the bridge's bounding box are retrieved.
+For each of those new target objects, the algorithm verifies the same criteria (the edge is a master edge, with OSM ID that has not yet been flagged,
+it is of expected highway class and does not have maxheight tags). Additionally, it checks if the edge's polyline properly crosses the bridge's polyline,
+to exclude any edges that might have been caught in the bounding box but do not actually intersect with the bridge, or only touch it at either end.
+For each edge which passed through all these filters, a separate fixing instruction is added and a single flag is created. 
+
+To learn more about the code, please look at the comments in the source code for the check.
+[TunnelBridgeHeightLimitCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java)

--- a/docs/checks/tunnelBridgeHeightLimitCheck.md
+++ b/docs/checks/tunnelBridgeHeightLimitCheck.md
@@ -3,7 +3,7 @@
 #### Description
 
 This check identifies roads of limited vertical clearance (tunnels, covered roads, and roads crossed by bridges) that do not have 'maxheight' or 'maxheight:physical' tags set. 
-The valid highway classes for this check are:
+The valid highway classes for this check (configurable) are:
 MOTORWAY_LINK, TRUNK_LINK, PRIMARY, PRIMARY_LINK, SECONDARY, SECONDARY_LINK
 
 This is a port of Osmose check #7130.

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
@@ -85,7 +85,8 @@ public class TunnelBridgeHeightLimitCheck extends BaseCheck<Long>
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         // case 1 (tunnel) & 2 (covered highway)
-        if ((TunnelTag.isTunnel(object) || isCovered(object)) && isHighwayWithoutMaxHeight(object))
+        if ((TunnelTag.isTunnel(object) || this.isCovered(object))
+                && this.isHighwayWithoutMaxHeight(object))
         {
             final Long osmId = object.getOsmIdentifier();
             markAsFlagged(osmId);
@@ -104,8 +105,8 @@ public class TunnelBridgeHeightLimitCheck extends BaseCheck<Long>
                     .filter(edge -> edge.isMainEdge()
                             && edge.getOsmIdentifier() != bridge.getOsmIdentifier()
                             && !isFlagged(edge.getOsmIdentifier())
-                            && isHighwayWithoutMaxHeight(edge)
-                            && edgeCrossesBridge(edge.asPolyLine(), bridgeAsPolyLine))
+                            && this.isHighwayWithoutMaxHeight(edge)
+                            && this.edgeCrossesBridge(edge.asPolyLine(), bridgeAsPolyLine))
                     .forEach(edge ->
                     {
                         markAsFlagged(edge.getOsmIdentifier());

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
@@ -150,7 +150,8 @@ public class TunnelBridgeHeightLimitCheck extends BaseCheck<Long>
 
     private boolean isHighwayWithoutMaxHeight(final AtlasObject object)
     {
-        return highwayFilter.test(object) && !Validators.hasValuesFor(object, MaxHeightTag.class)
+        return this.highwayFilter.test(object)
+                && !Validators.hasValuesFor(object, MaxHeightTag.class)
                 && object.getTag(MAXHEIGHT_PHYSICAL).isEmpty();
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
@@ -70,7 +70,7 @@ public class TunnelBridgeHeightLimitCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Edge && ((Edge) object).isMasterEdge()
+        return object instanceof Edge && ((Edge) object).isMainEdge()
                 && !isFlagged(object.getOsmIdentifier());
     }
 
@@ -101,7 +101,7 @@ public class TunnelBridgeHeightLimitCheck extends BaseCheck<Long>
             final PolyLine bridgeAsPolyLine = bridge.asPolyLine();
             final Set<Edge> edgesToFlag = new HashSet<>();
             Iterables.stream(bridge.getAtlas().edgesIntersecting(bridge.bounds()))
-                    .filter(edge -> edge.isMasterEdge()
+                    .filter(edge -> edge.isMainEdge()
                             && edge.getOsmIdentifier() != bridge.getOsmIdentifier()
                             && !isFlagged(edge.getOsmIdentifier())
                             && isHighwayWithoutMaxHeight(edge)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheck.java
@@ -1,0 +1,153 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.BridgeTag;
+import org.openstreetmap.atlas.tags.CoveredTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.MaxHeightTag;
+import org.openstreetmap.atlas.tags.TunnelTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Flags highways (of certain classes) which should have a 'maxheight' or 'maxheight:*' tag but do
+ * not have either. This is a port of Osmose check #7130.<br>
+ * <b>Target objects:</b><br>
+ * 1. Tunnels<br>
+ * 2. Covered ways<br>
+ * 3. Ways passing under bridges<br>
+ * <b>Target highway classes:</b><br>
+ * MOTORWAY_LINK, TRUNK_LINK, PRIMARY, PRIMARY_LINK, SECONDARY, SECONDARY_LINK
+ *
+ * @author wlodarsk
+ */
+public class TunnelBridgeHeightLimitCheck extends BaseCheck<Long>
+{
+
+    private static final long serialVersionUID = 7912181047816225229L;
+
+    private static final String FALLBACK_INSTRUCTION_TEMPLATE = "Way {0,number,#} %s but vehicle height limit is not specified. Add a 'maxheight' or 'maxheight:physical' tag according to an existing legal or physical restriction.";
+    private static final int TUNNEL_CASE_INDEX = 0;
+    private static final int COVERED_CASE_INDEX = 1;
+    private static final int BRIDGE_CASE_INDEX = 2;
+    private static final List<String> FALLBACK_CASES = Arrays.asList("is a tunnel", "is covered",
+            "passes under bridge ({1,number,#})");
+    private static final List<String> FALLBACK_INSTRUCTIONS = FALLBACK_CASES.stream()
+            .map(caseDescription -> String.format(FALLBACK_INSTRUCTION_TEMPLATE, caseDescription))
+            .collect(Collectors.toList());
+    private static final String MAXHEIGHT_PHYSICAL = "maxheight:physical";
+
+    /**
+     * Default constructor.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public TunnelBridgeHeightLimitCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Edge && ((Edge) object).isMasterEdge()
+                && !isFlagged(object.getOsmIdentifier());
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        // case 1 (tunnel) & 2 (covered highway)
+        if ((TunnelTag.isTunnel(object) || isCovered(object)) && isHighwayWithoutMaxHeight(object))
+        {
+            final Long osmId = object.getOsmIdentifier();
+            markAsFlagged(osmId);
+            final int instructionIndex = TunnelTag.isTunnel(object) ? TUNNEL_CASE_INDEX
+                    : COVERED_CASE_INDEX;
+            return Optional
+                    .of(createFlag(object, getLocalizedInstruction(instructionIndex, osmId)));
+        }
+        // case 3 (road passing under bridge)
+        if (BridgeTag.isBridge(object))
+        {
+            final Edge bridge = (Edge) object;
+            final PolyLine bridgeAsPolyLine = bridge.asPolyLine();
+            final Set<Edge> edgesToFlag = new HashSet<>();
+            Iterables.stream(bridge.getAtlas().edgesIntersecting(bridge.bounds()))
+                    .filter(edge -> edge.isMasterEdge()
+                            && edge.getOsmIdentifier() != bridge.getOsmIdentifier()
+                            && !isFlagged(edge.getOsmIdentifier())
+                            && isHighwayWithoutMaxHeight(edge)
+                            && edgeCrossesBridge(edge.asPolyLine(), bridgeAsPolyLine))
+                    .forEach(edge ->
+                    {
+                        markAsFlagged(edge.getOsmIdentifier());
+                        edgesToFlag.add(edge);
+                    });
+            if (!edgesToFlag.isEmpty())
+            {
+                final CheckFlag checkFlag = new CheckFlag(getTaskIdentifier(bridge));
+                edgesToFlag.forEach(
+                        edge -> checkFlag.addObject(edge, getLocalizedInstruction(BRIDGE_CASE_INDEX,
+                                edge.getOsmIdentifier(), bridge.getOsmIdentifier())));
+                return Optional.of(checkFlag);
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    // check if the two polylines intersect at any location other than the bridge's endpoints
+    private boolean edgeCrossesBridge(final PolyLine edge, final PolyLine bridge)
+    {
+        return edge.intersections(bridge).stream()
+                .anyMatch(loc -> !loc.equals(bridge.first()) && !loc.equals(bridge.last()));
+    }
+
+    private boolean isCovered(final AtlasObject object)
+    {
+        return Validators.isOfType(object, CoveredTag.class, CoveredTag.YES, CoveredTag.ARCADE,
+                CoveredTag.COLONNADE);
+    }
+
+    private boolean isHighwayWithoutMaxHeight(final AtlasObject object)
+    {
+        return Validators.isOfType(object, HighwayTag.class, HighwayTag.MOTORWAY_LINK,
+                HighwayTag.TRUNK_LINK, HighwayTag.PRIMARY, HighwayTag.PRIMARY_LINK,
+                HighwayTag.SECONDARY, HighwayTag.SECONDARY_LINK)
+                && !Validators.hasValuesFor(object, MaxHeightTag.class)
+                && object.getTag(MAXHEIGHT_PHYSICAL).isEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheckTest.java
@@ -7,8 +7,6 @@ import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
-import com.google.common.collect.Iterables;
-
 /**
  * Test cases for {@link TunnelBridgeHeightLimitCheck}
  *
@@ -68,11 +66,11 @@ public class TunnelBridgeHeightLimitCheckTest
             Assert.assertEquals(1, flags.size());
             // task is created for the expected bridge object
             Assert.assertEquals("1000000001", flags.get(0).getIdentifier());
-            // only one edge is flagged
-            Assert.assertEquals(1, flags.get(0).getFlaggedObjects().size());
-            // the flagged edge has the expected OSM ID
-            Assert.assertEquals("4000", Iterables.getOnlyElement(flags.get(0).getFlaggedObjects())
-                    .getProperties().get("osmIdentifier"));
+            // both edges of the flagged Way are included
+            Assert.assertEquals(2, flags.get(0).getFlaggedObjects().size());
+            // both edges have the expected OSM ID
+            flags.get(0).getFlaggedObjects().forEach(object -> Assert.assertEquals("4000",
+                    object.getProperties().get("osmIdentifier")));
         });
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheckTest.java
@@ -1,0 +1,94 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+import com.google.common.collect.Iterables;
+
+/**
+ * Test cases for {@link TunnelBridgeHeightLimitCheck}
+ *
+ * @author ladwlo
+ */
+public class TunnelBridgeHeightLimitCheckTest
+{
+
+    @Rule
+    public TunnelBridgeHeightLimitCheckTestRule setup = new TunnelBridgeHeightLimitCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final Configuration inlineConfiguration = ConfigurationResolver
+            .inlineConfiguration("{\"TunnelBridgeHeightLimitCheck\":{}}");
+
+    @Test
+    public void bidirectionalTunnelWithoutMaxHeightIsFlaggedOnce()
+    {
+        this.verifier.actual(this.setup.getBidirectionalTunnelWithoutMaxHeight(),
+                new TunnelBridgeHeightLimitCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void bridgeWithoutCrossingRoadsIsIgnored()
+    {
+        this.verifier.actual(this.setup.getBridgeWithNoCrossingRoads(),
+                new TunnelBridgeHeightLimitCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void coveredRoadWithoutMaxHeightSplitIntoTwoEdgesIsFlaggedOnce()
+    {
+        this.verifier.actual(this.setup.getCoveredRoadWithoutMaxHeightSplitIntoTwoEdges(),
+                new TunnelBridgeHeightLimitCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void lowClassTunnelWithoutMaxHeightIsIgnored()
+    {
+        this.verifier.actual(this.setup.getLowClassTunnelWithoutMaxHeight(),
+                new TunnelBridgeHeightLimitCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void roadWithoutMaxHeightPassingUnderBridgeIsFlagged()
+    {
+        this.verifier.actual(this.setup.getRoadsPassingUnderBridge(),
+                new TunnelBridgeHeightLimitCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags ->
+        {
+            Assert.assertEquals(1, flags.size());
+            // task is created for the expected bridge object
+            Assert.assertEquals("1000000001", flags.get(0).getIdentifier());
+            // only one edge is flagged
+            Assert.assertEquals(1, flags.get(0).getFlaggedObjects().size());
+            // the flagged edge has the expected OSM ID
+            Assert.assertEquals("4000", Iterables.getOnlyElement(flags.get(0).getFlaggedObjects())
+                    .getProperties().get("osmIdentifier"));
+        });
+    }
+
+    @Test
+    public void tunnelAndCoveredRoadWithMaxHeightAreIgnored()
+    {
+        this.verifier.actual(this.setup.getTunnelAndCoveredRoadWithMaxHeight(),
+                new TunnelBridgeHeightLimitCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
+    public void uncoveredRoadWithoutMaxHeightIsIgnored()
+    {
+        this.verifier.actual(this.setup.getUncoveredRoadWithoutMaxHeight(),
+                new TunnelBridgeHeightLimitCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/TunnelBridgeHeightLimitCheckTestRule.java
@@ -1,0 +1,193 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import static org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import static org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import static org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+import org.openstreetmap.atlas.checks.base.checks.BaseTestRule;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * Test Atlases for {@link TunnelBridgeHeightLimitCheckTest}
+ *
+ * @author ladwlo
+ */
+public class TunnelBridgeHeightLimitCheckTestRule extends BaseTestRule
+{
+
+    // bridge or standalone road/tunnel
+    private static final String LOC_1 = "47.0,-122.1";
+    private static final String LOC_2 = "47.2,-122.1";
+    // crossing edge
+    private static final String LOC_3 = "47.1,-122.0";
+    private static final String LOC_4 = "47.1,-122.2";
+    // edge with multiple crossings; way split into two edges
+    private static final String LOC_5 = "47.0,-122.0";
+    private static final String LOC_6 = "47.1,-122.2";
+    private static final String LOC_7 = "47.2,-122.0";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOC_1)),
+                    @Node(coordinates = @Loc(value = LOC_2)) },
+            // edges
+            edges = { @Edge(
+                    // master
+                    id = "1000000001", coordinates = { @Loc(value = LOC_1),
+                            @Loc(value = LOC_2) }, tags = { "highway=primary", "tunnel=yes" }),
+                    @Edge(
+                            // reversed
+                            id = "-1000000001", coordinates = { @Loc(value = LOC_2),
+                                    @Loc(value = LOC_1) }, tags = { "highway=primary",
+                                            "tunnel=yes" }) })
+    // positive case; should only flag master edge
+    private Atlas bidirectionalTunnelWithoutMaxHeight;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOC_1)),
+                    @Node(coordinates = @Loc(value = LOC_2)),
+                    @Node(coordinates = @Loc(value = LOC_5)),
+                    @Node(coordinates = @Loc(value = LOC_7)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_1),
+                            @Loc(value = LOC_2) }, tags = { "highway=primary", "bridge=yes" }),
+                    @Edge(id = "2000000001", coordinates = { @Loc(value = LOC_5),
+                            @Loc(value = LOC_7) }, tags = { "highway=primary" }) })
+    // negative case: no edges with violations
+    private Atlas bridgeWithNoCrossingRoads;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOC_5)),
+                    @Node(coordinates = @Loc(value = LOC_6)),
+                    @Node(coordinates = @Loc(value = LOC_7)) },
+            // edges
+            edges = { @Edge(
+                    // first part of way #1
+                    id = "1000000001", coordinates = { @Loc(value = LOC_5),
+                            @Loc(value = LOC_6) }, tags = { "highway=primary", "covered=yes" }),
+                    @Edge(
+                            // second part of way #1
+                            id = "1000000002", coordinates = { @Loc(value = LOC_6),
+                                    @Loc(value = LOC_7) }, tags = { "highway=primary",
+                                            "covered=yes" }) })
+    // positive case; should only flag given OSM ID once
+    private Atlas coveredRoadWithoutMaxHeightSplitIntoTwoEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOC_1)),
+                    @Node(coordinates = @Loc(value = LOC_2)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_1),
+                    @Loc(value = LOC_2) }, tags = { "highway=tertiary", "tunnel=yes" }) })
+    // negative case: highway class does not match
+    private Atlas lowClassTunnelWithoutMaxHeight;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOC_1)),
+                    @Node(coordinates = @Loc(value = LOC_2)),
+                    @Node(coordinates = @Loc(value = LOC_3)),
+                    @Node(coordinates = @Loc(value = LOC_4)),
+                    @Node(coordinates = @Loc(value = LOC_5)),
+                    @Node(coordinates = @Loc(value = LOC_6)),
+                    @Node(coordinates = @Loc(value = LOC_7)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_1),
+                            @Loc(value = LOC_2) }, tags = { "highway=primary", "bridge=yes" }),
+                    // negative case: edge only touches the bridge (at one end)
+                    @Edge(id = "2000000001", coordinates = { @Loc(value = LOC_1),
+                            @Loc(value = LOC_5) }, tags = { "highway=primary" }),
+                    // negative case: not a master edge
+                    @Edge(id = "-2000000001", coordinates = { @Loc(value = LOC_5),
+                            @Loc(value = LOC_1) }, tags = { "highway=primary" }),
+                    // negative case: edge only touches the bridge (at the other end)
+                    @Edge(id = "3000000001", coordinates = { @Loc(value = LOC_2),
+                            @Loc(value = LOC_7) }, tags = { "highway=primary" }),
+                    // positive case: edge crosses the bridge
+                    @Edge(id = "4000000001", coordinates = { @Loc(value = LOC_5),
+                            @Loc(value = LOC_6),
+                            @Loc(value = LOC_7) }, tags = { "highway=primary" }),
+                    // negative case: edge with the same OSM ID already flagged
+                    @Edge(id = "4000000002", coordinates = { @Loc(value = LOC_7),
+                            @Loc(value = LOC_6),
+                            @Loc(value = LOC_5) }, tags = { "highway=primary" }),
+                    // negative case: edge crossed the bridge but has a low class
+                    @Edge(id = "5000000001", coordinates = { @Loc(value = LOC_5),
+                            @Loc(value = LOC_6) }, tags = { "highway=tertiary" }),
+                    // negative case: edge crosses the bridge but maxheight tag is present
+                    @Edge(id = "6000000001", coordinates = { @Loc(value = LOC_6),
+                            @Loc(value = LOC_7) }, tags = { "highway=primary", "maxheight=3.5" }) })
+    // positive, should only flag one edge that matches all conditions
+    private Atlas roadsPassingUnderBridge;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOC_5)),
+                    @Node(coordinates = @Loc(value = LOC_6)),
+                    @Node(coordinates = @Loc(value = LOC_7)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_5),
+                            @Loc(value = LOC_6) }, tags = { "highway=primary", "tunnel=yes",
+                                    "maxheight=4.0" }),
+                    @Edge(id = "2000000001", coordinates = { @Loc(value = LOC_6),
+                            @Loc(value = LOC_7) }, tags = { "highway=primary", "covered=yes",
+                                    "maxheight:physical=3.8" }) })
+    // negative case: has maxheight
+    private Atlas tunnelAndCoveredRoadWithMaxHeight;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOC_5)),
+                    @Node(coordinates = @Loc(value = LOC_6)),
+                    @Node(coordinates = @Loc(value = LOC_7)) },
+            // edges - two cases: one with covered=no and another without any covered tag
+            edges = {
+                    @Edge(id = "1000000001", coordinates = { @Loc(value = LOC_5),
+                            @Loc(value = LOC_6) }, tags = { "highway=primary", "covered=no" }),
+                    @Edge(id = "2000000001", coordinates = { @Loc(value = LOC_6),
+                            @Loc(value = LOC_7) }, tags = { "highway=primary" }) })
+    // negative case: is not covered
+    private Atlas uncoveredRoadWithoutMaxHeight;
+
+    public Atlas getBidirectionalTunnelWithoutMaxHeight()
+    {
+        return this.bidirectionalTunnelWithoutMaxHeight;
+    }
+
+    public Atlas getBridgeWithNoCrossingRoads()
+    {
+        return this.bridgeWithNoCrossingRoads;
+    }
+
+    public Atlas getCoveredRoadWithoutMaxHeightSplitIntoTwoEdges()
+    {
+        return this.coveredRoadWithoutMaxHeightSplitIntoTwoEdges;
+    }
+
+    public Atlas getLowClassTunnelWithoutMaxHeight()
+    {
+        return this.lowClassTunnelWithoutMaxHeight;
+    }
+
+    public Atlas getRoadsPassingUnderBridge()
+    {
+        return this.roadsPassingUnderBridge;
+    }
+
+    public Atlas getTunnelAndCoveredRoadWithMaxHeight()
+    {
+        return this.tunnelAndCoveredRoadWithMaxHeight;
+    }
+
+    public Atlas getUncoveredRoadWithoutMaxHeight()
+    {
+        return this.uncoveredRoadWithoutMaxHeight;
+    }
+}


### PR DESCRIPTION
### Description:

Port of Osmose check #7130. Flags tunnels, covered roads and roads crossing bridges, for which maxheight or maxheight:physical tag is not provided.
Issue #343

### Potential Impact:

None.

### Unit Test Approach:

Unit tests created for each of the three positive scenarios (a tunnel, a covered road and a road which passes under a bridge) and several negative scenarios (when some of the preconditions or check criteria are not met). Tests use local mini-atlases with artificial data.

### Test Results:

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
| NZL | 307 | 77 | 25% | 77 | 0 | 0% |
| DNK | 568 | 127 | 22% | 127 | 0 | 0% |
| ARG | 734 | 110 | 15% | 110 | 0 | 0% |
| LUX | 199 | 50 | 25% | 50 | 0 | 0% |
| VNM | 772 | 80 | 10% | 80 | 0 | 0% |