### PR TITLE
CHECKSTYLE: Ensure methods have `this` qualifier

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -110,7 +110,7 @@
         <module name="PackageDeclaration"/>
         <module name="ParameterAssignment"/>
         <module name="RequireThis">
-            <property name="checkMethods" value="false"/>
+            <property name="checkMethods" value="true"/>
             <property name="validateOnlyOverlapping" value="false"/>
         </module>
         <module name="SimplifyBooleanExpression" />

--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -77,18 +77,18 @@ public abstract class BaseCheck<T> implements Check, Serializable
      */
     public BaseCheck(final Configuration configuration)
     {
-        this.acceptPiers = configurationValue(configuration, PARAMETER_ACCEPT_PIERS, false);
-        this.countries = Collections.unmodifiableList(configurationValue(configuration,
+        this.acceptPiers = this.configurationValue(configuration, PARAMETER_ACCEPT_PIERS, false);
+        this.countries = Collections.unmodifiableList(this.configurationValue(configuration,
                 PARAMETER_PERMITLIST_COUNTRIES, Collections.emptyList()));
-        this.denylistCountries = Collections.unmodifiableList(configurationValue(configuration,
+        this.denylistCountries = Collections.unmodifiableList(this.configurationValue(configuration,
                 PARAMETER_DENYLIST_COUNTRIES, Collections.emptyList()));
-        this.tagFilter = TaggableFilter
-                .forDefinition(configurationValue(configuration, PARAMETER_PERMITLIST_TAGS, ""));
-        final Map<String, String> challengeMap = configurationValue(configuration,
+        this.tagFilter = TaggableFilter.forDefinition(
+                this.configurationValue(configuration, PARAMETER_PERMITLIST_TAGS, ""));
+        final Map<String, String> challengeMap = this.configurationValue(configuration,
                 PARAMETER_CHALLENGE, Collections.emptyMap());
-        this.flagLanguageMap = configurationValue(configuration, PARAMETER_FLAG,
+        this.flagLanguageMap = this.configurationValue(configuration, PARAMETER_FLAG,
                 Collections.emptyMap());
-        this.locale = configurationValue(configuration, PARAMETER_LOCALE_KEY,
+        this.locale = this.configurationValue(configuration, PARAMETER_LOCALE_KEY,
                 DEFAULT_LOCALE.getLanguage(), Locale::new);
         if (challengeMap.isEmpty())
         {
@@ -103,14 +103,14 @@ public abstract class BaseCheck<T> implements Check, Serializable
         }
         this.globalPolygonFilter = AtlasEntityPolygonsFilter.forConfiguration(configuration);
         this.checkPolygonFilter = AtlasEntityPolygonsFilter.forConfigurationValues(
-                configurationValue(configuration, AtlasEntityPolygonsFilter.INCLUDED_POLYGONS_KEY,
-                        Collections.emptyMap()),
-                configurationValue(configuration,
+                this.configurationValue(configuration,
+                        AtlasEntityPolygonsFilter.INCLUDED_POLYGONS_KEY, Collections.emptyMap()),
+                this.configurationValue(configuration,
                         AtlasEntityPolygonsFilter.INCLUDED_MULTIPOLYGONS_KEY,
                         Collections.emptyMap()),
-                configurationValue(configuration, AtlasEntityPolygonsFilter.EXCLUDED_POLYGONS_KEY,
-                        Collections.emptyMap()),
-                configurationValue(configuration,
+                this.configurationValue(configuration,
+                        AtlasEntityPolygonsFilter.EXCLUDED_POLYGONS_KEY, Collections.emptyMap()),
+                this.configurationValue(configuration,
                         AtlasEntityPolygonsFilter.EXCLUDED_MULTIPOLYGONS_KEY,
                         Collections.emptyMap()));
     }
@@ -150,7 +150,7 @@ public abstract class BaseCheck<T> implements Check, Serializable
     @Override
     public void clear()
     {
-        clearFlaggedIdentifiers();
+        this.clearFlaggedIdentifiers();
     }
 
     @Override
@@ -293,7 +293,7 @@ public abstract class BaseCheck<T> implements Check, Serializable
 
     protected final String configurationKey(final Class<?> type, final String key)
     {
-        return formatKey(type.getSimpleName(), key);
+        return this.formatKey(type.getSimpleName(), key);
     }
 
     /**
@@ -305,19 +305,19 @@ public abstract class BaseCheck<T> implements Check, Serializable
      */
     protected final String configurationKey(final String key)
     {
-        return formatKey(getCheckName(), key);
+        return this.formatKey(this.getCheckName(), key);
     }
 
     protected <U> U configurationValue(final Configuration configuration, final String key,
             final U defaultValue)
     {
-        return configuration.get(configurationKey(key), defaultValue).value();
+        return configuration.get(this.configurationKey(key), defaultValue).value();
     }
 
     protected <U, V> V configurationValue(final Configuration configuration, final String key,
             final U defaultValue, final Function<U, V> transform)
     {
-        return configuration.get(configurationKey(key), defaultValue, transform).value();
+        return configuration.get(this.configurationKey(key), defaultValue, transform).value();
     }
 
     protected CheckFlag createFlag(final AtlasObject object, final String instruction)

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -139,12 +139,12 @@ public class CheckResourceLoader
 
     public <T extends Check> Set<T> loadChecks(final Predicate<Class> isEnabled)
     {
-        return loadChecks(isEnabled, this.configuration);
+        return this.loadChecks(isEnabled, this.configuration);
     }
 
     public <T extends Check> Set<T> loadChecks(final Configuration configuration)
     {
-        return loadChecks(this::isEnabledByConfiguration, configuration);
+        return this.loadChecks(this::isEnabledByConfiguration, configuration);
     }
 
     /**
@@ -178,13 +178,13 @@ public class CheckResourceLoader
      */
     public <T extends Check> Set<T> loadChecks()
     {
-        return loadChecks(this::isEnabledByConfiguration, this.configuration);
+        return this.loadChecks(this::isEnabledByConfiguration, this.configuration);
     }
 
     public <T extends Check> Set<T> loadChecksForCountry(final String country)
     {
         final Configuration countryConfiguration = this.getConfigurationForCountry(country);
-        return loadChecks(checkClass -> this.isEnabledByConfiguration(countryConfiguration,
+        return this.loadChecks(checkClass -> this.isEnabledByConfiguration(countryConfiguration,
                 checkClass, country), countryConfiguration);
     }
 
@@ -303,7 +303,7 @@ public class CheckResourceLoader
 
     private boolean isEnabledByConfiguration(final Class checkClass)
     {
-        return isEnabledByConfiguration(this.configuration, checkClass);
+        return this.isEnabledByConfiguration(this.configuration, checkClass);
     }
 
     private boolean isEnabledByConfiguration(final Configuration configuration,

--- a/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/FlagStatisticsSubCommand.java
@@ -107,12 +107,13 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
             // Write the counts for the input logs is requested
             if (outputTypes.contains(OutputTypes.RUN_SUMMARY.toString()))
             {
-                this.writeCSV(outputFolder + "/runSummary.csv", generateFullOutput(inputCounts));
+                this.writeCSV(outputFolder + "/runSummary.csv",
+                        this.generateFullOutput(inputCounts));
             }
             // Generate the totals output
-            List<List<String>> totalsOutput = generateTotalsOutput(inputCounts);
+            List<List<String>> totalsOutput = this.generateTotalsOutput(inputCounts);
             // Generate the counts output if requested
-            List<List<String>> countsOutput = generateCountsOutput(inputCounts);
+            List<List<String>> countsOutput = this.generateCountsOutput(inputCounts);
 
             // Get the optional reference input
             final Optional<String> referenceFilePath = this.optionAndArgumentDelegate
@@ -132,14 +133,14 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
                 if (outputTypes.contains(OutputTypes.RUN_SUMMARY.toString()))
                 {
                     this.writeCSV(outputFolder + "/runSummaryDifference.csv",
-                            generateFullOutput(differenceCounts));
+                            this.generateFullOutput(differenceCounts));
                 }
 
                 // Add the reference and difference metrics to the totals output
-                totalsOutput = addReferenceAndDifferenceToTotalsOutput(totalsOutput,
+                totalsOutput = this.addReferenceAndDifferenceToTotalsOutput(totalsOutput,
                         referenceCounts, differenceCounts);
                 // Add the reference and difference metrics to the counts output
-                countsOutput = addReferenceAndDifferenceToCountsOutput(countsOutput,
+                countsOutput = this.addReferenceAndDifferenceToCountsOutput(countsOutput,
                         referenceCounts, differenceCounts);
             }
 
@@ -232,15 +233,16 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
         for (int index = 1; index < outputLines.size(); index++)
         {
             // Get the reference value for the country and check
-            final Optional<Long> referenceCount = getCountryCheckCount(referenceCountryCheckCounts,
-                    stage1Output.get(index).get(0), stage1Output.get(index).get(1));
+            final Optional<Long> referenceCount = this.getCountryCheckCount(
+                    referenceCountryCheckCounts, stage1Output.get(index).get(0),
+                    stage1Output.get(index).get(1));
             // Append the value or an empty string
             stage1Output.get(index).add(2,
                     referenceCount.isPresent() ? String.valueOf(referenceCount.get())
                             : EMPTY_STRING);
 
             // Get the difference value for the country and check
-            final Optional<Long> differenceCount = getCountryCheckCount(diffCountryCheckCounts,
+            final Optional<Long> differenceCount = this.getCountryCheckCount(diffCountryCheckCounts,
                     stage1Output.get(index).get(0), stage1Output.get(index).get(1));
             // Append the value or an empty string
             stage1Output.get(index)
@@ -285,10 +287,10 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
             final String check = outputLines.get(index).get(0);
             // Add the reference total
             outputLines.get(index).add(1,
-                    String.valueOf(getCheckTotal(referenceCountryCheckCounts, check)));
+                    String.valueOf(this.getCheckTotal(referenceCountryCheckCounts, check)));
             // Add the difference total
             outputLines.get(index)
-                    .add(String.valueOf(getCheckTotal(diffCountryCheckCounts, check)));
+                    .add(String.valueOf(this.getCheckTotal(diffCountryCheckCounts, check)));
         }
 
         return outputLines;
@@ -334,7 +336,8 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
             countryCheckRow.add(check);
 
             // Get the optional country check count
-            final Optional<Long> count = getCountryCheckCount(countryCheckCounts, country, check);
+            final Optional<Long> count = this.getCountryCheckCount(countryCheckCounts, country,
+                    check);
             if (count.isPresent())
             {
                 // If present add the value
@@ -390,7 +393,7 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
             // Get the value of the check for each country
             checkRow.addAll(countries.stream().map(country ->
             {
-                final Optional<Long> count = getCountryCheckCount(countryCheckCounts, country,
+                final Optional<Long> count = this.getCountryCheckCount(countryCheckCounts, country,
                         check);
 
                 if (count.isPresent())
@@ -401,7 +404,7 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
                 return EMPTY_STRING;
             }).collect(Collectors.toList()));
             // Get the total count for this check across all countries
-            checkRow.add(String.valueOf(getCheckTotal(countryCheckCounts, check)));
+            checkRow.add(String.valueOf(this.getCheckTotal(countryCheckCounts, check)));
             outputLines.add(checkRow);
         });
 
@@ -455,7 +458,7 @@ public class FlagStatisticsSubCommand extends AbstractAtlasShellToolsCommand
             // Add the check name
             checkRow.add(check);
             // Add the total count
-            checkRow.add(String.valueOf(getCheckTotal(countryCheckCounts, check)));
+            checkRow.add(String.valueOf(this.getCheckTotal(countryCheckCounts, check)));
             outputLines.add(checkRow);
         });
 

--- a/src/main/java/org/openstreetmap/atlas/checks/commands/JSONFlagDiffSubCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/commands/JSONFlagDiffSubCommand.java
@@ -89,11 +89,11 @@ public abstract class JSONFlagDiffSubCommand implements FlexibleSubCommand
                 .getOption(OUTPUT_FOLDER_PARAMETER);
         if (output.isPresent())
         {
-            writeSetToGeoJSON(additions,
+            this.writeSetToGeoJSON(additions,
                     new File(String.format("%s/additions-%d-%d.%s", output.get(),
                             new Date().getTime(), this.countMapValues(additions),
                             this.fileExtension)));
-            writeSetToGeoJSON(subtractions,
+            this.writeSetToGeoJSON(subtractions,
                     new File(String.format("%s/subtractions-%d-%d.%s", output.get(),
                             new Date().getTime(), this.countMapValues(subtractions),
                             this.fileExtension)));
@@ -197,9 +197,9 @@ public abstract class JSONFlagDiffSubCommand implements FlexibleSubCommand
     protected int getReferenceSize()
     {
         int sourceSize = 0;
-        for (final String check : getReference().keySet())
+        for (final String check : this.getReference().keySet())
         {
-            sourceSize += getReference().get(check).size();
+            sourceSize += this.getReference().get(check).size();
         }
         return sourceSize;
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/AtlasDataSource.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/AtlasDataSource.java
@@ -115,7 +115,7 @@ public class AtlasDataSource implements Serializable, AutoCloseable
      */
     public Atlas load(final String input, final String country)
     {
-        return load(input, country, intermediateAtlas ->
+        return this.load(input, country, intermediateAtlas ->
         {
         });
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
@@ -138,8 +138,8 @@ public class IntegrityCheckSparkJob extends IntegrityChecksCommandArguments
     public void start(final CommandMap commandMap)
     {
         final String atlasDirectory = (String) commandMap.get(ATLAS_FOLDER);
-        final String input = Optional.ofNullable(input(commandMap)).orElse(atlasDirectory);
-        final String output = output(commandMap);
+        final String input = Optional.ofNullable(this.input(commandMap)).orElse(atlasDirectory);
+        final String output = this.output(commandMap);
         @SuppressWarnings("unchecked")
         final Set<OutputFormats> outputFormats = (Set<OutputFormats>) commandMap
                 .get(OUTPUT_FORMATS);
@@ -170,11 +170,11 @@ public class IntegrityCheckSparkJob extends IntegrityChecksCommandArguments
         final boolean compressOutput = Boolean
                 .parseBoolean((String) commandMap.get(SparkJob.COMPRESS_OUTPUT));
 
-        final Map<String, String> sparkContext = configurationMap();
+        final Map<String, String> sparkContext = this.configurationMap();
         final CheckResourceLoader checkLoader = new CheckResourceLoader(checksConfiguration);
         // check configuration and country list
         final Set<BaseCheck<?>> preOverriddenChecks = checkLoader.loadChecks();
-        if (!isValidInput(countries, preOverriddenChecks))
+        if (!this.isValidInput(countries, preOverriddenChecks))
         {
             logger.error("No countries supplied or checks enabled, exiting!");
             return;
@@ -204,7 +204,7 @@ public class IntegrityCheckSparkJob extends IntegrityChecksCommandArguments
         logger.info("Initialized checks: {}", infoMessage2);
 
         // Parallelize on the countries
-        final JavaPairRDD<String, Set<BaseCheck>> countryCheckRDD = getContext()
+        final JavaPairRDD<String, Set<BaseCheck>> countryCheckRDD = this.getContext()
                 .parallelizePairs(countryCheckTuples, countryCheckTuples.size());
 
         // Set target and temporary folders
@@ -378,11 +378,11 @@ public class IntegrityCheckSparkJob extends IntegrityChecksCommandArguments
     @Override
     protected List<String> outputToClean(final CommandMap command)
     {
-        final String output = output(command);
+        final String output = this.output(command);
         final List<String> staticPaths = super.outputToClean(command);
-        staticPaths.add(getAlternateSubFolderOutput(output, OUTPUT_FLAG_FOLDER));
-        staticPaths.add(getAlternateSubFolderOutput(output, OUTPUT_GEOJSON_FOLDER));
-        staticPaths.add(getAlternateSubFolderOutput(output, OUTPUT_ATLAS_FOLDER));
+        staticPaths.add(this.getAlternateSubFolderOutput(output, OUTPUT_FLAG_FOLDER));
+        staticPaths.add(this.getAlternateSubFolderOutput(output, OUTPUT_GEOJSON_FOLDER));
+        staticPaths.add(this.getAlternateSubFolderOutput(output, OUTPUT_ATLAS_FOLDER));
         return staticPaths;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -106,10 +106,10 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
     {
         final Time start = Time.now();
         final String atlasDirectory = (String) commandMap.get(ATLAS_FOLDER);
-        final String input = Optional.ofNullable(input(commandMap)).orElse(atlasDirectory);
+        final String input = Optional.ofNullable(this.input(commandMap)).orElse(atlasDirectory);
 
         // Gather arguments
-        final String output = output(commandMap);
+        final String output = this.output(commandMap);
         @SuppressWarnings("unchecked")
         final Set<OutputFormats> outputFormats = (Set<OutputFormats>) commandMap
                 .get(OUTPUT_FORMATS);
@@ -131,7 +131,7 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
                                 .orElse(ConfigurationResolver.emptyConfiguration())))
                 .collect(Collectors.toList()));
 
-        final Map<String, String> sparkContext = configurationMap();
+        final Map<String, String> sparkContext = this.configurationMap();
 
         // File loading helpers
         final AtlasFilePathResolver resolver = new AtlasFilePathResolver(checksConfiguration);
@@ -209,12 +209,12 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
                             .format("Running checks on %s", tasksForCountry.get(0).getCountry()));
 
                     this.getContext().parallelize(tasksForCountry, tasksForCountry.size())
-                            .mapToPair(produceFlags(input, output, this.configurationMap(),
+                            .mapToPair(this.produceFlags(input, output, this.configurationMap(),
                                     fileHelper, shardingBroadcast, distanceToLoadShards,
                                     (Boolean) commandMap.get(MULTI_ATLAS)))
                             .reduceByKey(UniqueCheckFlagContainer::combine)
                             // Generate outputs
-                            .foreach(processFlags(output, fileHelper, outputFormats));
+                            .foreach(this.processFlags(output, fileHelper, outputFormats));
                 });
             }
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -342,7 +342,7 @@ public final class CheckFlagEvent extends Event
 
     public String asLineDelimitedGeoJsonFeatures()
     {
-        return asLineDelimitedGeoJsonFeatures(jsonObject ->
+        return this.asLineDelimitedGeoJsonFeatures(jsonObject ->
         {
         });
     }
@@ -352,8 +352,8 @@ public final class CheckFlagEvent extends Event
         final JsonObject flagGeoJsonFeature = this.flag.asGeoJsonFeature();
         final JsonObject flagGeoJsonProperties = flagGeoJsonFeature.get("properties")
                 .getAsJsonObject();
-        flagGeoJsonProperties.addProperty("flag:check", getCheckName());
-        flagGeoJsonProperties.addProperty("flag:timestamp", getTimestamp().toString());
+        flagGeoJsonProperties.addProperty("flag:check", this.getCheckName());
+        flagGeoJsonProperties.addProperty("flag:timestamp", this.getTimestamp().toString());
 
         jsonMutator.accept(flagGeoJsonFeature);
 

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessor.java
@@ -93,7 +93,7 @@ public final class CheckFlagGeoJsonProcessor implements Processor<CheckFlagEvent
             bucketLock.readLock().unlock();
         }
 
-        final int batchSize = computeBatchSize();
+        final int batchSize = this.computeBatchSize();
         if (featureBucket.size() >= batchSize)
         {
             bucketLock.writeLock().lock();

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -106,9 +106,9 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     public CheckFlag(final String identifier, final Set<? extends AtlasObject> objects,
             final List<String> instructions, final List<Location> points)
     {
-        addObjects(objects);
-        addPoints(points);
-        addInstructions(instructions);
+        this.addObjects(objects);
+        this.addPoints(points);
+        this.addInstructions(instructions);
         this.identifier = identifier;
     }
 
@@ -234,12 +234,12 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 
     public JsonObject asGeoJsonFeature()
     {
-        final JsonObject geometry = boundsGeoJsonGeometry();
+        final JsonObject geometry = this.boundsGeoJsonGeometry();
 
         final JsonObject properties = new JsonObject();
         properties.addProperty("flag:type", CheckFlag.class.getSimpleName());
-        properties.addProperty("flag:id", getIdentifier());
-        properties.addProperty("flag:instructions", getInstructions());
+        properties.addProperty("flag:id", this.getIdentifier());
+        properties.addProperty("flag:instructions", this.getInstructions());
 
         // The legacy GeoJSON FeatureCollection doesn't actually provide this,
         // but I figure this might be useful to know about if it's there...
@@ -376,14 +376,14 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         task.setTaskIdentifier(this.identifier);
 
         // Add custom pin point(s), if supplied.
-        final Set<Location> points = getPoints();
+        final Set<Location> points = this.getPoints();
         if (!points.isEmpty())
         {
             task.setPoints(points);
         }
         else
         {
-            final Set<PolyLine> polyLines = getPolyLines();
+            final Set<PolyLine> polyLines = this.getPolyLines();
             if (!polyLines.isEmpty())
             {
                 // Retrieve the first item in the list and retrieve the first point in the
@@ -435,7 +435,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
      */
     public Iterable<Iterable<Location>> getShapes()
     {
-        return Iterables.asIterable(getPolyLines().stream()
+        return Iterables.asIterable(this.getPolyLines().stream()
                 .map(polyLine -> (Iterable<Location>) polyLine).collect(Collectors.toList()));
     }
 
@@ -466,7 +466,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     @Override
     public Iterator<Location> iterator()
     {
-        return new MultiIterable<>(getShapes()).iterator();
+        return new MultiIterable<>(this.getShapes()).iterator();
     }
 
     /**
@@ -496,7 +496,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         try (BufferedWriter out = new BufferedWriter(
                 new OutputStreamWriter(writableResource.write(), StandardCharsets.UTF_8)))
         {
-            out.write(toString());
+            out.write(this.toString());
         }
         catch (final Exception e)
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedObject.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedObject.java
@@ -87,7 +87,7 @@ public abstract class FlaggedObject implements Serializable, Located
      */
     public boolean hasCountry()
     {
-        return !getCountry().equals(COUNTRY_MISSING);
+        return !this.getCountry().equals(COUNTRY_MISSING);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPoint.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPoint.java
@@ -51,7 +51,7 @@ public class FlaggedPoint extends FlaggedObject
     {
         this.locationItem = locationItem;
         this.point = locationItem.getLocation();
-        this.properties = initProperties(locationItem);
+        this.properties = this.initProperties(locationItem);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPolyline.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedPolyline.java
@@ -55,8 +55,8 @@ public class FlaggedPolyline extends FlaggedObject
         {
             this.polyLine = new PolyLine(atlasItem.getRawGeometry());
         }
-        this.properties = initProperties(atlasItem);
-        this.country = initCountry(atlasItem);
+        this.properties = this.initProperties(atlasItem);
+        this.country = this.initCountry(atlasItem);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -43,16 +43,16 @@ public class FlaggedRelation extends FlaggedObject
     public FlaggedRelation(final Relation relation)
     {
         this.relation = relation;
-        this.properties = initProperties(relation);
-        this.country = initCountry(relation);
+        this.properties = this.initProperties(relation);
+        this.country = this.initCountry(relation);
         this.multipolygonGeometry = this.relationGeometry(relation);
     }
 
     public FlaggedRelation(final Relation relation, final MultiPolygon geoJsonGeometry)
     {
         this.relation = relation;
-        this.properties = initProperties(relation);
-        this.country = initCountry(relation);
+        this.properties = this.initProperties(relation);
+        this.country = this.initCountry(relation);
         this.multipolygonGeometry = geoJsonGeometry;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
@@ -136,7 +136,7 @@ public class MapRouletteClient implements Serializable
         {
             task.setChallengeName(challenge.getName());
         }
-        updateChallengeTaskList(challenge, task, projectConfiguration);
+        this.updateChallengeTaskList(challenge, task, projectConfiguration);
     }
 
     public int getCurrentBatchSize()
@@ -184,7 +184,7 @@ public class MapRouletteClient implements Serializable
             final long challengeId = this.connection.createChallenge(project, challenge);
             if (challengeId != -1 && project.getId() != -1)
             {
-                writeChallengeIdsToFile(challengeId, project.getId());
+                this.writeChallengeIdsToFile(challengeId, project.getId());
             }
             challenge.setId(challengeId);
             challengeMap.put(challenge.getName(), challenge);

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -103,7 +103,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
             }
         }
         this.mapRouletteClient.setOutputPath((Optional<String>) commandMap.getOption(OUTPUT_PATH));
-        execute(commandMap, mapRoulette);
+        this.execute(commandMap, mapRoulette);
         return 0;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -50,7 +50,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
 
     MapRouletteConnection(final MapRouletteConfiguration configuration)
     {
-        if (configuration == null || !isAbleToConnectToMapRoulette(configuration))
+        if (configuration == null || !this.isAbleToConnectToMapRoulette(configuration))
         {
             throw new IllegalArgumentException(
                     "configuration can't be null and must be able to connect to MapRouletteServers to create a connection.");
@@ -146,7 +146,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         final String type = challengeJson.has(Survey.KEY_ANSWERS) ? KEY_SURVEY : KEY_CHALLENGE;
         final String encodedChallengeQuery = URLEncoder
                 .encode(challenge.getName(), StandardCharsets.UTF_8).replace("+", "%20");
-        return create(
+        return this.create(
                 String.format("/api/v2/project/%d/challenge/%s", project.getId(),
                         encodedChallengeQuery),
                 String.format("/api/v2/%s", type), String.format("/api/v2/%s/", type) + "%s",
@@ -158,7 +158,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     public long createProject(final Project project)
             throws UnsupportedEncodingException, URISyntaxException
     {
-        return create(String.format("/api/v2/projectByName/%s", project.getName()),
+        return this.create(String.format("/api/v2/projectByName/%s", project.getName()),
                 "/api/v2/project", "/api/v2/project/%s", project.toJson(),
                 String.format("Created/Updated Project with ID {} and name %s", project.getName()));
     }
@@ -190,7 +190,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         {
             endIndex = Math.min(startIndex + MAXIMUM_BATCH_SIZE, uniqueTasks.size());
             final List<Task> uploadList = uniqueTasks.subList(startIndex, endIndex);
-            succeeded &= internalUploadBatchTasks(challengeId, uploadList);
+            succeeded &= this.internalUploadBatchTasks(challengeId, uploadList);
             startIndex += MAXIMUM_BATCH_SIZE;
         }
         while (endIndex != uniqueTasks.size() - 1 && startIndex < uniqueTasks.size());
@@ -204,7 +204,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         final String challengeName = task.getChallengeName();
         final String taskIdentifier = task.getTaskIdentifier();
         logger.debug("Uploading task {} for challenge {}", taskIdentifier, challengeName);
-        return uploadTask(challengeId, Collections.singletonList(task), true);
+        return this.uploadTask(challengeId, Collections.singletonList(task), true);
     }
 
     private boolean internalUploadBatchTasks(final long parentChallengeId, final List<Task> data)
@@ -216,7 +216,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         }
         logger.debug("Uploading batch of {} tasks for project/challenge {}/{}", data.size(),
                 data.get(0).getProjectName(), data.get(0).getChallengeName());
-        return uploadTask(parentChallengeId, data, true);
+        return this.uploadTask(parentChallengeId, data, true);
     }
 
     private boolean isAbleToConnectToMapRoulette(final MapRouletteConfiguration configuration)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.checks.maproulette;
 
-import static org.openstreetmap.atlas.checks.utility.FileUtility.LogOutputFileType;
 import static org.openstreetmap.atlas.geography.geojson.GeoJsonConstants.PROPERTIES;
 
 import java.io.BufferedReader;
@@ -23,6 +22,7 @@ import org.openstreetmap.atlas.checks.maproulette.data.Task;
 import org.openstreetmap.atlas.checks.maproulette.serializer.ChallengeDeserializer;
 import org.openstreetmap.atlas.checks.maproulette.serializer.TaskDeserializer;
 import org.openstreetmap.atlas.checks.utility.FileUtility;
+import org.openstreetmap.atlas.checks.utility.FileUtility.LogOutputFileType;
 import org.openstreetmap.atlas.locale.IsoCountry;
 import org.openstreetmap.atlas.streaming.resource.File;
 import org.openstreetmap.atlas.tags.ISOCountryTag;
@@ -199,7 +199,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             final String checkinCommentPrefix, final String checkinComment)
     {
         final Map<String, String> challengeMap = fallbackConfiguration
-                .get(getChallengeParameter(checkName), Collections.emptyMap()).value();
+                .get(this.getChallengeParameter(checkName), Collections.emptyMap()).value();
         final Gson gson = new GsonBuilder().disableHtmlEscaping()
                 .registerTypeAdapter(Challenge.class, new ChallengeDeserializer()).create();
         final Challenge result = gson.fromJson(gson.toJson(challengeMap), Challenge.class);

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Task.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Task.java
@@ -100,9 +100,9 @@ public class Task
         final JsonObject task = new JsonObject();
         final JsonObject result = new JsonObject();
         result.addProperty(TASK_TYPE, "FeatureCollection");
-        result.add(TASK_FEATURES, generateTaskFeatures(this.points, this.geoJson));
+        result.add(TASK_FEATURES, this.generateTaskFeatures(this.points, this.geoJson));
         task.add(TASK_INSTRUCTION, new JsonPrimitive(this.instruction));
-        task.add(TASK_NAME, new JsonPrimitive(getTaskIdentifier()));
+        task.add(TASK_NAME, new JsonPrimitive(this.getTaskIdentifier()));
         task.add(TASK_PARENT_ID, new JsonPrimitive(parentIdentifier));
         task.add(TASK_GEOMETRIES, result);
         return task;

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/ElevationUtilities.java
@@ -125,12 +125,12 @@ public final class ElevationUtilities implements Serializable
      */
     public short getElevation(final Location location)
     {
-        final short[][] map = getMap(location);
+        final short[][] map = this.getMap(location);
         if (Arrays.equals(EMPTY_MAP, map))
         {
             return NO_ELEVATION;
         }
-        final int[] index = getIndex(location, map.length);
+        final int[] index = this.getIndex(location, map.length);
         return map[index[0]][index[1]];
     }
 
@@ -147,8 +147,8 @@ public final class ElevationUtilities implements Serializable
      */
     public double getIncline(final Location start, final Location end)
     {
-        final short startElevation = getElevation(start);
-        final short endElevation = getElevation(end);
+        final short startElevation = this.getElevation(start);
+        final short endElevation = this.getElevation(end);
         if (startElevation == NO_ELEVATION || endElevation == NO_ELEVATION)
         {
             return Double.NaN;
@@ -205,7 +205,7 @@ public final class ElevationUtilities implements Serializable
         final int lat = (int) Math.floor(latDegrees);
         final int lon = (int) Math.floor(lonDegrees);
         return this.loadedSrtm.computeIfAbsent(Pair.of(lat, lon),
-                pair -> loadMap(pair.getLeft(), pair.getRight()));
+                pair -> this.loadMap(pair.getLeft(), pair.getRight()));
     }
 
     /**
@@ -217,7 +217,7 @@ public final class ElevationUtilities implements Serializable
      */
     public Distance getResolution(final Location location)
     {
-        final short[][] map = getMap(location);
+        final short[][] map = this.getMap(location);
         if (Arrays.equals(EMPTY_MAP, map))
         {
             return Distance.MAXIMUM;
@@ -270,12 +270,12 @@ public final class ElevationUtilities implements Serializable
      */
     public boolean inSameDataPoint(final Location one, final Location two)
     {
-        final short[][] mapOne = getMap(one);
-        final short[][] mapTwo = getMap(two);
+        final short[][] mapOne = this.getMap(one);
+        final short[][] mapTwo = this.getMap(two);
         if (Arrays.equals(mapOne, mapTwo) && !Arrays.equals(EMPTY_MAP, mapOne))
         {
-            final int[] indexOne = getIndex(one, mapOne.length);
-            final int[] indexTwo = getIndex(two, mapTwo.length);
+            final int[] indexOne = this.getIndex(one, mapOne.length);
+            final int[] indexTwo = this.getIndex(two, mapTwo.length);
             if (Arrays.equals(indexOne, indexTwo))
             {
                 return true;
@@ -314,7 +314,7 @@ public final class ElevationUtilities implements Serializable
      */
     private synchronized short[][] loadMap(final int lat, final int lon)
     {
-        final String filename = getSrtmFileName(lat, lon);
+        final String filename = this.getSrtmFileName(lat, lon);
         Path path = Paths.get(this.srtmPath, filename);
         if (!path.toFile().isFile())
         {
@@ -334,7 +334,7 @@ public final class ElevationUtilities implements Serializable
         try (InputStream is = CompressionUtilities
                 .getUncompressedInputStream(Files.newInputStream(path)))
         {
-            return readStream(is);
+            return this.readStream(is);
         }
         catch (final IOException e)
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/OverlappingAOIPolygonCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/OverlappingAOIPolygonCheck.java
@@ -62,8 +62,8 @@ public class OverlappingAOIPolygonCheck extends BaseCheck<Long>
         super(configuration);
         this.minimumIntersect = this.configurationValue(configuration, "intersect.minimum.limit",
                 MINIMUM_PROPORTION_DEFAULT);
-        final List<String> aoiFiltersString = configurationValue(configuration, "aoi.tags.filters",
-                AOI_FILTERS_DEFAULT);
+        final List<String> aoiFiltersString = this.configurationValue(configuration,
+                "aoi.tags.filters", AOI_FILTERS_DEFAULT);
         aoiFiltersString
                 .forEach(string -> this.aoiFilters.add(TaggableFilter.forDefinition(string)));
     }
@@ -82,7 +82,7 @@ public class OverlappingAOIPolygonCheck extends BaseCheck<Long>
         // aoiFilters. aoiFiltersTest() and aoiFilters is used in place of a single TaggableFilter
         // so that each filter may be tested separately later.
         return object instanceof Area && !this.isFlagged(object.getIdentifier())
-                && aoiFiltersTest(object);
+                && this.aoiFiltersTest(object);
     }
 
     /**
@@ -105,7 +105,7 @@ public class OverlappingAOIPolygonCheck extends BaseCheck<Long>
                 .stream(object.getAtlas().areasIntersecting(aoiBounds,
                         area -> area.getIdentifier() != aoi.getIdentifier()
                                 && !this.isFlagged(area.getIdentifier())
-                                && area.intersects(aoiPolygon) && aoiFiltersTest(area)))
+                                && area.intersects(aoiPolygon) && this.aoiFiltersTest(area)))
                 .collectToSet();
 
         final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(object));
@@ -116,7 +116,7 @@ public class OverlappingAOIPolygonCheck extends BaseCheck<Long>
         for (final Area area : overlappingAreas)
         {
             if (IntersectionUtilities.findIntersectionPercentage(aoiPolygon,
-                    area.asPolygon()) >= this.minimumIntersect && aoiFiltersTest(object, area))
+                    area.asPolygon()) >= this.minimumIntersect && this.aoiFiltersTest(object, area))
             {
                 flag.addObject(area);
                 flag.addInstruction(this.getLocalizedInstruction(0, object.getOsmIdentifier(),

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/PedestrianAreaOverlappingEdgeCheck.java
@@ -74,7 +74,7 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
     {
         // Valid object for the check is a pedestrian area that has not been flagged
         return object instanceof Area && this.isPedestrianArea(object)
-                && !isFlagged(object.getOsmIdentifier());
+                && !this.isFlagged(object.getOsmIdentifier());
     }
 
     @Override
@@ -143,7 +143,7 @@ public class PedestrianAreaOverlappingEdgeCheck extends BaseCheck<Long>
             this.markAsFlagged(object.getOsmIdentifier());
             final CheckFlag flag = this.createFlag(overlappingEdges,
                     this.getLocalizedInstruction(0, object.getOsmIdentifier(),
-                            new StringList(getIdentifiers(overlappingEdges)).join(", ")));
+                            new StringList(this.getIdentifiers(overlappingEdges)).join(", ")));
             flag.addObject(object);
             return Optional.of(flag);
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/ShadowDetectionCheck.java
@@ -208,7 +208,7 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
             final AtlasObject checking = toCheck.poll();
 
             // If a connection to the ground is found the parts are not floating
-            if (!isOffGround(checking))
+            if (!this.isOffGround(checking))
             {
                 isFloating = false;
             }
@@ -335,7 +335,7 @@ public class ShadowDetectionCheck extends BaseCheck<Long>
                             ? objectPolygon.overlaps((Polygon) partPolygon)
                             : objectPolygon.overlaps((MultiPolygon) partPolygon))
                     // Check 3D overlap
-                    && neighborsHeightContains(part, object);
+                    && this.neighborsHeightContains(part, object);
         }
         // Ignore malformed MultiPolygons
         catch (final CoreException invalidMultiPolygon)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/WaterAreaCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/WaterAreaCheck.java
@@ -66,7 +66,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
     /**
      * Check if an object matches a filter
-     * 
+     *
      * @param filters
      *            The filters to check against
      * @param object
@@ -81,7 +81,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
     /**
      * Check if two objects match the same filter
-     * 
+     *
      * @param filters
      *            The filters to check
      * @param object1
@@ -99,7 +99,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
     /**
      * Create a new WaterAreaCheck
-     * 
+     *
      * @param configuration
      *            The configuration for the new Check
      */
@@ -108,18 +108,18 @@ public class WaterAreaCheck extends BaseCheck<Long>
         super(configuration);
         this.minimumIntersect = this.configurationValue(configuration, "intersect.minimum.limit",
                 MINIMUM_PROPORTION_DEFAULT);
-        List<String> filtersString = configurationValue(configuration, "water.tags.filters",
+        List<String> filtersString = this.configurationValue(configuration, "water.tags.filters",
                 WATER_FILTERS);
         filtersString.forEach(string -> this.areaFilters.add(TaggableFilter.forDefinition(string)));
-        filtersString = configurationValue(configuration, "waterway.tags.filters",
+        filtersString = this.configurationValue(configuration, "waterway.tags.filters",
                 WATERWAY_FILTERS);
         filtersString
                 .forEach(string -> this.waterwayFilters.add(TaggableFilter.forDefinition(string)));
-        filtersString = configurationValue(configuration, "water.tags.filtersrequireswaterway",
+        filtersString = this.configurationValue(configuration, "water.tags.filtersrequireswaterway",
                 WATER_FILTERS_WATERWAY);
         filtersString.forEach(string -> this.waterRequiringWaterwayFilters
                 .add(TaggableFilter.forDefinition(string)));
-        filtersString = configurationValue(configuration, "water.tags.crossing.ignore",
+        filtersString = this.configurationValue(configuration, "water.tags.crossing.ignore",
                 WATERWAY_CROSSING_IGNORE);
         filtersString.forEach(
                 string -> this.waterwayCrossingIgnore.add(TaggableFilter.forDefinition(string)));
@@ -128,7 +128,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return object instanceof Area && (!isFlagged(object.getOsmIdentifier()))
+        return object instanceof Area && (!this.isFlagged(object.getOsmIdentifier()))
                 && matchesFilter(this.areaFilters, object);
     }
 
@@ -141,9 +141,9 @@ public class WaterAreaCheck extends BaseCheck<Long>
                 .stream(area.getAtlas().linesIntersecting(areaPolygon,
                         atlasObject -> matchesFilter(this.waterwayFilters, atlasObject)))
                 .collectToList();
-        CheckFlag flag = checkForMissingWaterway(null, area, waterways);
-        flag = checkForNoExitingWays(flag, areaPolygon, area, waterways);
-        flag = checkForOverlappingWaterways(flag, area);
+        CheckFlag flag = this.checkForMissingWaterway(null, area, waterways);
+        flag = this.checkForNoExitingWays(flag, areaPolygon, area, waterways);
+        flag = this.checkForOverlappingWaterways(flag, area);
 
         if (flag != null)
         {
@@ -160,7 +160,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
     /**
      * Check if an object is already flagged
-     * 
+     *
      * @param objects
      *            The objects to check
      * @return {@code true} if *all* objects are flagged
@@ -173,7 +173,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
     /**
      * Check a waterway area for a missing waterway way
-     * 
+     *
      * @param flag
      *            The flag to add data to. May be null.
      * @param area
@@ -201,7 +201,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
     /**
      * Check a waterway area for exiting and entering waterways (only checks for one or the other)
-     * 
+     *
      * @param flag
      *            The flag to add data to. May be null.
      * @param areaPolygon
@@ -238,7 +238,7 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
     /**
      * Check for overlapping waterways
-     * 
+     *
      * @param flag
      *            The flag to add data to. May be null.
      * @param area
@@ -263,21 +263,22 @@ public class WaterAreaCheck extends BaseCheck<Long>
 
         final List<Area> areaIntersections = possibleAreaIntersections.stream()
                 .flatMap(pair -> pair.getRight().stream()).distinct()
-                .filter(tArea -> !intersections(area.getClosedGeometry(), tArea.getClosedGeometry())
+                .filter(tArea -> !this
+                        .intersections(area.getClosedGeometry(), tArea.getClosedGeometry())
                         .isEmpty())
                 .filter(tArea -> matchesFilter(this.waterwayCrossingIgnore, tArea)
                         && matchesFilter(this.waterwayCrossingIgnore, area)
                         || !matchesFilter(this.waterwayCrossingIgnore, tArea)
                                 && !matchesFilter(this.waterwayCrossingIgnore, area))
                 .collect(Collectors.toList());
-        if (!areaIntersections.isEmpty() && !alreadyFlagged(areaIntersections))
+        if (!areaIntersections.isEmpty() && !this.alreadyFlagged(areaIntersections))
         {
             if (returnFlag == null)
             {
                 returnFlag = new CheckFlag(this.getTaskIdentifier(area));
             }
             returnFlag.addPoints(possibleAreaIntersections.stream()
-                    .filter(pair -> !alreadyFlagged(pair.getRight())).map(Pair::getLeft)
+                    .filter(pair -> !this.alreadyFlagged(pair.getRight())).map(Pair::getLeft)
                     .map(Segment::middle).collect(Collectors.toList()));
             returnFlag.addInstruction(this.getLocalizedInstruction(
                     FALLBACK_INSTRUCTIONS.indexOf(INSTRUCTION_WATERWAY_INTERSECTION),

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -91,14 +91,14 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     public EdgeCrossingEdgeCheck(final Configuration configuration)
     {
         super(configuration);
-        this.minimumHighwayType = configurationValue(configuration, "minimum.highway.type",
+        this.minimumHighwayType = this.configurationValue(configuration, "minimum.highway.type",
                 MINIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
     }
 
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TypePredicates.IS_EDGE.test(object) && isValidCrossingEdge(object);
+        return TypePredicates.IS_EDGE.test(object) && this.isValidCrossingEdge(object);
     }
 
     @Override
@@ -138,7 +138,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                     final Tuple2<Edge, Set<Edge>> minPair = minIdentifierPair.get();
                     if (!this.isFlagged(minPair._1().getIdentifier()))
                     {
-                        return createEdgeCrossCheckFlag(minPair._1(), minPair._2());
+                        return this.createEdgeCrossCheckFlag(minPair._1(), minPair._2());
                     }
                 }
             }
@@ -164,11 +164,11 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private Optional<CheckFlag> createEdgeCrossCheckFlag(final Edge edge,
             final Set<Edge> collectedEdges)
     {
-        final CheckFlag newFlag = new CheckFlag(getTaskIdentifier(edge));
+        final CheckFlag newFlag = new CheckFlag(this.getTaskIdentifier(edge));
         this.markAsFlagged(edge.getIdentifier());
         final Set<Location> points = collectedEdges.stream()
                 .filter(crossEdge -> crossEdge.getIdentifier() != edge.getIdentifier())
-                .flatMap(crossEdge -> getIntersection(edge, crossEdge).stream())
+                .flatMap(crossEdge -> this.getIntersection(edge, crossEdge).stream())
                 .collect(Collectors.toSet());
         newFlag.addInstruction(
                 this.getLocalizedInstruction(0, edge.getOsmIdentifier(), collectedEdges.stream()

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingBuildingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingBuildingCheck.java
@@ -116,14 +116,14 @@ public class LineCrossingBuildingCheck extends BaseCheck<Long>
         // MapRoulette will display way-sectioned edges in case there is an invalid crossing.
         // Therefore, if an OSM way crosses a building multiple times in separate edges, then
         // each edge will be marked explicitly.
-        final List<Edge> edges = findCrossingItems(atlas.edgesIntersecting(areaAsPolygon),
+        final List<Edge> edges = this.findCrossingItems(atlas.edgesIntersecting(areaAsPolygon),
                 areaAsPolygon);
-        final List<Line> lines = findCrossingItems(atlas.linesIntersecting(areaAsPolygon),
+        final List<Line> lines = this.findCrossingItems(atlas.linesIntersecting(areaAsPolygon),
                 areaAsPolygon);
 
         if (edges != null || lines != null)
         {
-            final CheckFlag flag = new CheckFlag(getTaskIdentifier(object));
+            final CheckFlag flag = new CheckFlag(this.getTaskIdentifier(object));
             flag.addObject(object);
             flag.addInstruction(this.getLocalizedInstruction(0, object.getOsmIdentifier()));
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
@@ -270,14 +270,15 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
         // Then retrieve the invalid crossing edges, lines, buildings
         final Atlas atlas = object.getAtlas();
         final Iterable<AtlasItem> invalidCrossingItems = this.flagBuildings
-                ? new MultiIterable<>(collectOffendingLineItems(atlas, object, waterbody),
+                ? new MultiIterable<>(this.collectOffendingLineItems(atlas, object, waterbody),
                         atlas.areasIntersecting(waterbody,
                                 area -> BuildingTag.isBuilding(area)
                                         && !NONOFFENDING_BUILDINGS.test(area)
                                         && LevelTag.areOnSameLevel(object, area)
                                         && !this.getInteractionsPerWaterbodyComponent(waterbody,
                                                 object, area.asPolygon()).isEmpty()))
-                : new MultiIterable<AtlasItem>(collectOffendingLineItems(atlas, object, waterbody));
+                : new MultiIterable<AtlasItem>(
+                        this.collectOffendingLineItems(atlas, object, waterbody));
 
         // This waterbody has no invalid crossings
         if (!invalidCrossingItems.iterator().hasNext())
@@ -285,7 +286,7 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
             return Optional.empty();
         }
 
-        final CheckFlag newFlag = new CheckFlag(getTaskIdentifier(object));
+        final CheckFlag newFlag = new CheckFlag(this.getTaskIdentifier(object));
         newFlag.addObject(object);
         newFlag.addInstruction(this.getLocalizedInstruction(0, object.getOsmIdentifier()));
 
@@ -386,12 +387,13 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
     {
         return atlas.lineItemsIntersecting(waterbody, lineItem ->
         {
-            if (isOffendingLineItem(object).test(lineItem))
+            if (this.isOffendingLineItem(object).test(lineItem))
             {
                 // All potentially flaggable interactions (intersect,within) between the lineItem
                 // and the waterbody (or its outer member components if it's a multipolygon)
-                final Set<Tuple<PolyLine, Set<Location>>> interactionsPerWaterbodyComponent = getInteractionsPerWaterbodyComponent(
-                        waterbody, object, lineItem.asPolyLine());
+                final Set<Tuple<PolyLine, Set<Location>>> interactionsPerWaterbodyComponent = this
+                        .getInteractionsPerWaterbodyComponent(waterbody, object,
+                                lineItem.asPolyLine());
                 // Just need to see if the intersection points are allowed in OSM; if not flag them
                 return !interactionsPerWaterbodyComponent.isEmpty()
                         && interactionsPerWaterbodyComponent.stream().anyMatch(

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/OceanBleedingCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/OceanBleedingCheck.java
@@ -142,7 +142,7 @@ public class OceanBleedingCheck extends BaseCheck<Long>
             // feature
             final Iterable<LineItem> intersectingLinearFeatures = object.getAtlas()
                     .lineItemsIntersecting(oceanBoundary,
-                            isInvalidlyInteractingWithOcean(oceanBoundary));
+                            this.isInvalidlyInteractingWithOcean(oceanBoundary));
             final Iterable<Area> intersectingBuildingFeatures = object.getAtlas()
                     .areasIntersecting(oceanBoundary, BuildingTag::isBuilding);
             intersectingLinearFeatures.forEach(offendingLineItems::add);
@@ -157,9 +157,9 @@ public class OceanBleedingCheck extends BaseCheck<Long>
                             && !oceanBoundary.fullyGeometricallyEncloses(lineItem.asPolyLine())
                             || object instanceof LineItem && ((LineItem) object).asPolyLine()
                                     .intersects(lineItem.asPolyLine()))
-                            && isInvalidlyInteractingWithOcean(
+                            && this.isInvalidlyInteractingWithOcean(
                                     oceanIsArea ? oceanBoundary : ((LineItem) object).asPolyLine())
-                                            .test(lineItem));
+                                    .test(lineItem));
             final Iterable<Area> intersectingBuildingFeatures = object.getAtlas().areasIntersecting(
                     oceanBoundary,
                     area -> (oceanIsArea

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/SelfIntersectingPolylineCheck.java
@@ -114,7 +114,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
         {
             polyline = ((Area) object).asPolygon();
             // Send duplicate Edge instructions if duplicate Edges exist
-            localizedInstructionIndex = hasDuplicateSegments(polyline) ? THREE : 1;
+            localizedInstructionIndex = this.hasDuplicateSegments(polyline) ? THREE : 1;
         }
         else
         {
@@ -153,7 +153,7 @@ public class SelfIntersectingPolylineCheck extends BaseCheck<Long>
 
             if (!isJtsValid)
             {
-                response = Optional.of(createFlag(object,
+                response = Optional.of(this.createFlag(object,
                         this.getLocalizedInstruction(localizedInstructionIndex)));
             }
             else

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/UnwalkableWaysCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/UnwalkableWaysCheck.java
@@ -57,15 +57,15 @@ public class UnwalkableWaysCheck extends BaseCheck<Long>
     {
         super(configuration);
 
-        this.minimumHighwayType = configurationValue(configuration, "minimum.highway.type",
+        this.minimumHighwayType = this.configurationValue(configuration, "minimum.highway.type",
                 MINIMUM_HIGHWAY_TYPE_DEFAULT.toString(),
                 tag -> HighwayTag.valueOf(tag.toUpperCase()));
 
-        this.walkwayTags = configurationValue(configuration, "walkway.tags", DEFAULT_WALKWAY_TAGS)
-                .stream().map(value -> HighwayTag.valueOf(value.toUpperCase()))
-                .toArray(HighwayTag[]::new);
+        this.walkwayTags = this
+                .configurationValue(configuration, "walkway.tags", DEFAULT_WALKWAY_TAGS).stream()
+                .map(value -> HighwayTag.valueOf(value.toUpperCase())).toArray(HighwayTag[]::new);
 
-        this.includeDualCrossingDualCarriageways = configurationValue(configuration,
+        this.includeDualCrossingDualCarriageways = this.configurationValue(configuration,
                 "includeDualCrossingDualCarriageways", false);
     }
 
@@ -103,9 +103,9 @@ public class UnwalkableWaysCheck extends BaseCheck<Long>
 
         // Filter the connected edges on either end of this edge to narrow down to potential
         // dual carriageways.
-        final Set<Edge> startEdges = filterConnectedEdgesToCandidates(
+        final Set<Edge> startEdges = this.filterConnectedEdgesToCandidates(
                 crossingEdge.start().connectedEdges(), crossingEdge);
-        final Set<Edge> endEdges = filterConnectedEdgesToCandidates(
+        final Set<Edge> endEdges = this.filterConnectedEdgesToCandidates(
                 crossingEdge.end().connectedEdges(), crossingEdge);
 
         // used for comparing directions of candidate edges to find ones in opposite directions
@@ -146,7 +146,7 @@ public class UnwalkableWaysCheck extends BaseCheck<Long>
                 // Based on that, we can then do a basic check if the original edge is also a dual
                 // carriageway.
                 if (!this.includeDualCrossingDualCarriageways
-                        && hasReverseCarriageway(crossingEdge))
+                        && this.hasReverseCarriageway(crossingEdge))
                 {
                     logger.trace("Skipping {} as possible dual carriageway.",
                             matchingEndEdge.get().getOsmIdentifier());
@@ -155,7 +155,7 @@ public class UnwalkableWaysCheck extends BaseCheck<Long>
 
                 // create the flag for the original edge.
                 logger.info("Flagging {}", crossingEdge.getOsmIdentifier());
-                final CheckFlag flag = createFlag(crossingEdge,
+                final CheckFlag flag = this.createFlag(crossingEdge,
                         this.getLocalizedInstruction(0, crossingEdge.getOsmIdentifier()));
                 return Optional.of(flag);
             }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ApproximateWayCheck.java
@@ -56,16 +56,16 @@ public class ApproximateWayCheck extends BaseCheck<Long>
     public ApproximateWayCheck(final Configuration configuration)
     {
         super(configuration);
-        this.maxDeviationRatio = configurationValue(configuration, "deviation.ratio.max",
+        this.maxDeviationRatio = this.configurationValue(configuration, "deviation.ratio.max",
                 DEVIATION_MAXIMUM_RATIO_DEFAULT, Double::doubleValue);
-        this.minDeviationLength = configurationValue(configuration, "deviation.minimum.meters",
+        this.minDeviationLength = this.configurationValue(configuration, "deviation.minimum.meters",
                 DEVIATION_MINIMUM_LENGTH_DEFAULT, Distance::meters);
         final String highwayType = this.configurationValue(configuration, "highway.minimum",
                 HIGHWAY_MINIMUM_DEFAULT);
         this.highwayMinimum = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
-        this.minAngle = configurationValue(configuration, "angle.minimum", MIN_ANGLE_DEFAULT);
-        this.maxAngle = configurationValue(configuration, "angle.max", MAX_ANGLE_DEFAULT);
-        this.bezierStep = configurationValue(configuration, "bezierStep", BEZIER_STEP_DEFAULT);
+        this.minAngle = this.configurationValue(configuration, "angle.minimum", MIN_ANGLE_DEFAULT);
+        this.maxAngle = this.configurationValue(configuration, "angle.max", MAX_ANGLE_DEFAULT);
+        this.bezierStep = this.configurationValue(configuration, "bezierStep", BEZIER_STEP_DEFAULT);
     }
 
     /**
@@ -79,7 +79,7 @@ public class ApproximateWayCheck extends BaseCheck<Long>
     public boolean validCheckForObject(final AtlasObject object)
     {
         return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMainEdge()
-                && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object);
+                && HighwayTag.isCarNavigableHighway(object) && this.isMinimumHighwayType(object);
     }
 
     /**
@@ -105,13 +105,13 @@ public class ApproximateWayCheck extends BaseCheck<Long>
         {
             final Segment seg1 = segments.get(index);
             final Segment seg2 = segments.get(index + 1);
-            final double angle = findAngle(seg1, seg2);
+            final double angle = this.findAngle(seg1, seg2);
             // ignore sharp turns and almost straightaways
             if (angle < this.minAngle || angle > this.maxAngle)
             {
                 return false;
             }
-            final double distance = quadraticBezier(seg1.first(), seg2.first(), seg2.end());
+            final double distance = this.quadraticBezier(seg1.first(), seg2.first(), seg2.end());
             final double legsLength = seg1.length().asMeters() + seg2.length().asMeters();
             return distance > this.minDeviationLength.asMeters()
                     && distance / legsLength > this.maxDeviationRatio;
@@ -119,8 +119,8 @@ public class ApproximateWayCheck extends BaseCheck<Long>
 
         if (isCrude)
         {
-            return Optional.of(
-                    createFlag(object, this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
 
         return Optional.empty();
@@ -204,7 +204,7 @@ public class ApproximateWayCheck extends BaseCheck<Long>
             final double pointY = (pow(1 - step, 2) * startY)
                     + (2 * step * (1 - step) * anchorY + pow(step, 2) * endY);
             // distance from point on bezier curve to anchor
-            final double distance = distance(pointX, pointY, anchorX, anchorY);
+            final double distance = this.distance(pointX, pointY, anchorX, anchorY);
             if (distance < min)
             {
                 min = distance;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -83,15 +83,16 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
         /*
          * This will retrieve two values, minimum and maximum length in the JSON configuration.
          */
-        this.minimumDistance = configurationValue(configuration, "length.minimum.meters",
+        this.minimumDistance = this.configurationValue(configuration, "length.minimum.meters",
                 DISTANCE_MINIMUM_METERS_DEFAULT, Distance::meters);
-        this.maximumDistance = configurationValue(configuration, "length.maximum.kilometers",
+        this.maximumDistance = this.configurationValue(configuration, "length.maximum.kilometers",
                 DISTANCE_MAXIMUM_KILOMETERS_DEFAULT, Distance::kilometers);
         // This retrieves the minimum highway type from the config
         final String highwayType = this.configurationValue(configuration, "highway.minimum",
                 HIGHWAY_MINIMUM_DEFAULT);
         this.highwayMinimum = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
-        this.checkConstructionRoad = configurationValue(configuration, "construction.check", false);
+        this.checkConstructionRoad = this.configurationValue(configuration, "construction.check",
+                false);
     }
 
     /**
@@ -111,7 +112,7 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     {
         // Consider navigable main edges
         return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMainEdge()
-                && HighwayTag.isCarNavigableHighway(object) && isMinimumHighwayType(object)
+                && HighwayTag.isCarNavigableHighway(object) && this.isMinimumHighwayType(object)
                 && !intersectsAirport((Edge) object);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheck.java
@@ -92,7 +92,7 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
                     // add all overlapping edges not yet flagged and not pedestrian areas
                     overlappingItems.addAll(Iterables
                             .stream(atlas.edgesIntersecting(box, Edge::isMainEdge))
-                            .filter(notEqual(object).and(notIn(object))
+                            .filter(notEqual(object).and(this.notIn(object))
                                     .and(this.overlapsSegment(start, end))
                                     .and(this.filterPedestrianAreas ? edge -> !this.edgeIsArea(edge)
                                             : this.notPedestrianAreas((Edge) object))
@@ -109,7 +109,7 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
                         .forEach(overlapEdge -> this.markAsFlagged(overlapEdge.getIdentifier()));
                 final CheckFlag flag = this.createFlag(overlappingItems,
                         this.getLocalizedInstruction(0, object.getOsmIdentifier(),
-                                new StringList(osmIdentifiers(overlappingItems)).join(", ")));
+                                new StringList(this.osmIdentifiers(overlappingItems)).join(", ")));
                 // If the edges are part of the same way, give special instructions
                 if (overlappingItems.stream().anyMatch(
                         overlapEdge -> overlapEdge.getOsmIdentifier() == object.getOsmIdentifier()))
@@ -143,7 +143,7 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
     {
         return (Validators.isOfType(edge, HighwayTag.class, HighwayTag.PEDESTRIAN)
                 || Validators.isOfType(edge, ManMadeTag.class, ManMadeTag.PIER))
-                && (AREA_YES_TAG.test(edge) || isPartOfClosedWay(edge))
+                && (AREA_YES_TAG.test(edge) || this.isPartOfClosedWay(edge))
                 || (Validators.isOfType(edge, HighwayTag.class, HighwayTag.SERVICE)
                         && AREA_YES_TAG.test(edge));
     }
@@ -217,9 +217,9 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
         return edge ->
         {
             // Check if the edge is a pedestrian area
-            final boolean edgeIsPedArea = edgeIsArea(edge);
+            final boolean edgeIsPedArea = this.edgeIsArea(edge);
             // Check if the object is a pedestrian area
-            final boolean objectIsPedArea = edgeIsArea(object);
+            final boolean objectIsPedArea = this.edgeIsArea(object);
             // If both are pedestrian areas, or one is a pedestrian area and the other is a lower
             // priority highway than the configurable return false
             return !((edgeIsPedArea && objectIsPedArea)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheck.java
@@ -27,7 +27,7 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
  * two intersections with navigable roads {@link RoundaboutMissingTagCheck#MINIMUM_INTERSECTION}
  * connections. See https://wiki.openstreetmap.org/wiki/Tag:junction%3Droundabout for more
  * information about roundabouts
- * 
+ *
  * @author vladlemberg
  */
 
@@ -56,10 +56,10 @@ public class RoundaboutMissingTagCheck extends BaseCheck<Long>
     public RoundaboutMissingTagCheck(final Configuration configuration)
     {
         super(configuration);
-        this.maxAngleThreshold = configurationValue(configuration, "angle.threshold.maximum_degree",
-                MAX_THRESHOLD_DEGREES_DEFAULT, Angle::degrees);
-        this.minAngleThreshold = configurationValue(configuration, "angle.threshold.minimum_degree",
-                MIN_THRESHOLD_DEGREES_DEFAULT, Angle::degrees);
+        this.maxAngleThreshold = this.configurationValue(configuration,
+                "angle.threshold.maximum_degree", MAX_THRESHOLD_DEGREES_DEFAULT, Angle::degrees);
+        this.minAngleThreshold = this.configurationValue(configuration,
+                "angle.threshold.minimum_degree", MIN_THRESHOLD_DEGREES_DEFAULT, Angle::degrees);
     }
 
     /**
@@ -88,7 +88,7 @@ public class RoundaboutMissingTagCheck extends BaseCheck<Long>
     {
         final Edge edge = (Edge) object;
 
-        final PolyLine originalGeom = buildOriginalOsmWayGeometry(edge);
+        final PolyLine originalGeom = this.buildOriginalOsmWayGeometry(edge);
         // check maximum angle
         final List<Tuple<Angle, Location>> maxOffendingAngles = originalGeom
                 .anglesGreaterThanOrEqualTo(this.maxAngleThreshold);
@@ -99,7 +99,7 @@ public class RoundaboutMissingTagCheck extends BaseCheck<Long>
         if (maxOffendingAngles.isEmpty() && minOffendingAngles.isEmpty())
         {
             this.markAsFlagged(object.getOsmIdentifier());
-            return Optional.of(createFlag(new OsmWayWalker(edge).collectEdges(),
+            return Optional.of(this.createFlag(new OsmWayWalker(edge).collectEdges(),
                     this.getLocalizedInstruction(0)));
         }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
@@ -43,7 +43,7 @@ public class SharpAngleCheck extends BaseCheck<Long>
     public SharpAngleCheck(final Configuration configuration)
     {
         super(configuration);
-        this.threshold = configurationValue(configuration, "threshold.degrees",
+        this.threshold = this.configurationValue(configuration, "threshold.degrees",
                 THRESHOLD_DEGREES_DEFAULT, Angle::degrees);
     }
 
@@ -66,9 +66,9 @@ public class SharpAngleCheck extends BaseCheck<Long>
 
         final List<Tuple<Angle, Location>> offendingAngles = edge.asPolyLine()
                 .anglesGreaterThanOrEqualTo(this.threshold);
-        if (!offendingAngles.isEmpty() && !hasBeenFlagged(edge))
+        if (!offendingAngles.isEmpty() && !this.hasBeenFlagged(edge))
         {
-            flagEdge(edge);
+            this.flagEdge(edge);
             final String checkMessage;
 
             if (offendingAngles.size() == 1)
@@ -84,8 +84,8 @@ public class SharpAngleCheck extends BaseCheck<Long>
                         offendingAngles.size());
             }
 
-            final List<Location> offendingLocations = buildLocationList(offendingAngles);
-            return Optional.of(createFlag(object, checkMessage, offendingLocations));
+            final List<Location> offendingLocations = this.buildLocationList(offendingAngles);
+            return Optional.of(this.createFlag(object, checkMessage, offendingLocations));
         }
 
         return Optional.empty();
@@ -107,7 +107,7 @@ public class SharpAngleCheck extends BaseCheck<Long>
 
     /**
      * Flags the given edge and its reverse edge
-     * 
+     *
      * @param edge
      *            The edge to flag
      */
@@ -123,7 +123,7 @@ public class SharpAngleCheck extends BaseCheck<Long>
 
     /**
      * Checks if the supplied edge or its reverse edge has already been flagged
-     * 
+     *
      * @param edge
      *            edge to check
      * @return {@code true} if the reverse edge has already been flagged

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ShortSegmentCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ShortSegmentCheck.java
@@ -81,12 +81,12 @@ public class ShortSegmentCheck extends BaseCheck<Long>
     public ShortSegmentCheck(final Configuration configuration)
     {
         super(configuration);
-        this.maximumLength = configurationValue(configuration, "edge.length.maximum.meters",
+        this.maximumLength = this.configurationValue(configuration, "edge.length.maximum.meters",
                 MAXIMUM_LENGTH_DEFAULT, Distance::meters);
-        this.minimumValence = configurationValue(configuration, "node.valence.minimum",
+        this.minimumValence = this.configurationValue(configuration, "node.valence.minimum",
                 MINIMUM_VALENCE_DEFAULT);
         this.minimumHighwayPriority = Enum.valueOf(HighwayTag.class,
-                configurationValue(configuration, "highway.priority.minimum",
+                this.configurationValue(configuration, "highway.priority.minimum",
                         MINIMUM_HIGHWAY_PRIORITY_DEFAULT).toUpperCase());
     }
 
@@ -113,9 +113,9 @@ public class ShortSegmentCheck extends BaseCheck<Long>
         final Edge edge = (Edge) object;
         final Optional<Node> lowValenceNodes = getConnectedNodesWithValenceLessThan(edge,
                 this.minimumValence);
-        if (lowValenceNodes.isPresent() && !isGateLike((Edge) object))
+        if (lowValenceNodes.isPresent() && !this.isGateLike((Edge) object))
         {
-            return Optional.of(createFlag(object,
+            return Optional.of(this.createFlag(object,
                     this.getLocalizedInstruction(0, object.getIdentifier(),
                             this.maximumLength.asMeters(), lowValenceNodes.get().getIdentifier(),
                             this.minimumValence),

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadCheck.java
@@ -98,15 +98,15 @@ public class SnakeRoadCheck extends BaseCheck<Long>
         this.markAsFlagged(object.getOsmIdentifier());
 
         // Instantiate the network walk with the starting edge
-        final SnakeRoadNetworkWalk walk = initializeNetworkWalk(edge);
+        final SnakeRoadNetworkWalk walk = this.initializeNetworkWalk(edge);
 
         // Walk the road
-        walkNetwork(edge, walk);
+        this.walkNetwork(edge, walk);
 
         // If we've found a snake road, create a flag
-        if (networkWalkQualifiesAsSnakeRoad(walk))
+        if (this.networkWalkQualifiesAsSnakeRoad(walk))
         {
-            return Optional.of(createFlag(walk.getVisitedEdges(),
+            return Optional.of(this.createFlag(walk.getVisitedEdges(),
                     this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadNetworkWalk.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SnakeRoadNetworkWalk.java
@@ -75,7 +75,7 @@ public class SnakeRoadNetworkWalk
     protected void checkIfEdgeHeadingDifferenceExceedsThreshold(final Edge incoming,
             final Edge outgoing)
     {
-        if (!isSnakeRoad())
+        if (!this.isSnakeRoad())
         {
             final Optional<Heading> incomingHeading = incoming.overallHeading();
             final Optional<Heading> outgoingHeading = outgoing.overallHeading();
@@ -83,7 +83,7 @@ public class SnakeRoadNetworkWalk
                     && incomingHeading.get().difference(outgoingHeading.get())
                             .isGreaterThanOrEqualTo(this.edgeHeadingDifferenceThreshold))
             {
-                setSnakeRoadStatus(true);
+                this.setSnakeRoadStatus(true);
             }
         }
     }
@@ -103,23 +103,23 @@ public class SnakeRoadNetworkWalk
      */
     protected void filterFalsePositives()
     {
-        if (isSnakeRoad() && (hasRoadName() || hasRefTag()))
+        if (this.isSnakeRoad() && (this.hasRoadName() || this.hasRefTag()))
         {
             // Gather all connected edges for the first and last edge of this road
             final Set<Edge> connections = new HashSet<>();
-            connections.addAll(
-                    getMainEdgesForConnectedEdgesOfDifferentWays((Edge) getVisitedEdges().first()));
-            connections.addAll(
-                    getMainEdgesForConnectedEdgesOfDifferentWays((Edge) getVisitedEdges().last()));
+            connections.addAll(this.getMainEdgesForConnectedEdgesOfDifferentWays(
+                    (Edge) this.getVisitedEdges().first()));
+            connections.addAll(this.getMainEdgesForConnectedEdgesOfDifferentWays(
+                    (Edge) this.getVisitedEdges().last()));
 
             // Check their connections for connected names and ref tags
             for (final Edge connection : connections)
             {
                 final Optional<String> connectionName = connection.getTag(NameTag.KEY);
                 final Optional<String> refTag = connection.getTag(ReferenceTag.KEY);
-                if (connectionName.equals(getRoadName()) || refTag.equals(getRefTag()))
+                if (connectionName.equals(this.getRoadName()) || refTag.equals(this.getRefTag()))
                 {
-                    setSnakeRoadStatus(false);
+                    this.setSnakeRoadStatus(false);
                     break;
                 }
             }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ValenceOneImportantRoadCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/ValenceOneImportantRoadCheck.java
@@ -67,8 +67,8 @@ public class ValenceOneImportantRoadCheck extends BaseCheck<Long>
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Edge edge = (Edge) object;
-        final boolean beginsWithValence1 = inboundValence(edge) == ONE;
-        final boolean endsWithValence1 = outboundValence(edge) == ONE;
+        final boolean beginsWithValence1 = this.inboundValence(edge) == ONE;
+        final boolean endsWithValence1 = this.outboundValence(edge) == ONE;
 
         if (beginsWithValence1 || endsWithValence1)
         {
@@ -89,13 +89,14 @@ public class ValenceOneImportantRoadCheck extends BaseCheck<Long>
                             edge.end().getIdentifier()));
 
                     // edge-case, check for reversed segments
-                    if (reverseOutboundValence(edge) >= ONE && reverseInboundValence(edge) >= ONE)
+                    if (this.reverseOutboundValence(edge) >= ONE
+                            && this.reverseInboundValence(edge) >= ONE)
                     {
                         instructions.add(this.getLocalizedInstruction(2));
                     }
                     // check for Line connections
-                    construction = hasConstructionConnection(edge.end());
-                    accessNo = hasNoAccessConnection(edge.end());
+                    construction = this.hasConstructionConnection(edge.end());
+                    accessNo = this.hasNoAccessConnection(edge.end());
                 }
                 else
                 {
@@ -106,11 +107,11 @@ public class ValenceOneImportantRoadCheck extends BaseCheck<Long>
                 // check for Line connections
                 if (!construction)
                 {
-                    construction = hasConstructionConnection(edge.start());
+                    construction = this.hasConstructionConnection(edge.start());
                 }
                 if (!accessNo)
                 {
-                    accessNo = hasNoAccessConnection(edge.start());
+                    accessNo = this.hasNoAccessConnection(edge.start());
                 }
             }
             else
@@ -119,8 +120,8 @@ public class ValenceOneImportantRoadCheck extends BaseCheck<Long>
                 locations = Collections.singletonList(edge.end().getLocation());
                 instructions.add(this.getLocalizedInstruction(FOUR, edge.end().getIdentifier()));
                 // check for Line connections
-                construction = hasConstructionConnection(edge.end());
-                accessNo = hasNoAccessConnection(edge.end());
+                construction = this.hasConstructionConnection(edge.end());
+                accessNo = this.hasNoAccessConnection(edge.end());
             }
 
             if (construction)
@@ -132,7 +133,7 @@ public class ValenceOneImportantRoadCheck extends BaseCheck<Long>
                 instructions.add(this.getLocalizedInstruction(SIX));
             }
 
-            return Optional.of(createFlag(edge, instructions.join(SINGLE_SPACE), locations));
+            return Optional.of(this.createFlag(edge, instructions.join(SINGLE_SPACE), locations));
         }
         return Optional.empty();
     }
@@ -207,21 +208,21 @@ public class ValenceOneImportantRoadCheck extends BaseCheck<Long>
 
     private long inboundValence(final Edge edge)
     {
-        return directionalValence(edge.start(), INWARD);
+        return this.directionalValence(edge.start(), INWARD);
     }
 
     private long outboundValence(final Edge edge)
     {
-        return directionalValence(edge.end(), OUTWARD);
+        return this.directionalValence(edge.end(), OUTWARD);
     }
 
     private long reverseInboundValence(final Edge edge)
     {
-        return directionalValence(edge.end(), INWARD);
+        return this.directionalValence(edge.end(), INWARD);
     }
 
     private long reverseOutboundValence(final Edge edge)
     {
-        return directionalValence(edge.start(), OUTWARD);
+        return this.directionalValence(edge.start(), OUTWARD);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/GeneralizedCoastlineCheck.java
@@ -82,9 +82,9 @@ public class GeneralizedCoastlineCheck extends BaseCheck<Long>
         final Predicate<Relation> memberIsSourcePGS = this.coastlineTagFilter::test;
 
         return object instanceof LineItem
-                && (isCoastline(object) && this.coastlineTagFilter.test(object)
-                        || hasRelationMembers(object, memberIsCoastline)
-                                && hasRelationMembers(object, memberIsSourcePGS));
+                && (this.isCoastline(object) && this.coastlineTagFilter.test(object)
+                        || this.hasRelationMembers(object, memberIsCoastline)
+                                && this.hasRelationMembers(object, memberIsSourcePGS));
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -230,7 +230,7 @@ public class WaterWayCheck extends BaseCheck<Long>
                             .toArray(Location[]::new));
             // If the waterway ends to the right of the coastline, it ended in an ocean.
             // If the waterway ends on the coastline, it ended in an ocean.
-            if (isRightOf(coast, linePolyline.last())
+            if (this.isRightOf(coast, linePolyline.last())
                     || lineItem.asPolyLine().contains(linePolyline.last()))
             {
                 return true;
@@ -331,7 +331,7 @@ public class WaterWayCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return !isFlagged(object.getOsmIdentifier()) && object instanceof LineItem
+        return !this.isFlagged(object.getOsmIdentifier()) && object instanceof LineItem
                 && this.waterwayTagFilter.test(object);
     }
 
@@ -343,10 +343,10 @@ public class WaterWayCheck extends BaseCheck<Long>
         final Location first = line.asPolyLine().first();
         final Atlas atlas = line.getAtlas();
         CheckFlag flag = null;
-        flag = flagCircularWaterway(flag, line);
-        flag = flagIncline(flag, line, first, last);
-        flag = flagNoSink(flag, atlas, line, last);
-        flag = flagCrossingWays(flag, atlas, line);
+        flag = this.flagCircularWaterway(flag, line);
+        flag = this.flagIncline(flag, line, first, last);
+        flag = this.flagNoSink(flag, atlas, line, last);
+        flag = this.flagCrossingWays(flag, atlas, line);
         if (flag != null)
         {
             super.markAsFlagged(object.getOsmIdentifier());
@@ -409,7 +409,7 @@ public class WaterWayCheck extends BaseCheck<Long>
                     FALLBACK_INSTRUCTIONS.indexOf(CIRCULAR_WATERWAY), line.getOsmIdentifier());
             if (returnFlag == null)
             {
-                returnFlag = createFlag(line, instructions,
+                returnFlag = this.createFlag(line, instructions,
                         Collections.singletonList(line.asPolyLine().first()));
             }
             else
@@ -435,7 +435,7 @@ public class WaterWayCheck extends BaseCheck<Long>
     private CheckFlag flagCrossingWays(final CheckFlag flag, final Atlas atlas, final LineItem line)
     {
         CheckFlag returnFlag = flag;
-        final Collection<LineItem> crossed = getIntersectingWaterways(atlas, line);
+        final Collection<LineItem> crossed = this.getIntersectingWaterways(atlas, line);
         for (final LineItem lineItemCrossed : crossed)
         {
             final Iterator<Location> intersections = lineItemCrossed.asPolyLine()
@@ -447,7 +447,7 @@ public class WaterWayCheck extends BaseCheck<Long>
                         lineItemCrossed.getOsmIdentifier());
                 if (returnFlag == null)
                 {
-                    returnFlag = createFlag(Sets.hashSet(line, lineItemCrossed), instruction,
+                    returnFlag = this.createFlag(Sets.hashSet(line, lineItemCrossed), instruction,
                             Arrays.asList(intersections.next()));
                 }
                 else
@@ -494,7 +494,7 @@ public class WaterWayCheck extends BaseCheck<Long>
                     this.elevationUtils.getResolution(first).asMeters());
             if (returnFlag == null)
             {
-                return createFlag(line, instruction);
+                return this.createFlag(line, instruction);
             }
             returnFlag.addInstruction(instruction);
             return returnFlag;
@@ -518,7 +518,7 @@ public class WaterWayCheck extends BaseCheck<Long>
     private CheckFlag flagNoSink(final CheckFlag flag, final Atlas atlas, final LineItem line,
             final Location last)
     {
-        if (isValidEndToCheck(atlas, last) && !doesWaterwayEndInSink(atlas, line)
+        if (this.isValidEndToCheck(atlas, last) && !this.doesWaterwayEndInSink(atlas, line)
                 && !endsWithBoundaryNode(atlas, line))
         {
             CheckFlag returnFlag = flag;
@@ -528,7 +528,7 @@ public class WaterWayCheck extends BaseCheck<Long>
                     line.getOsmIdentifier());
             if (returnFlag == null)
             {
-                returnFlag = createFlag(line, instruction, Collections.singletonList(last));
+                returnFlag = this.createFlag(line, instruction, Collections.singletonList(last));
             }
             else
             {
@@ -555,7 +555,7 @@ public class WaterWayCheck extends BaseCheck<Long>
                         && lineItem.asPolyLine().intersects(linePoly));
         final Set<LineItem> sameLayerWays = Iterables.stream(intersectingWaterways)
                 .filter(potential -> LayerTag.areOnSameLayer(line, potential)
-                        && !waterwayConnects(line, potential))
+                        && !this.waterwayConnects(line, potential))
                 .collectToSet();
         sameLayerWays.removeIf(line::equals);
         return sameLayerWays;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/AddressPointMatchCheck.java
@@ -56,7 +56,7 @@ public class AddressPointMatchCheck extends BaseCheck<Object>
     {
         super(configuration);
         this.boundsSize = Distance
-                .meters(configurationValue(configuration, "bounds.size", BOUNDS_SIZE_DEFAULT));
+                .meters(this.configurationValue(configuration, "bounds.size", BOUNDS_SIZE_DEFAULT));
     }
 
     @Override
@@ -65,7 +65,7 @@ public class AddressPointMatchCheck extends BaseCheck<Object>
         // Object is an instance of Point
         return object instanceof Point
                 // And does not have an Associated Street Relation
-                && !hasAssociatedStreetRelation(object)
+                && !this.hasAssociatedStreetRelation(object)
                 // And has an AddressHouseNumberTag
                 && object.getTag(AddressHousenumberTag.KEY).isPresent()
                 // And either doesn't have the addr:street tag, has the tag but has a null value,

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -59,10 +59,10 @@ public class ConnectivityCheck extends BaseCheck<Long>
     public ConnectivityCheck(final Configuration configuration)
     {
         super(configuration);
-        this.threshold = configurationValue(configuration, "nearby.edge.distance.meters",
+        this.threshold = this.configurationValue(configuration, "nearby.edge.distance.meters",
                 NEARBY_EDGE_THRESHOLD_DISTANCE_METERS_DEFAULT, Distance::meters);
         this.denylistedHighwaysTaggableFilter = TaggableFilter
-                .forDefinition(configurationValue(configuration, "denylisted.highway.filter",
+                .forDefinition(this.configurationValue(configuration, "denylisted.highway.filter",
                         DEFAULT_DENYLISTED_HIGHWAYS_TAG_FILTER));
     }
 
@@ -82,7 +82,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
     {
         final Node node = (Node) object;
         final Rectangle box = node.getLocation().boxAround(this.threshold);
-        final CheckFlag connectivityFlag = new CheckFlag(getTaskIdentifier(object));
+        final CheckFlag connectivityFlag = new CheckFlag(this.getTaskIdentifier(object));
         final ArrayList<String> disconnectedObjects = new ArrayList<>();
         final Map<Long, Set<Edge>> nodeLayerMap = this.getLayerMap(node);
         // Get nearby Edges, ignoring ones that have a level tag or for whom themselves or their
@@ -112,7 +112,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
                     && !node.equals(nodeNearby) && !BarrierTag.isBarrier(nodeNearby)
                     && !Validators.isOfType(nodeNearby, NoExitTag.class, NoExitTag.YES)
                     && nodeNearby.connectedEdges().stream().anyMatch(this::validEdgeFilter)
-                    && !hasValidConnection(node, connectedEdges, nodeNearby))
+                    && !this.hasValidConnection(node, connectedEdges, nodeNearby))
             {
                 this.markAsFlagged(nodeNearby.getOsmIdentifier());
                 connectivityFlag.addObject(nodeNearby);
@@ -123,9 +123,9 @@ public class ConnectivityCheck extends BaseCheck<Long>
         {
             // There is a valid main edge close by that is not validly connected to the start
             // node.
-            if (edgeNearby.isMainEdge() && validEdgeFilter(edgeNearby)
+            if (edgeNearby.isMainEdge() && this.validEdgeFilter(edgeNearby)
                     && !connectedEdges.contains(edgeNearby)
-                    && !hasValidConnection(node, connectedEdges, edgeNearby)
+                    && !this.hasValidConnection(node, connectedEdges, edgeNearby)
                     // Make sure that the spatial index did not over estimate.
                     && node.snapTo(edgeNearby).getDistance()
                             .isLessThanOrEqualTo(this.threshold.scaleBy(THRESHOLD_SCALE)))
@@ -332,7 +332,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
             }
             // If toFind is found, check the connecting route for convergence
             else if (checking.connectedNodes().contains(toFind)
-                    && isConverging(node, rootEdge, toFind, checking))
+                    && this.isConverging(node, rootEdge, toFind, checking))
             {
                 return true;
             }
@@ -394,8 +394,8 @@ public class ConnectivityCheck extends BaseCheck<Long>
                 secondEdges.clear();
             }
             // If toFind is found, check the connecting route for convergence
-            else if (checking.equals(toFind)
-                    && isConverging(node, rootEdge, secondEdge ? rootEdge : previousEdge, checking))
+            else if (checking.equals(toFind) && this.isConverging(node, rootEdge,
+                    secondEdge ? rootEdge : previousEdge, checking))
             {
                 return true;
             }
@@ -467,16 +467,16 @@ public class ConnectivityCheck extends BaseCheck<Long>
             final Edge lastEdge)
     {
         // Get the heading from node along the connection route
-        final Optional<Heading> firstHeading = getEdgeHeadingFromNode(firstEdge, node);
+        final Optional<Heading> firstHeading = this.getEdgeHeadingFromNode(firstEdge, node);
         // Get the heading from endNode along the connection route
         final Optional<Heading> lastHeading = lastEdge.start().equals(endNode)
                 ? lastEdge.asPolyLine().initialHeading()
                 : lastEdge.asPolyLine().reversed().initialHeading();
         // Get the heading from node to endNode
-        final Optional<Heading> connectionHeading = getConnectedHeading(node.getLocation(),
+        final Optional<Heading> connectionHeading = this.getConnectedHeading(node.getLocation(),
                 endNode.getLocation());
         // Return true if the headings form a triangle
-        return headingsFormTriangle(firstHeading, connectionHeading, lastHeading);
+        return this.headingsFormTriangle(firstHeading, connectionHeading, lastHeading);
     }
 
     /**
@@ -507,15 +507,15 @@ public class ConnectivityCheck extends BaseCheck<Long>
         if (!node.getLocation().equals(snappedLocation))
         {
             // Get the heading from node along the connection route
-            final Optional<Heading> firstHeading = getEdgeHeadingFromNode(firstEdge, node);
+            final Optional<Heading> firstHeading = this.getEdgeHeadingFromNode(firstEdge, node);
             // Get the heading from snappedLocation along the route
-            final Optional<Heading> lastHeading = getHeadingFromSnap(snappedLocation, previousEdge,
-                    lastEdge);
+            final Optional<Heading> lastHeading = this.getHeadingFromSnap(snappedLocation,
+                    previousEdge, lastEdge);
             // Get the heading from node to snappedLocation
-            final Optional<Heading> connectionHeading = getConnectedHeading(node.getLocation(),
+            final Optional<Heading> connectionHeading = this.getConnectedHeading(node.getLocation(),
                     snappedLocation);
             // Return true if the headings form a triangle
-            return headingsFormTriangle(firstHeading, connectionHeading, lastHeading);
+            return this.headingsFormTriangle(firstHeading, connectionHeading, lastHeading);
         }
         return false;
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/InvalidMiniRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/InvalidMiniRoundaboutCheck.java
@@ -82,7 +82,7 @@ public class InvalidMiniRoundaboutCheck extends BaseCheck<Long>
         {
             result = Optional
                     .of(this.flagNode(node, carNavigableEdges, this.getLocalizedInstruction(1,
-                            node.getOsmIdentifier(), getMainEdgeCount(carNavigableEdges))));
+                            node.getOsmIdentifier(), this.getMainEdgeCount(carNavigableEdges))));
         }
         return result;
     }
@@ -152,6 +152,6 @@ public class InvalidMiniRoundaboutCheck extends BaseCheck<Long>
      */
     private boolean isTurnaround(final Collection<Edge> carNavigableEdges)
     {
-        return getMainEdgeCount(carNavigableEdges) == 1 && carNavigableEdges.size() == 2;
+        return this.getMainEdgeCount(carNavigableEdges) == 1 && carNavigableEdges.size() == 2;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
@@ -209,8 +209,8 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
             if (this.overlapMinimumPoints <= shapePoints
                     && shapePoints <= this.overlapMaximumPoints)
             {
-                return Optional
-                        .of(checkOverlap(multiPolygon, multipolygonRelation.getOsmIdentifier()));
+                return Optional.of(
+                        this.checkOverlap(multiPolygon, multipolygonRelation.getOsmIdentifier()));
             }
             return Optional.empty();
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidSignBoardRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidSignBoardRelationCheck.java
@@ -100,7 +100,7 @@ public class InvalidSignBoardRelationCheck extends BaseCheck<Long>
 
         // If the from route doesn't meet the to way, this is invalid
         if (!fromRouteAndReasons.getSecond().flatMap(fromRoute -> toRouteAndReasons.getSecond()
-                .map(toRoute -> fromAndToMeet(fromRoute, toRoute))).orElse(false))
+                .map(toRoute -> this.fromAndToMeet(fromRoute, toRoute))).orElse(false))
         {
             instructions.add(this.getLocalizedInstruction(FROM_TO_NO_MEETING_INDEX));
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -56,17 +56,17 @@ public class OneMemberRelationCheck extends BaseCheck<Object>
         {
             if (members.get(0).getEntity().getType().equals(ItemType.RELATION))
             {
-                return Optional.of(createFlag(getRelationMembers((Relation) object),
+                return Optional.of(this.createFlag(this.getRelationMembers((Relation) object),
                         this.getLocalizedInstruction(2, relation.getOsmIdentifier(),
                                 members.get(0).getEntity().getOsmIdentifier())));
             }
             // If the relation is a multi-polygon,
             if (relation.isMultiPolygon())
             {
-                return Optional.of(createFlag(getRelationMembers((Relation) object),
+                return Optional.of(this.createFlag(this.getRelationMembers((Relation) object),
                         this.getLocalizedInstruction(1, relation.getOsmIdentifier())));
             }
-            return Optional.of(createFlag(getRelationMembers((Relation) object),
+            return Optional.of(this.createFlag(this.getRelationMembers((Relation) object),
                     this.getLocalizedInstruction(0, relation.getOsmIdentifier())));
         }
         return Optional.empty();

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ImproperAndUnknownRoadNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/ImproperAndUnknownRoadNameCheck.java
@@ -47,7 +47,7 @@ public class ImproperAndUnknownRoadNameCheck extends BaseCheck<Long>
     public ImproperAndUnknownRoadNameCheck(final Configuration configuration)
     {
         super(configuration);
-        this.improperNames = configurationValue(configuration, "names.improper",
+        this.improperNames = this.configurationValue(configuration, "names.improper",
                 IMPROPER_NAMES_DEFAULT);
     }
 
@@ -63,14 +63,14 @@ public class ImproperAndUnknownRoadNameCheck extends BaseCheck<Long>
         if (!this.isFlagged(object.getOsmIdentifier()))
         {
             final Set<String> instructions = new HashSet<>();
-            getAllNameTags(object).entrySet().forEach(
-                    entry -> updateInstructions(entry, instructions, object.getOsmIdentifier()));
+            this.getAllNameTags(object).entrySet().forEach(entry -> this.updateInstructions(entry,
+                    instructions, object.getOsmIdentifier()));
 
             if (!instructions.isEmpty())
             {
                 this.markAsFlagged(object.getOsmIdentifier());
-                final CheckFlag flag = createFlag(new OsmWayWalker((Edge) object).collectEdges(),
-                        "");
+                final CheckFlag flag = this
+                        .createFlag(new OsmWayWalker((Edge) object).collectEdges(), "");
                 flag.addInstructions(instructions);
                 return Optional.of(flag);
             }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidAccessTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidAccessTagCheck.java
@@ -55,8 +55,8 @@ public class InvalidAccessTagCheck extends BaseCheck<Long>
     {
         super(configuration);
 
-        final String highwayType = (String) this.configurationValue(configuration,
-                "minimum.highway.type", MINIMUM_HIGHWAY_TYPE_DEFAULT);
+        final String highwayType = this.configurationValue(configuration, "minimum.highway.type",
+                MINIMUM_HIGHWAY_TYPE_DEFAULT);
         this.minimumHighwayType = Enum.valueOf(HighwayTag.class, highwayType.toUpperCase());
     }
 
@@ -74,7 +74,7 @@ public class InvalidAccessTagCheck extends BaseCheck<Long>
     {
         return AccessTag.isNo(object) && ((object instanceof Edge) || (object instanceof Line))
                 && Edge.isMainEdgeIdentifier(object.getIdentifier())
-                && !this.isFlagged(object.getOsmIdentifier()) && isMinimumHighway(object);
+                && !this.isFlagged(object.getOsmIdentifier()) && this.isMinimumHighway(object);
     }
 
     /**
@@ -87,7 +87,7 @@ public class InvalidAccessTagCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        if (!isInMilitaryArea((LineItem) object))
+        if (!this.isInMilitaryArea((LineItem) object))
         {
             this.markAsFlagged(object.getOsmIdentifier());
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -51,7 +51,7 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
     public InvalidLanesTagCheck(final Configuration configuration)
     {
         super(configuration);
-        this.lanesFilter = (TaggableFilter) configurationValue(configuration, "lanes.filter",
+        this.lanesFilter = this.configurationValue(configuration, "lanes.filter",
                 LANES_FILTER_DEFAULT, value -> TaggableFilter.forDefinition(value.toString()));
     }
 
@@ -81,7 +81,7 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        if (this.isChecked.contains(object.getIdentifier()) || !partOfTollBooth(object))
+        if (this.isChecked.contains(object.getIdentifier()) || !this.partOfTollBooth(object))
         {
             this.markAsFlagged(object.getOsmIdentifier());
 
@@ -150,7 +150,7 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
      */
     private boolean partOfTollBooth(final AtlasObject object)
     {
-        final HashSet<Edge> connectedInvalidEdges = connectedInvalidLanes(object);
+        final HashSet<Edge> connectedInvalidEdges = this.connectedInvalidLanes(object);
 
         // check for toll booths
         for (final Edge edge : connectedInvalidEdges)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/MixedCaseNameCheck.java
@@ -81,20 +81,20 @@ public class MixedCaseNameCheck extends BaseCheck<String>
     public MixedCaseNameCheck(final Configuration configuration)
     {
         super(configuration);
-        this.checkNameCountries = (List<String>) configurationValue(configuration,
-                "check_name.countries", CHECK_NAME_COUNTRIES_DEFAULT);
-        this.languageNameTags = (List<String>) configurationValue(configuration,
-                "name.language.keys", LANGUAGE_NAME_TAGS_DEFAULT);
-        this.lowerCasePrepositions = (List<String>) configurationValue(configuration,
-                "name.prepositions", LOWER_CASE_PREPOSITIONS_DEFAULT);
-        this.lowerCaseArticles = (List<String>) configurationValue(configuration, "name.articles",
+        this.checkNameCountries = this.configurationValue(configuration, "check_name.countries",
+                CHECK_NAME_COUNTRIES_DEFAULT);
+        this.languageNameTags = this.configurationValue(configuration, "name.language.keys",
+                LANGUAGE_NAME_TAGS_DEFAULT);
+        this.lowerCasePrepositions = this.configurationValue(configuration, "name.prepositions",
+                LOWER_CASE_PREPOSITIONS_DEFAULT);
+        this.lowerCaseArticles = this.configurationValue(configuration, "name.articles",
                 LOWER_CASE_ARTICLES_DEFAULT);
-        this.splitCharacters = (String) configurationValue(configuration, "regex.split",
+        this.splitCharacters = this.configurationValue(configuration, "regex.split",
                 SPLIT_CHARACTERS_DEFAULT);
-        this.nameAffixes = (String) configurationValue(configuration, "name.affixes",
-                NAME_AFFIXES_DEFAULT, value -> String.join("|", (List<String>) value));
-        this.mixedCaseUnits = (String) configurationValue(configuration, "name.units",
-                MIXED_CASE_UNITS_DEFAULT, value -> String.join("|", (List<String>) value));
+        this.nameAffixes = this.configurationValue(configuration, "name.affixes",
+                NAME_AFFIXES_DEFAULT, value -> String.join("|", value));
+        this.mixedCaseUnits = this.configurationValue(configuration, "name.units",
+                MIXED_CASE_UNITS_DEFAULT, value -> String.join("|", value));
 
         // Compile regex
         this.upperCasePattern = Pattern.compile("\\p{Lu}");
@@ -151,14 +151,14 @@ public class MixedCaseNameCheck extends BaseCheck<String>
         final String country = object.tag(ISOCountryTag.KEY);
         if (country != null && this.checkNameCountries.contains(country.toUpperCase())
                 && Validators.hasValuesFor(object, NameTag.class)
-                && isMixedCase(osmTags.get(NameTag.KEY)))
+                && this.isMixedCase(osmTags.get(NameTag.KEY)))
         {
             mixedCaseNameTags.add(NameTag.KEY);
         }
         // Check all language name tags
         for (final String key : this.languageNameTags)
         {
-            if (osmTags.containsKey(key) && isMixedCase(osmTags.get(key)))
+            if (osmTags.containsKey(key) && this.isMixedCase(osmTags.get(key)))
             {
                 mixedCaseNameTags.add(key);
             }
@@ -210,7 +210,7 @@ public class MixedCaseNameCheck extends BaseCheck<String>
             for (final String word : wordArray)
             {
                 // Check if the word is intentionally mixed case
-                if (!isMixedCaseUnit(word))
+                if (!this.isMixedCaseUnit(word))
                 {
                     final Matcher firstLetterMatcher = this.anyLetterPattern.matcher(word);
                     // If the word is not in the list of prepositions, and the
@@ -227,8 +227,8 @@ public class MixedCaseNameCheck extends BaseCheck<String>
                             // If the word is not all upper case: check if all the letters not
                             // following apostrophes, unless at the end of the word, are lower case
                             || this.lowerCasePattern.matcher(word).find()
-                                    && !isMixedCaseApostrophe(word)
-                                    && isProperNonFirstCapital(word))
+                                    && !this.isMixedCaseApostrophe(word)
+                                    && this.isProperNonFirstCapital(word))
                     {
                         return true;
                     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameGapCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameGapCheck.java
@@ -65,9 +65,9 @@ public class RoadNameGapCheck extends BaseCheck<Long>
     public RoadNameGapCheck(final Configuration configuration)
     {
         super(configuration);
-        this.validHighwayTag = configurationValue(configuration, "valid.highway.tag",
-                VALID_HIGHWAY_TAG_DEFAULT).stream().map(String::toLowerCase)
-                        .collect(Collectors.toList());
+        this.validHighwayTag = this
+                .configurationValue(configuration, "valid.highway.tag", VALID_HIGHWAY_TAG_DEFAULT)
+                .stream().map(String::toLowerCase).collect(Collectors.toList());
     }
 
     /**
@@ -99,17 +99,17 @@ public class RoadNameGapCheck extends BaseCheck<Long>
         final Edge edge = (Edge) object;
         final EdgePredicate edgePredicate = new EdgePredicate(edge);
         final Set<Edge> inEdges = edge.inEdges().stream()
-                .filter(obj -> validCheckForObject(obj) && edgePredicate.isSameHeading(obj))
+                .filter(obj -> this.validCheckForObject(obj) && edgePredicate.isSameHeading(obj))
                 .collect(Collectors.toSet());
         final Set<Edge> outEdges = edge.outEdges().stream()
-                .filter(obj -> validCheckForObject(obj) && edgePredicate.isSameHeading(obj))
+                .filter(obj -> this.validCheckForObject(obj) && edgePredicate.isSameHeading(obj))
                 .collect(Collectors.toSet());
         if (inEdges.isEmpty() || outEdges.isEmpty())
         {
             return Optional.empty();
         }
 
-        final Set<String> matchingInAndOutEdgeNames = getMatchingInAndOutEdgeNames(inEdges,
+        final Set<String> matchingInAndOutEdgeNames = this.getMatchingInAndOutEdgeNames(inEdges,
                 outEdges);
         if (matchingInAndOutEdgeNames.isEmpty())
         {
@@ -121,8 +121,8 @@ public class RoadNameGapCheck extends BaseCheck<Long>
         // doesn't have a name.
         if (!edge.getName().isPresent())
         {
-            return Optional.of(
-                    createFlag(object, this.getLocalizedInstruction(0, edge.getOsmIdentifier())));
+            return Optional.of(this.createFlag(object,
+                    this.getLocalizedInstruction(0, edge.getOsmIdentifier())));
         }
         final Optional<String> edgeName = edge.getName();
 
@@ -130,9 +130,9 @@ public class RoadNameGapCheck extends BaseCheck<Long>
         {
             final Set<Edge> connectedEdges = edge.connectedEdges().stream()
                     .filter(this::validCheckForObject).collect(Collectors.toSet());
-            return findMatchingEdgeNameWithConnectedEdges(connectedEdges, edgeName.get())
+            return this.findMatchingEdgeNameWithConnectedEdges(connectedEdges, edgeName.get())
                     ? Optional.empty()
-                    : Optional.of(createFlag(object, this.getLocalizedInstruction(1,
+                    : Optional.of(this.createFlag(object, this.getLocalizedInstruction(1,
                             edge.getOsmIdentifier(), edgeName.get())));
 
         }

--- a/src/test/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJobTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJobTest.java
@@ -42,7 +42,7 @@ public class ShardedIntegrityChecksSparkJobTest
     @Test
     public void countFlagsTest() throws FileNotFoundException, IOException
     {
-        generateData();
+        this.generateData();
 
         Assert.assertTrue(OUTPUT.child("flag").child(COUNTRY_CODE).exists());
         final Set<File> flagFiles = OUTPUT.child("flag").child(COUNTRY_CODE).listFilesRecursively()
@@ -59,7 +59,7 @@ public class ShardedIntegrityChecksSparkJobTest
     @Test
     public void countGeojsonTest()
     {
-        generateData();
+        this.generateData();
 
         Assert.assertTrue(OUTPUT.child("geojson").child(COUNTRY_CODE).exists());
         Assert.assertTrue(OUTPUT.child("geojson").child(COUNTRY_CODE).listFilesRecursively()
@@ -69,7 +69,7 @@ public class ShardedIntegrityChecksSparkJobTest
     @Test
     public void countMetricsTest()
     {
-        generateData();
+        this.generateData();
 
         Assert.assertTrue(OUTPUT.child("metric").child(COUNTRY_CODE).exists());
         Assert.assertEquals(2, OUTPUT.child("metric").child(COUNTRY_CODE).listFilesRecursively()
@@ -79,7 +79,7 @@ public class ShardedIntegrityChecksSparkJobTest
     @Test
     public void tippecanoeTest()
     {
-        generateData();
+        this.generateData();
 
         Assert.assertTrue(OUTPUT.child("tippecanoe").child(COUNTRY_CODE).exists());
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagFileProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagFileProcessorTest.java
@@ -40,49 +40,49 @@ public class CheckFlagFileProcessorTest
     @Test
     public void testBatchSizeEvent() throws IOException
     {
-        processCompleteAndValidate(BATCH_SIZE);
+        this.processCompleteAndValidate(BATCH_SIZE);
     }
 
     @Test
     public void testBatchSizeMinusOneEvent() throws IOException
     {
-        processCompleteAndValidate(BATCH_SIZE - 1);
+        this.processCompleteAndValidate(BATCH_SIZE - 1);
     }
 
     @Test
     public void testBatchSizePlusOneEvent() throws IOException
     {
-        processCompleteAndValidate(BATCH_SIZE + 1);
+        this.processCompleteAndValidate(BATCH_SIZE + 1);
     }
 
     @Test
     public void testOneEvent() throws IOException
     {
-        processCompleteAndValidate(1);
+        this.processCompleteAndValidate(1);
     }
 
     @Test
     public void testTenEvent() throws IOException
     {
-        processCompleteAndValidate(10);
+        this.processCompleteAndValidate(10);
     }
 
     @Test
     public void testTwoBatchSizeEvent() throws IOException
     {
-        processCompleteAndValidate(2 * BATCH_SIZE);
+        this.processCompleteAndValidate(2 * BATCH_SIZE);
     }
 
     @Test
     public void testTwoEvent() throws IOException
     {
-        processCompleteAndValidate(2);
+        this.processCompleteAndValidate(2);
     }
 
     @Test
     public void testZeroEvent() throws IOException
     {
-        processCompleteAndValidate(0);
+        this.processCompleteAndValidate(0);
     }
 
     private void compareJsonAndEventObject(final String json, final CheckFlagEvent event)
@@ -114,7 +114,7 @@ public class CheckFlagFileProcessorTest
             for (final String line : file.lines())
             {
                 actualEventCount++;
-                compareJsonAndEventObject(line, SAMPLE_EVENT);
+                this.compareJsonAndEventObject(line, SAMPLE_EVENT);
             }
         }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessorTest.java
@@ -36,31 +36,31 @@ public class CheckFlagGeoJsonProcessorTest
     @Test
     public void testHundredEvent() throws IOException
     {
-        processCompleteAndValidate(100);
+        this.processCompleteAndValidate(100);
     }
 
     @Test
     public void testOneEvent() throws IOException
     {
-        processCompleteAndValidate(1);
+        this.processCompleteAndValidate(1);
     }
 
     @Test
     public void testTenEvent() throws IOException
     {
-        processCompleteAndValidate(10);
+        this.processCompleteAndValidate(10);
     }
 
     @Test
     public void testTwoEvent() throws IOException
     {
-        processCompleteAndValidate(2);
+        this.processCompleteAndValidate(2);
     }
 
     @Test
     public void testZeroEvent() throws IOException
     {
-        processCompleteAndValidate(0);
+        this.processCompleteAndValidate(0);
     }
 
     private void processCompleteAndValidate(final int eventCount)

--- a/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagTippecanoeProcessorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagTippecanoeProcessorTest.java
@@ -39,31 +39,31 @@ public class CheckFlagTippecanoeProcessorTest
     @Test
     public void testHundredEvent() throws IOException
     {
-        processCompleteAndValidate(100);
+        this.processCompleteAndValidate(100);
     }
 
     @Test
     public void testOneEvent() throws IOException
     {
-        processCompleteAndValidate(1);
+        this.processCompleteAndValidate(1);
     }
 
     @Test
     public void testTenEvent() throws IOException
     {
-        processCompleteAndValidate(10);
+        this.processCompleteAndValidate(10);
     }
 
     @Test
     public void testTwoEvent() throws IOException
     {
-        processCompleteAndValidate(2);
+        this.processCompleteAndValidate(2);
     }
 
     @Test
     public void testZeroEvent() throws IOException
     {
-        processCompleteAndValidate(0);
+        this.processCompleteAndValidate(0);
     }
 
     private void processCompleteAndValidate(final int eventCount)
@@ -86,7 +86,7 @@ public class CheckFlagTippecanoeProcessorTest
         Assert.assertEquals(Math.max((int) Math.ceil(eventCount / (double) BATCH_SIZE), 1),
                 files.size());
 
-        processTippecanoeLineDelimitedGeoJson(eventCount, files);
+        this.processTippecanoeLineDelimitedGeoJson(eventCount, files);
 
         // Cleanup
         tempDirectory.delete();

--- a/src/test/java/org/openstreetmap/atlas/checks/event/MetricFileGeneratorTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/MetricFileGeneratorTest.java
@@ -74,31 +74,31 @@ public class MetricFileGeneratorTest
     @Test
     public void testHundredEvent() throws IOException
     {
-        processCompleteAndValidate(100);
+        this.processCompleteAndValidate(100);
     }
 
     @Test
     public void testOneEvent() throws IOException
     {
-        processCompleteAndValidate(1);
+        this.processCompleteAndValidate(1);
     }
 
     @Test
     public void testTenEvent() throws IOException
     {
-        processCompleteAndValidate(10);
+        this.processCompleteAndValidate(10);
     }
 
     @Test
     public void testTwoEvent() throws IOException
     {
-        processCompleteAndValidate(2);
+        this.processCompleteAndValidate(2);
     }
 
     @Test
     public void testZeroEvent() throws IOException
     {
-        processCompleteAndValidate(0);
+        this.processCompleteAndValidate(0);
     }
 
     private void processCompleteAndValidate(final int eventCount) throws IOException

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
@@ -94,7 +94,7 @@ public class ChallengeSerializationTest
         final String raw = challenge.readAndClose();
 
         final JsonObject deserializedJson = deserializedChallenge.toJson("123456789");
-        final JsonObject rawJson = getGson().fromJson(raw, JsonObject.class);
+        final JsonObject rawJson = this.getGson().fromJson(raw, JsonObject.class);
 
         Assert.assertEquals(deserializedJson.get("name"), rawJson.get("name"));
         Assert.assertEquals(deserializedJson.get("description"), rawJson.get("description"));
@@ -118,7 +118,7 @@ public class ChallengeSerializationTest
         final String raw = challenge.readAndClose();
 
         final JsonObject deserializedJson = deserializedChallenge.toJson("123456789");
-        final JsonObject rawJson = getGson().fromJson(raw, JsonObject.class);
+        final JsonObject rawJson = this.getGson().fromJson(raw, JsonObject.class);
 
         Assert.assertEquals("123456789", deserializedJson.get("name").getAsString());
         Assert.assertNull(rawJson.get("name"));
@@ -138,7 +138,7 @@ public class ChallengeSerializationTest
     {
         final ClassResource challengeResource = new ClassResource(resource);
         final JsonObject challengeJSON = challengeResource.getJSONResourceObject(JsonObject.class);
-        return getGson().fromJson(challengeJSON, Challenge.class);
+        return this.getGson().fromJson(challengeJSON, Challenge.class);
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheckTest.java
@@ -40,26 +40,27 @@ public class BigNodeBadDataCheckTest
     @Test
     public void testBigNodeAtlas()
     {
-        Assert.assertTrue(runTest(this.setup.getBigNodeAtlas(), this.configNormalThreshold, 1));
+        Assert.assertTrue(
+                this.runTest(this.setup.getBigNodeAtlas(), this.configNormalThreshold, 1));
     }
 
     @Test
     public void testCheckBasedOnJunctionEdges()
     {
-        Assert.assertTrue(runTest(this.setup.getAtlas(), this.configLowJunctionsThreshold, 3));
+        Assert.assertTrue(this.runTest(this.setup.getAtlas(), this.configLowJunctionsThreshold, 3));
     }
 
     @Test
     public void testCheckBasedOnPaths()
     {
-        Assert.assertTrue(runTest(this.setup.getAtlas(), this.configLowPathsThreshold, 6));
+        Assert.assertTrue(this.runTest(this.setup.getAtlas(), this.configLowPathsThreshold, 6));
     }
 
     @Test
     public void testConnectedEdgesHighwayFiltering()
     {
-        Assert.assertTrue(
-                runTest(this.setup.getAtlas(), this.configLowPathsThresholdWithHighwayFilter, 4));
+        Assert.assertTrue(this.runTest(this.setup.getAtlas(),
+                this.configLowPathsThresholdWithHighwayFilter, 4));
     }
 
     private boolean runTest(final Atlas atlas, final Configuration config,


### PR DESCRIPTION
See https://github.com/osmlab/atlas-checks/pull/332#discussion_r485816232. It turns out that it is checkstyle, not spotless, that looks for `this` qualifiers.

### Description:
Add `this` qualifiers to methods.

### Potential Impact:
N/A

### Unit Test Approach:
N/A

### Test Results:
N/A

