### PR TITLE
[Dockerfile] Add working directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ FROM gradle:jdk11
 RUN mkdir -p /app/atlas-checks
 COPY . /app/atlas-checks
 
+WORKDIR /app/atlas-checks
 ENTRYPOINT ["/app/atlas-checks/gradlew"]


### PR DESCRIPTION
### Description:

This fixes an issue with the Docker file that would throw the following error when attempting to execute specific gradle commands:

`"run" is not a Task found in root project 'gradle'`

Looking at the image, it turns out the working directory was set to /home/gradle:

<img width="670" alt="Screen Shot 2020-09-17 at 8 34 36 PM" src="https://user-images.githubusercontent.com/1947857/93552404-441bcc00-f925-11ea-93eb-e5488687606a.png">


### Potential Impact:

No downstream impact. 

### Unit Test Approach:

Ran the following commands:

```
 docker run checks run
 docker run checks clean build
```

### Test Results:

Build worked as expected
