### PR TITLE
Bump version to 6.1.3 after release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.openstreetmap.atlas
-version=6.1.2-SNAPSHOT
+version=6.1.3-SNAPSHOT
 maven2_url=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 snapshot_url=https://oss.sonatype.org/content/repositories/snapshots/
 project_name="OSM Atlas Checks"


### PR DESCRIPTION
### Description:

This is the version bump after the current release. Prep for next release.