### PR TITLE
Updating the version atlas-checks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=6.1.1-SNAPSHOT
+version=6.1.2-SNAPSHOT
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/
 project_name="OSM Atlas Checks"


### PR DESCRIPTION
Updating the version of atlas-checks to 6.1.2-SNAPSHOT for this release.

