### PR TITLE
countryShardMapFromShardFiles Reads too Much

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -134,7 +134,6 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
         final Map<String, String> sparkContext = this.configurationMap();
 
         // File loading helpers
-        final AtlasFilePathResolver resolver = new AtlasFilePathResolver(checksConfiguration);
         final SparkFileHelper fileHelper = new SparkFileHelper(sparkContext);
         final CheckResourceLoader checkLoader = new CheckResourceLoader(checksConfiguration);
 

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -174,7 +174,7 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
 
         // Find the shards for each country atlas files
         final MultiMap<String, Shard> countryShards = countryShardMapFromShardFiles(
-                countries.stream().collect(Collectors.toSet()), resolver, input, sparkContext);
+                countries.stream().collect(Collectors.toSet()), input, sparkContext);
         if (countryShards.isEmpty())
         {
             throw new CoreException("No atlas files found in input.");


### PR DESCRIPTION
### Description:
This is to fix a bug with `IntegrityChecksCommandArguments.countryShardMapFromShardFiles()`. This method reads the input atlas files to assign shards to countries. For each country it was recursively reading all files in the input path. This fixes it so for each country it only reads the country's folder, and it only reads the file name instead of opening the file. 

### Potential Impact:
This should increase the pre-spark speed of the job.

### Unit Test Approach:

None

### Test Results:
Tested locally and observed that only the file names for a single country were read in for each country.
Tested with remote files and saw a 73% decrease in overall runtime. 

