### PR TITLE
CheckFlag Fix Suggestions

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -47,6 +47,7 @@ public final class CheckFlagEvent extends Event
     private static final String FEATURE_COLLECTION = "FeatureCollection";
     private static final String INSTRUCTIONS = "instructions";
     private static final String IDENTIFIERS = "identifiers";
+    private static final String FIX_SUGGESTIONS = "fix_suggestions";
 
     private static final Gson GSON = new Gson();
 
@@ -151,7 +152,7 @@ public final class CheckFlagEvent extends Event
         flagProperties.add("feature_osmids", uniqueFeatureOsmIds);
         flagProperties.addProperty("feature_count", featureProperties.size());
         flagProperties.add(IDENTIFIERS, GSON.toJsonTree(flag.getUniqueIdentifiers()));
-        flagProperties.add("fix_suggestions", getFixSuggestionDescriptions(flag));
+        flagProperties.add(FIX_SUGGESTIONS, getFixSuggestionDescriptions(flag));
 
         feature.addProperty("id", flag.getIdentifier());
         feature.add("properties", flagProperties);
@@ -207,7 +208,7 @@ public final class CheckFlagEvent extends Event
         flagJson.add("properties", flagPropertiesJson);
 
         // Add fix suggestions as their own foreign object in the geojson
-        flagJson.add("fix_suggestions", getFixSuggestionDescriptions(flag));
+        flagJson.add(FIX_SUGGESTIONS, getFixSuggestionDescriptions(flag));
 
         return flagJson;
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagEvent.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openstreetmap.atlas.checks.base.Check;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.flag.FlaggedObject;
@@ -34,7 +35,8 @@ import com.google.gson.JsonPrimitive;
  * Wraps a {@link CheckFlag} for submission to the
  * {@link org.openstreetmap.atlas.event.EventService} for handling {@link Check} results
  *
- * @author mkalender, bbreithaupt
+ * @author mkalender
+ * @author bbreithaupt
  */
 public final class CheckFlagEvent extends Event
 {
@@ -149,6 +151,7 @@ public final class CheckFlagEvent extends Event
         flagProperties.add("feature_osmids", uniqueFeatureOsmIds);
         flagProperties.addProperty("feature_count", featureProperties.size());
         flagProperties.add(IDENTIFIERS, GSON.toJsonTree(flag.getUniqueIdentifiers()));
+        flagProperties.add("fix_suggestions", getFixSuggestionDescriptions(flag));
 
         feature.addProperty("id", flag.getIdentifier());
         feature.add("properties", flagProperties);
@@ -202,6 +205,10 @@ public final class CheckFlagEvent extends Event
 
         // Add properties to the previously generate geojson
         flagJson.add("properties", flagPropertiesJson);
+
+        // Add fix suggestions as their own foreign object in the geojson
+        flagJson.add("fix_suggestions", getFixSuggestionDescriptions(flag));
+
         return flagJson;
     }
 
@@ -233,6 +240,17 @@ public final class CheckFlagEvent extends Event
         }
         return Optional.ofNullable(highestHighwayTag)
                 .map(tag -> String.format("%s=%s", HighwayTag.KEY, tag.getTagValue()));
+    }
+
+    private static JsonObject getFixSuggestionDescriptions(final CheckFlag flag)
+    {
+        final JsonObject fixSuggestionObject = new JsonObject();
+        flag.getFixSuggestions()
+                .forEach(suggestion -> fixSuggestionObject.add(
+                        StringUtils.capitalize(suggestion.getItemType().toString().toLowerCase())
+                                + suggestion.getIdentifier(),
+                        suggestion.explain().toJsonElement()));
+        return fixSuggestionObject;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -115,7 +115,8 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
 
     /**
      * Creates a {@link CheckFlag} with the addition of a list of {@code point} {@link Location}s
-     * that highlight specific points in the geometry that caused the rule violation
+     * that highlight specific points and a {@link Set} of {@link FeatureChange}s that suggest how
+     * to fix the flagged objects.
      *
      * @param identifier
      *            the identifying value to flag

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -5,8 +5,10 @@ import java.io.OutputStreamWriter;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -23,6 +25,7 @@ import org.openstreetmap.atlas.geography.Located;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasItem;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
@@ -61,6 +64,7 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     private Set<FlaggedObject> flaggedObjects = new LinkedHashSet<>();
     private final String identifier;
     private final List<String> instructions = new ArrayList<>();
+    private final Set<FeatureChange> fixSuggestions = new HashSet<>();
 
     /**
      * A basic constructor that simply flags some identifying value
@@ -106,10 +110,64 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
     public CheckFlag(final String identifier, final Set<? extends AtlasObject> objects,
             final List<String> instructions, final List<Location> points)
     {
+        this(identifier, objects, instructions, points, new HashSet<>());
+    }
+
+    /**
+     * Creates a {@link CheckFlag} with the addition of a list of {@code point} {@link Location}s
+     * that highlight specific points in the geometry that caused the rule violation
+     *
+     * @param identifier
+     *            the identifying value to flag
+     * @param objects
+     *            {@link AtlasObject}s to flag
+     * @param instructions
+     *            a list of free form instructions
+     * @param points
+     *            {@code point} {@link Location}s to highlight
+     * @param fixSuggestions
+     *            {@link Set} of {@link FeatureChange}s representing suggested fixes for flagged
+     *            features
+     */
+    public CheckFlag(final String identifier, final Set<? extends AtlasObject> objects,
+            final List<String> instructions, final List<Location> points,
+            final Set<FeatureChange> fixSuggestions)
+    {
         addObjects(objects);
         addPoints(points);
         addInstructions(instructions);
         this.identifier = identifier;
+        this.addFixSuggestions(fixSuggestions);
+    }
+
+    /**
+     * Add a single {@link FeatureChange} to the fix suggestions. Fix suggestions should be
+     * {@link FeatureChange}s of
+     * {@link org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity}s created from flagged
+     * {@link org.openstreetmap.atlas.geography.atlas.items.AtlasEntity}s with changes suggesting
+     * how the flagged feature can be fixed.
+     *
+     * @param suggestion
+     *            {@link FeatureChange} with suggested alterations to a flagged feature
+     * @return this {@link CheckFlag}
+     */
+    public CheckFlag addFixSuggestion(final FeatureChange suggestion)
+    {
+        this.fixSuggestions.add(suggestion);
+        return this;
+    }
+
+    /**
+     * Add a {@link Set} of {@link FeatureChange}s to the fix suggestions.
+     *
+     * @param suggestions
+     *            {@link Collection} of {@link FeatureChange} fix suggestions
+     * @return this {@link CheckFlag}
+     */
+    public CheckFlag addFixSuggestions(final Collection<FeatureChange> suggestions)
+    {
+        this.fixSuggestions.addAll(suggestions);
+        return this;
     }
 
     /**
@@ -300,6 +358,14 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
             }
         }
         return FlaggedObject.COUNTRY_MISSING;
+    }
+
+    /**
+     * @return a {@link Set} of {@link FeatureChange} fix suggestions
+     */
+    public Set<FeatureChange> getFixSuggestions()
+    {
+        return this.fixSuggestions;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheck.java
@@ -105,7 +105,7 @@ public class AreasWithHighwayTagCheck extends BaseCheck<Long>
                                             (AtlasEntity) ((CompleteEntity) CompleteEntity
                                                     .shallowFrom((AtlasEntity) toFlag))
                                                             .withTags(toFlag.getTags())
-                                                            .withRemovedTag(HighwayTag.KEY),
+                                                            .withRemovedTag(AreaTag.KEY),
                                             object.getAtlas()))
                                     .collect(Collectors.toSet()));
                 });

--- a/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagEventTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagEventTest.java
@@ -1,0 +1,307 @@
+package org.openstreetmap.atlas.checks.event;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescriptorType;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptorName;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteRelation;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.names.NameTag;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Unit tests for {@link CheckFlagEvent}.
+ *
+ * @author bbreithaupt
+ */
+public class CheckFlagEventTest
+{
+
+    @Rule
+    public final CheckFlagEventTestRule rule = new CheckFlagEventTestRule();
+
+    @Test
+    public void flagToFeatureAddTagFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToFeature(
+                new CheckFlag("1").addFixSuggestion(FeatureChange.add(
+                        CompleteNode.from(atlas.node(1)).withAddedTag(NameTag.KEY, "n"), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.get("properties").getAsJsonObject().has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("properties").getAsJsonObject()
+                .get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.TAG.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.ADD.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(NameTag.KEY, firstDescriptor.get("key").getAsString());
+        Assert.assertEquals("n", firstDescriptor.get("value").getAsString());
+    }
+
+    @Test
+    public void flagToFeatureRemoveTagFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToFeature(
+                new CheckFlag("1").addFixSuggestion(FeatureChange
+                        .add(CompleteNode.from(atlas.node(1)).withRemovedTag(LayerTag.KEY), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.get("properties").getAsJsonObject().has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("properties").getAsJsonObject()
+                .get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.TAG.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.REMOVE.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(LayerTag.KEY, firstDescriptor.get("key").getAsString());
+        Assert.assertEquals("1", firstDescriptor.get("value").getAsString());
+    }
+
+    @Test
+    public void flagToFeatureUpdateGeometryFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent
+                .flagToFeature(
+                        new CheckFlag("1")
+                                .addFixSuggestion(
+                                        FeatureChange.add(
+                                                (AtlasEntity) CompleteNode.from(atlas.node(1))
+                                                        .withGeometry(Collections
+                                                                .singleton(Location.CENTER)),
+                                                atlas)),
+                        Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.get("properties").getAsJsonObject().has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("properties").getAsJsonObject()
+                .get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.GEOMETRY.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.UPDATE.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(Location.CENTER.toWkt(),
+                firstDescriptor.get("afterView").getAsString());
+    }
+
+    @Test
+    public void flagToFeatureUpdateRelationMemberRoleFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToFeature(
+                new CheckFlag("1").addFixSuggestion(
+                        FeatureChange.add(CompleteRelation.from(atlas.relation(123))
+                                .changeMemberRole(atlas.node(1), "still_not_real"), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.get("properties").getAsJsonObject().has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("properties").getAsJsonObject()
+                .get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Relation123"));
+        final JsonObject node1 = fixSuggestions.get("Relation123").getAsJsonObject();
+        Assert.assertEquals(2, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.RELATION_MEMBER.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.ADD.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals("still_not_real", firstDescriptor.get("role").getAsString());
+        final JsonObject secondDescriptor = node1.get("descriptors").getAsJsonArray().get(1)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.RELATION_MEMBER.toString(),
+                secondDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.REMOVE.toString(),
+                secondDescriptor.get("type").getAsString());
+        Assert.assertEquals("not_real", secondDescriptor.get("role").getAsString());
+    }
+
+    @Test
+    public void flagToFeatureUpdateTagFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToFeature(
+                new CheckFlag("1")
+                        .addFixSuggestion(FeatureChange.add(CompleteNode.from(atlas.node(1))
+                                .withReplacedTag(LayerTag.KEY, LayerTag.KEY, "2"), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.get("properties").getAsJsonObject().has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("properties").getAsJsonObject()
+                .get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.TAG.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.UPDATE.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(LayerTag.KEY, firstDescriptor.get("key").getAsString());
+        Assert.assertEquals("2", firstDescriptor.get("value").getAsString());
+        Assert.assertEquals("1", firstDescriptor.get("originalValue").getAsString());
+    }
+
+    @Test
+    public void flagToJsonAddTagFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToJson(
+                new CheckFlag("1").addFixSuggestion(FeatureChange.add(
+                        CompleteNode.from(atlas.node(1)).withAddedTag(NameTag.KEY, "n"), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.TAG.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.ADD.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(NameTag.KEY, firstDescriptor.get("key").getAsString());
+        Assert.assertEquals("n", firstDescriptor.get("value").getAsString());
+    }
+
+    @Test
+    public void flagToJsonRemoveTagFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToJson(
+                new CheckFlag("1").addFixSuggestion(FeatureChange
+                        .add(CompleteNode.from(atlas.node(1)).withRemovedTag(LayerTag.KEY), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.TAG.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.REMOVE.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(LayerTag.KEY, firstDescriptor.get("key").getAsString());
+        Assert.assertEquals("1", firstDescriptor.get("value").getAsString());
+    }
+
+    @Test
+    public void flagToJsonUpdateGeometryFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent
+                .flagToJson(
+                        new CheckFlag("1")
+                                .addFixSuggestion(
+                                        FeatureChange.add(
+                                                (AtlasEntity) CompleteNode.from(atlas.node(1))
+                                                        .withGeometry(Collections
+                                                                .singleton(Location.CENTER)),
+                                                atlas)),
+                        Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.GEOMETRY.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.UPDATE.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(Location.CENTER.toWkt(),
+                firstDescriptor.get("afterView").getAsString());
+    }
+
+    @Test
+    public void flagToJsonUpdateRelationMemberRoleFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToJson(
+                new CheckFlag("1").addFixSuggestion(
+                        FeatureChange.add(CompleteRelation.from(atlas.relation(123))
+                                .changeMemberRole(atlas.node(1), "still_not_real"), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Relation123"));
+        final JsonObject node1 = fixSuggestions.get("Relation123").getAsJsonObject();
+        Assert.assertEquals(2, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.RELATION_MEMBER.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.ADD.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals("still_not_real", firstDescriptor.get("role").getAsString());
+        final JsonObject secondDescriptor = node1.get("descriptors").getAsJsonArray().get(1)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.RELATION_MEMBER.toString(),
+                secondDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.REMOVE.toString(),
+                secondDescriptor.get("type").getAsString());
+        Assert.assertEquals("not_real", secondDescriptor.get("role").getAsString());
+    }
+
+    @Test
+    public void flagToJsonUpdateTagFixSuggestionTest()
+    {
+        final Atlas atlas = this.rule.getAtlas();
+        final JsonObject flagJson = CheckFlagEvent.flagToJson(
+                new CheckFlag("1")
+                        .addFixSuggestion(FeatureChange.add(CompleteNode.from(atlas.node(1))
+                                .withReplacedTag(LayerTag.KEY, LayerTag.KEY, "2"), atlas)),
+                Collections.emptyMap());
+
+        Assert.assertTrue(flagJson.has("fix_suggestions"));
+        final JsonObject fixSuggestions = flagJson.get("fix_suggestions").getAsJsonObject();
+        Assert.assertTrue(fixSuggestions.has("Node1"));
+        final JsonObject node1 = fixSuggestions.get("Node1").getAsJsonObject();
+        Assert.assertEquals(1, node1.get("descriptors").getAsJsonArray().size());
+        final JsonObject firstDescriptor = node1.get("descriptors").getAsJsonArray().get(0)
+                .getAsJsonObject();
+        Assert.assertEquals(ChangeDescriptorName.TAG.toString(),
+                firstDescriptor.get("name").getAsString());
+        Assert.assertEquals(ChangeDescriptorType.UPDATE.toString(),
+                firstDescriptor.get("type").getAsString());
+        Assert.assertEquals(LayerTag.KEY, firstDescriptor.get("key").getAsString());
+        Assert.assertEquals("2", firstDescriptor.get("value").getAsString());
+        Assert.assertEquals("1", firstDescriptor.get("originalValue").getAsString());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagEventTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/event/CheckFlagEventTestRule.java
@@ -1,0 +1,32 @@
+package org.openstreetmap.atlas.checks.event;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * Unit test rule for {@link CheckFlagEventTest}.
+ *
+ * @author bbreithaupt
+ */
+public class CheckFlagEventTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "31.335310,-121.009566";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = TEST_1), tags = { "layer=1" }) },
+            // Relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "1", type = "node", role = "not_real") }) })
+    private Atlas atlas;
+
+    public Atlas getAtlas()
+    {
+        return this.atlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/flag/CheckFlagTest.java
@@ -14,7 +14,10 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.event.CheckFlagEvent;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteNode;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 
@@ -25,6 +28,7 @@ import com.google.gson.JsonObject;
  *
  * @author mkalender
  * @author sayas01
+ * @author bbreithaupt
  */
 public class CheckFlagTest
 {
@@ -80,6 +84,20 @@ public class CheckFlagTest
         final String geoJsonFeatureString = geoJsonFeature.toString();
 
         Assert.assertEquals(GEO_JSON_FEATURE_STRING, geoJsonFeatureString);
+    }
+
+    @Test
+    public void testFixSuggestions()
+    {
+        final CheckFlag flag = new CheckFlag("1");
+        final Atlas atlas = this.setup.getAtlas();
+        final FeatureChange change1 = FeatureChange.add(CompleteNode.from(atlas.node(1)));
+        final FeatureChange change2 = FeatureChange.add(CompleteNode.from(atlas.node(2)));
+
+        flag.addFixSuggestion(change1);
+        flag.addFixSuggestion(change2);
+        Assert.assertTrue(flag.getFixSuggestions().contains(change1));
+        Assert.assertTrue(flag.getFixSuggestions().contains(change2));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/areas/AreasWithHighwayTagCheckTest.java
@@ -1,14 +1,19 @@
 package org.openstreetmap.atlas.checks.validation.areas;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
 
 /**
  * @author matthieun
  * @author daniel-baah
+ * @author bbreithaupt
  */
 public class AreasWithHighwayTagCheckTest
 {
@@ -20,6 +25,17 @@ public class AreasWithHighwayTagCheckTest
     private final AreasWithHighwayTagCheck check = new AreasWithHighwayTagCheck(
             ConfigurationResolver.inlineConfiguration(
                     "{\"AreasWithHighwayTagCheck\":{\"tags.filter\":\"highway->*&area->yes\"}}"));
+
+    private static void verifyObjectsAndSuggestions(final CheckFlag flag, final int count)
+    {
+        Assert.assertEquals(count, flag.getFlaggedObjects().size());
+        Assert.assertEquals(count, flag.getFixSuggestions().size());
+        final List<Long> objectIds = flag.getFlaggedObjects().stream()
+                .map(object -> Long.valueOf(object.getProperties().get("identifier")))
+                .collect(Collectors.toList());
+        flag.getFixSuggestions().forEach(
+                suggestion -> Assert.assertTrue(objectIds.contains(suggestion.getIdentifier())));
+    }
 
     @Test
     public void areaNoHighwayTag()
@@ -33,21 +49,23 @@ public class AreasWithHighwayTagCheckTest
     {
         this.verifier.actual(this.setup.connectedEdgesBadTags(), this.check);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> verifyObjectsAndSuggestions(flag, 2));
     }
 
     @Test
     public void invalidAreaHighwayFootwayTag()
     {
         this.verifier.actual(this.setup.invalidAreaHighwayFootwayTagAtlas(), this.check);
-        this.verifier.verifyNotEmpty();
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verifyObjectsAndSuggestions(flag, 1));
     }
 
     @Test
     public void invalidAreaHighwayPrimaryTag()
     {
         this.verifier.actual(this.setup.invalidAreaHighwayPrimaryTagAtlas(), this.check);
-        this.verifier.verifyNotEmpty();
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verifyObjectsAndSuggestions(flag, 1));
     }
 
     @Test
@@ -55,6 +73,7 @@ public class AreasWithHighwayTagCheckTest
     {
         this.verifier.actual(this.setup.invalidEdgeHighwaySecondary(), this.check);
         this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verifyObjectsAndSuggestions(flag, 1));
     }
 
     @Test


### PR DESCRIPTION
### Description:

This is an expansion of the CheckFlag data structure to allow checks to add suggested fixes for data errors.

These suggested fixes can be added in the form of FeatureChanges. Ideally the FeatureChanges are created by altering CompleteEntity copies of AtlasEntitys that in the flaggedObjects of the CheckFlag. The FeatureChanges should also include a before view of the feature by providing an atlas context when creating it. The before view is necessary to calculate the changes made to the feature. 

2 new methods are added to CheckFlag for adding fix suggestions: `addFixSuggestion(FeatureChange)` and `addFixSuggestions(Collection<FeatureChange>)`. Both return the CheckFlag to allow for chained calls. 
A getter is also added for the fix suggestions: `public Set<FeatureChange> getFixSuggestions()`

The information from the fix suggestions is added to both the flag and geojson logs. In both it appears as an object under the key `fix_suggestions`, however, in the flag logs this key is found in the root object of the line and in the geojson it is under the properties or each feature collection. The `fix_suggestions` object contains elements whose keys are unique feature IDs. Each element contains a description of the changes made to a feature (See example below).

Included in this PR is an update to the AreasWithHighwayTagCheck to demonstrate the use of this new addition to CheckFlags. The check will now flag a feature and provide a suggested fix of either removing the area tag or updating the highway tag to be highway=pedestrian. The following are flag logs produced by the check:

```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            55.4535187,
            25.3628649
          ],
          [
            55.4535376,
            25.3627203
          ]
        ]
      },
      "properties": {
        "area": "yes",
        "last_edit_user_name": "CartographicChels",
        "last_edit_changeset": "70291534",
        "identifier": "209331363000004",
        "itemType": "Edge",
        "last_edit_time": "1557974395000",
        "last_edit_user_id": "9051059",
        "iso_country_code": "ARE",
        "osmIdentifier": "209331363",
        "highway": "footway",
        "last_edit_version": "2"
      }
    },
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            55.4535376,
            25.3627203
          ],
          [
            55.4536967,
            25.3627287
          ]
        ]
      },
      "properties": {
        "area": "yes",
        "last_edit_user_name": "CartographicChels",
        "last_edit_changeset": "70291534",
        "identifier": "209331363000001",
        "itemType": "Edge",
        "last_edit_time": "1557974395000",
        "last_edit_user_id": "9051059",
        "iso_country_code": "ARE",
        "osmIdentifier": "209331363",
        "highway": "footway",
        "last_edit_version": "2"
      }
    },
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            55.4536967,
            25.3627287
          ],
          [
            55.4536866,
            25.3628827
          ]
        ]
      },
      "properties": {
        "area": "yes",
        "last_edit_user_name": "CartographicChels",
        "last_edit_changeset": "70291534",
        "identifier": "209331363000002",
        "itemType": "Edge",
        "last_edit_time": "1557974395000",
        "last_edit_user_id": "9051059",
        "iso_country_code": "ARE",
        "osmIdentifier": "209331363",
        "highway": "footway",
        "last_edit_version": "2"
      }
    },
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            55.4536866,
            25.3628827
          ],
          [
            55.4535187,
            25.3628649
          ]
        ]
      },
      "properties": {
        "area": "yes",
        "last_edit_user_name": "CartographicChels",
        "last_edit_changeset": "70291534",
        "identifier": "209331363000003",
        "itemType": "Edge",
        "last_edit_time": "1557974395000",
        "last_edit_user_id": "9051059",
        "iso_country_code": "ARE",
        "osmIdentifier": "209331363",
        "highway": "footway",
        "last_edit_version": "2"
      }
    }
  ],
  "properties": {
    "id": "209331363000001209331363000002209331363000003209331363000004",
    "instructions": "1. The way with OSM ID 209331363 has a highway value of FOOTWAY, which should not have an area=yes tag. Consider changing this to highway=PEDESTRIAN.",
    "identifiers": [
      "Edge209331363000002",
      "Edge209331363000001",
      "Edge209331363000004",
      "Edge209331363000003"
    ],
    "generator": "AreasWithHighwayTagCheck",
    "timestamp": "Tue Sep 15 12:50:30 PDT 2020"
  },
  "fix_suggestions": {
    "Edge209331363000003": {
      "type": "UPDATE",
      "descriptors": [
        {
          "name": "TAG",
          "type": "UPDATE",
          "key": "highway",
          "value": "pedestrian",
          "originalValue": "footway"
        }
      ]
    },
    "Edge209331363000002": {
      "type": "UPDATE",
      "descriptors": [
        {
          "name": "TAG",
          "type": "UPDATE",
          "key": "highway",
          "value": "pedestrian",
          "originalValue": "footway"
        }
      ]
    },
    "Edge209331363000001": {
      "type": "UPDATE",
      "descriptors": [
        {
          "name": "TAG",
          "type": "UPDATE",
          "key": "highway",
          "value": "pedestrian",
          "originalValue": "footway"
        }
      ]
    },
    "Edge209331363000004": {
      "type": "UPDATE",
      "descriptors": [
        {
          "name": "TAG",
          "type": "UPDATE",
          "key": "highway",
          "value": "pedestrian",
          "originalValue": "footway"
        }
      ]
    }
  }
}
``` 

```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "LineString",
        "coordinates": [
          [
            56.3124025,
            25.1411205
          ],
          [
            56.3123332,
            25.1407975
          ],
          [
            56.3120985,
            25.1408437
          ],
          [
            56.3120824,
            25.140868
          ],
          [
            56.3121334,
            25.1410926
          ],
          [
            56.3122259,
            25.1411448
          ],
          [
            56.3124025,
            25.1411205
          ]
        ]
      },
      "properties": {
        "area": "yes",
        "wheelchair": "no",
        "last_edit_changeset": "56874082",
        "identifier": "503403567000001",
        "itemType": "Edge",
        "bicycle": "no",
        "iso_country_code": "ARE",
        "osmIdentifier": "503403567",
        "horse": "no",
        "last_edit_user_name": "Rotilom",
        "last_edit_time": "1520179798000",
        "last_edit_user_id": "6853562",
        "service": "parking_aisle",
        "highway": "path",
        "last_edit_version": "2",
        "foot": "yes"
      }
    }
  ],
  "properties": {
    "id": "503403567000001",
    "instructions": "1. The way with OSM ID 503403567 has a highway value of PATH, which should not have an area=yes tag.",
    "identifiers": [
      "Edge503403567000001"
    ],
    "generator": "AreasWithHighwayTagCheck",
    "timestamp": "Tue Sep 15 12:50:30 PDT 2020"
  },
  "fix_suggestions": {
    "Edge503403567000001": {
      "type": "UPDATE",
      "descriptors": [
        {
          "name": "TAG",
          "type": "REMOVE",
          "key": "area",
          "value": "yes"
        }
      ]
    }
  }
}
```

I was looking to add documentation on this addition withing the docs MD files, but could not find an appropriate place. The only technical guidance on writing a check appeared to be within specific tutorials. Any suggestions of a place are welcome, otherwise a new general check design doc may be needed. 

### Potential Impact:

Adds a new field to CheckFlag. Adds extra data in the logs.

### Unit Test Approach:

Added unit tests for the new CheckFlag methods. Created unit tests for the CheckFlagEvent class that test the `fix_suggestion` json for tag, geometry, and relation changes. Updated unit tests for AreasWithHighwayTagCheck to test the fix suggestions.

### Test Results:
Ran local tests with the IntegrityCheckSparkJob and ShardedIntegrityChecksSparkJob, using the altered AreasWithHighwayTagCheck. Both the flag and geojson logs showed the `fix_suggestion` section with the correct details. 


