### PR TITLE
Add script to automate Atlas Checks Spark job on EC2

### DIFF
--- a/scripts/cloud-check-control/README.md
+++ b/scripts/cloud-check-control/README.md
@@ -66,7 +66,7 @@ The following parameters are used by one or more of the commands. These paramete
 - `-p PROCESSES, --processes PROCESSES` - The number of parallel osmium processes to start. Note that when processing a large PBF file each osmium process will use a great deal of memory so small numbers of parallel processes is suggested. (Default: 32)
 - `-j CONFIG, --config CONFIG` - The json file to use as an [Atlas configuration file](https://github.com/osmlab/atlas-checks/blob/dev/docs/configuration.md) to control the Atlas Checks process. This can either be a fully qualified URL or a full path to a json file in the S3 Input bucket. (e.g my-s3-bucket/Atlas_Checks/configurations/special_config.json) (Default: https://raw.githubusercontent.com/osmlab/atlas-checks/dev/config/configuration.json)
 - `-f FORMATS --formats FORMATS` - A comma separated list of formats to use to determine the output format for Atlas Checks. (Default: 'flags')
-- `-m MEMORY,--memory MEMORY` - The Maximum amount of memory for the Spark job to use. (Default: 256)
+- `-m MEMORY,--memory MEMORY` - The Maximum amount of memory in GB for the Spark job to use. (Default: 256GB)
 - `-c COUNTRIES, --countries COUNTRIES` - A comma separated list of ISO3 country codes to perform the checks on.
 
 ### check

--- a/scripts/cloud-check-control/README.md
+++ b/scripts/cloud-check-control/README.md
@@ -1,0 +1,118 @@
+# cloudAtlasCheckControl - EC2 Atlas Checks Controller
+
+## Prerequisites
+
+### AWS EC2 and S3
+
+To execute the entire Atlas Check process the user will need access to an AWS account with EC2 and S3 resources. Please visit the [AWS website](https://aws.amazon.com/) to create and manage your account. This script makes use of [AWS EC2](https://aws.amazon.com/ec2/) resources to execute the Atlas Check Spark job and [AWS S3](https://aws.amazon.com/s3) object store to save the Atlas Checks results. To communicate with the AWS console and control the resources the scripts needs access the [AWS CLI](https://aws.amazon.com/cli/). To execute the AWS CLI you will need an "Access Key" and "Secret Access Key". These you will need to get from your AWS administrator. You will also need to set the default region. (e.g. "us-west-1").
+
+- [Install](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+  and then
+  [configure](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+  AWS CLI
+
+### AWS Key Pair
+
+To be able to execute commands on the EC2 instance that is created the scripts need to be able to ssh to the EC2 instance. To allow the script to ssh to the EC2 instance you need to create an AWS key pair.
+
+- [Create an AWS key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair)
+
+Make sure that your "my-key-pair.pem" file that is produced during this process is placed in your ~/.ssh/ directory and that the permissions are set correctly as the instructions indicate. Once a key pair has been created you may also need to adjust your [AWS security Groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) to allow ssh access from your local server. Please see your administrator for information on whether this is required for your setup.
+
+### AWS EC2 Template
+
+This script takes advantage of the ability for AWS to start EC2 instances from templates that have been created from an image of another EC2 image. This scrip assumes that you have created a template from an image of an EC2 instance that you will use to start new instances. Information of [Launch Templates](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html?icmpid=docs_ec2_console) is available from AWS, but for the purposes of this script and document we will assume that you have installed the python environment on an EC2 instance, created an image from that and then created a launch template from that image to use in the Atlas Checks process.
+
+### Python3
+
+Make sure python3 is installed. Instructions below for Mac. Also make sure that you source your .zshrc or restart your shell after you perform these steps.
+
+```
+brew install pyenv
+brew install python
+pyenv install 3.8.5
+pyenv global 3.8.5
+echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
+```
+
+### Python libraries
+
+Install python libraries necessary to execute the application.
+
+- boto3 - the python libraries to control EC2 instances
+- paramiko - ssh agent so the script can ssh to the EC2 instance.
+
+```
+sudo pip install boto3 paramiko
+```
+
+## Running the cloudAtlasCheckControl.py script
+
+There are three major commands you can use with the cloudAtlasCheckControl.py script. Each one has its own help. The main help display shows the flags and parameters that work with all the commands. The following parameters apply to all commands and must be used on the command line before the command.
+
+- `-h, --help` - Show help message and exit
+- `-n NAME, --name NAME` - If creating an EC2 instance, this NAME will be used to override the default EC2 instance name: 'AtlasChecks'. The script doesn't use the EC2 instance name so this can be set to any value that the user would like to use.
+- `-t TEMPLATE, --template TEMPLATE` - This parameter sets EC2 template name that will be used to create the EC2 instance from. If used, this parameter will override the default: 'atlas_checks-ec2-template'. At this time a template MUST be specified to operate properly.
+- `-m MINUTES, --minutes MINUTES` - This parameter will set the timeout, in minutes, that the script will use when waiting for the Atlas Check spark job to complete. The default is 6000 minutes.
+- `-v, --version` - Display the current version of the script.
+- `-T, --terminate` - This flag indicates that the user would like to terminate the EC2 instance after successful operation. If this flag is not specified then the script will leave any EC2 instance used or created running upon completion of the script. There are a few different scenarios where the script will not terminate even if termination is requested. The script will NOT terminate an EC2 instance if an error is encountered when processing any command. The script will also not terminate an EC2 instance if the check command is performed but the sync command is skipped (see --out parameter).
+
+The following parameters are used by one or more of the commands. These parameters may not apply to all command so see the command help file for which of these parameters are accepted, required, or optional for each command.
+
+- `-k KEY, --key KEY` - This parameter is the AWS key pair name created above. This parameter specifies the name of the key as specified in the AWS console. The similarly named pem file must be located in the user's ~/.ssh/ directory. See the following URL for instructions on creating a key: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html. (e.g. `--key=aws-key`)
+- `-i ID, --id ID` - This parameter specifies the ID of an existing VM instance to use. If this parameter is specified then the command that is being executed will NOT create a new EC2 instance and will, instead, attempt to connect to an EC2 instance with the given ID. Please note that this is the ID of the instance and not the name or description of the EC2 instance. The script will indicate the ID of the EC2 instance used in the log whether an EC2 instance is created or a running EC2 instance is used.
+- `-o OUT, --output OUT` - The S3 Output directory to push output results upon successful completion of Atlas Check spark job processing. If this parameter is not specified when executing Atlas Checks then the output of the checks will not be pushed to an external object store and the EC2 instance will not be terminated even if -T is used. (e.g. '--out=atlas-bucket/Atlas_Checks')
+- `-i IN, --input IN` - The S3 Input directory where atlas files are located to execute checks on. This S3 bucket will be mounted to the EC2 instance for readonly processing of the atlas files.
+- `-p PROCESSES, --processes PROCESSES` - The number of parallel osmium processes to start. Note that when processing a large PBF file each osmium process will use a great deal of memory so small numbers of parallel processes is suggested. (Default: 32)
+- `-j CONFIG, --config CONFIG` - The json file to use as an [Atlas configuration file](https://github.com/osmlab/atlas-checks/blob/dev/docs/configuration.md) to control the Atlas Checks process. This can either be a fully qualified URL or a full path to a json file in the S3 Input bucket. (e.g my-s3-bucket/Atlas_Checks/configurations/special_config.json) (Default: https://raw.githubusercontent.com/osmlab/atlas-checks/dev/config/configuration.json)
+- `-f FORMATS --formats FORMATS` - A comma separated list of formats to use to determine the output format for Atlas Checks. (Default: 'flags')
+- `-m MEMORY,--memory MEMORY` - The Maximum amount of memory for the Spark job to use. (Default: 256)
+- `-c COUNTRIES, --countries COUNTRIES` - A comma separated list of ISO3 country codes to perform the checks on.
+
+### check
+
+The check command is used to perform the Atlas Checks on an EC2 instance. If the --id parameter is specified for this command then the script will use an already running EC2 instance, otherwise the script will create a new instance from a launch template. Once connected to the EC2 instance the Atlas Checks spark job will be started as specified by the parameters and then monitor the EC2 instance for completion of the spark job. If the spark job completes successfully then the script will push results to an S3 bucket if the --out parameter is specified.
+
+Required Parameters: `-k` or `--key`, `-i` or `--input`
+
+Example: Create an EC2 Instance, Execute all the atlas checks, push flag output results to S3 bucket, and terminate the EC2 instance.
+
+```
+./cloudAtlasCheckControl.py --terminate check --key=my-key --input=my-s3-bucket/Atlas_Generator/Atlas_Files --out=my-s3-bucket/Atlas_Checks/results/
+```
+
+Example: The same as above except that this time only perform test on the USA and use 50 processes in parallel. Also, use the special_config.json file to indicate different settings for this Atlas Checks execution. Generate geojson and flags out output and push them to the S3 bucket. Terminate instance when complete.
+
+```
+./cloudAtlasCheckControl.py --terminate check --key=my-key --input=my-s3-bucket/Atlas_Generator/Atlas_Files --out=my-s3-bucket/Atlas_Checks/results/ --countries=USA --processes=50 --formats=flags,geojson --config=my-s3-bucket/Atlas_Checks/configurations/special_config.json
+```
+
+### sync
+
+The sync command can be used to connect to an instance that is running and sync the resulting Atlas Checks output files from a previous run to S3. This command is generally used after a successful Atlas Checks execution when the `out` parameter was not provided during the check command execution. It may also be used to re-sync Atlas Checks result files from a running instance to the S3 bucket.
+
+Required Parameters: `-i` or `--id`, `-k` or `--key`, `-o` or `--out`
+
+Example: Push Atlas Checks results that were produced on a running instance to the S3 bucket indicated.
+
+```
+./cloudAtlasCheckControl.py sync --key=my-key --output=mmy-s3-bucket/Atlas_Checks/results/ --id=i-0d48466b0e91ef786
+```
+
+### clean
+
+Clean can be used to clean up a running instance to prep it for a fresh Atlas Checks run. It can also be used to terminate a running instance without doing anything else by specifying the global `--terminate` flag.
+
+Required Parameters: `-i` or `--id`, `-k` or `--key`
+
+Example: Clean up a running EC2 instance to prep for a new Atlas Check execution.
+
+```
+./cloudAtlasCheckControl.py clean --key=my-key --id=i-0d48466b0e91ef786
+```
+
+Example: Terminate a running EC2 instance.
+
+```
+./cloudAtlasCheckControl.py --terminate clean --key=my-key --id=i-0d48466b0e91ef786
+```

--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -58,7 +58,7 @@ class CloudAtlasChecksControl:
         processes=32,
         memory=256,
         formats="flags",
-        countries="BRA",
+        countries="",
         s3InFolder=None,
         s3OutFolder=None,
         terminate=False,
@@ -521,9 +521,8 @@ def parse_args(cloudctl):
     parser_check.add_argument(
         "-c",
         "--countries",
-        help="COUNTRIES - A comma separated list of ISO3 codes. (Default: {})".format(
-            cloudctl.countries
-        ),
+        required=True,
+        help="COUNTRIES - A comma separated list of ISO3 codes. (e.g. --countries=GBR)",
     )
     parser_check.add_argument(
         "-m",

--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -142,12 +142,6 @@ class CloudAtlasChecksControl:
             if self.atlasConfig.find("http") < 0:
                 atlasConfig = "file://" + os.path.join(self.homeDir, self.atlasConfig)
 
-            # sync local input folder with S3 input bucket and directory
-            # cmd = "aws s3 sync s3://{} {}".format(self.s3InFolder, self.atlasInDir)
-            # if self.ssh_cmd(cmd):
-            #     finish("Unable to pull atlas input files from S3", -1)
-
-            # TODO Call command to submit job
             cmd = (
                 "/opt/spark/bin/spark-submit"
                 + " --class=org.openstreetmap.atlas.checks.distributed.ShardedIntegrityChecksSparkJob"
@@ -535,7 +529,7 @@ def parse_args(cloudctl):
         "-m",
         "--memory",
         type=int,
-        help="MEMORY - Gigs of memory for spark job. (Default: {})".format(
+        help="MEMORY - Gigs of memory for spark job. (Default: {} GB)".format(
             cloudctl.memory
         ),
     )
@@ -615,40 +609,39 @@ def evaluate(args, cloudctl):
     :param args: The user's input.
     :param cloudctl: An instance of CloudAtlasChecksControl to use.
     """
-    if args.terminate:
-        cloudctl.terminate = args.terminate
-    if args.name:
-        cloudctl.instanceName = args.name
-    if args.template:
-        cloudctl.templateName = args.templateName
-    if args.minutes:
-        cloudctl.timeoutMinutes = args.minutes
-    if hasattr(args, "input") and args.input:
-        cloudctl.s3InFolder = args.input
-    if hasattr(args, "processes") and args.processes:
-        cloudctl.processes = args.processes
-    if hasattr(args, "key") and args.key:
-        cloudctl.key = args.key
-    if hasattr(args, "output") and args.output:
-        cloudctl.s3OutFolder = args.output
-    if hasattr(args, "pbf") and args.pbf:
-        cloudctl.pbfURL = args.pbf
-    if hasattr(args, "countries") and args.countries:
-        cloudctl.countries = args.countries
-    if hasattr(args, "formats") and args.formats:
-        cloudctl.formats = args.formats
-    if hasattr(args, "memory") and args.memory:
-        cloudctl.memory = args.memory
-    if hasattr(args, "config") and args.config:
-        cloudctl.atlasConfig = args.config
-    if hasattr(args, "id") and args.id:
-        cloudctl.instanceId = args.id
-        cloudctl.get_instance_info()
-    if args.version:
+    cloudctl.terminate = args.terminate
+    if args.version is True:
         logger.critical("This is version {0}.".format(VERSION))
         finish()
+    if args.name is not None:
+        cloudctl.instanceName = args.name
+    if args.template is not None:
+        cloudctl.templateName = args.templateName
+    if args.minutes is not None:
+        cloudctl.timeoutMinutes = args.minutes
+    if hasattr(args, "input") and args.input is not None:
+        cloudctl.s3InFolder = args.input
+    if hasattr(args, "processes") and args.processes is not None:
+        cloudctl.processes = args.processes
+    if hasattr(args, "key") and args.key is not None:
+        cloudctl.key = args.key
+    if hasattr(args, "output") and args.output is not None:
+        cloudctl.s3OutFolder = args.output
+    if hasattr(args, "pbf") and args.pbf is not None:
+        cloudctl.pbfURL = args.pbf
+    if hasattr(args, "countries") and args.countries is not None:
+        cloudctl.countries = args.countries
+    if hasattr(args, "formats") and args.formats is not None:
+        cloudctl.formats = args.formats
+    if hasattr(args, "memory") and args.memory is not None:
+        cloudctl.memory = args.memory
+    if hasattr(args, "config") and args.config is not None:
+        cloudctl.atlasConfig = args.config
+    if hasattr(args, "id") and args.id is not None:
+        cloudctl.instanceId = args.id
+        cloudctl.get_instance_info()
 
-    if hasattr(args, "func") and args.func:
+    if hasattr(args, "func") and args.func is not None:
         args.func(cloudctl)
     else:
         finish("A command must be specified. Try '-h' for help.")

--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -106,7 +106,7 @@ class CloudAtlasChecksControl:
           - self.instanceId - indicates a running instance or "" to create one
           - self.S3Atlas - indicates the S3 bucket and path that contains atlas files
         """
-        logger.info("Start Sharding Process...")
+        logger.info("Start Atlas Check Spark Job...")
         if self.instanceId == "":
             self.create_instance()
             self.get_instance_info()
@@ -161,7 +161,7 @@ class CloudAtlasChecksControl:
             if self.ssh_cmd(cmd):
                 finish("Unable to execute spark job", -1)
         else:
-            logger.info("Detected a running sharding process.")
+            logger.info("Detected a running atlas check spark job.")
 
         # wait for script to complete
         if self.wait_for_process_to_complete():
@@ -333,12 +333,12 @@ class CloudAtlasChecksControl:
         """Wait for process to complete
 
         Will block execution while waiting for the completion of the spark
-        submit on the EC2 instance. Upon completion of the scrip it will look
+        submit on the EC2 instance. Upon completion of the script it will look
         at the log file produced to see if it completed successfully. If the
-        sharding script failed then this function will exit.
+        Atlas Checks spark job failed then this function will exit.
 
-        :returns: 0 - if sharding process completed successfully
-        :returns: 1 - if sharding process timed out
+        :returns: 0 - if Atlas check spark job completed successfully
+        :returns: 1 - if Atlas check spark job timed out
         """
         logger.info("Waiting for Spark Submit process to complete...")
         # wait for up to TIMEOUT seconds for the VM to be up and ready
@@ -382,7 +382,7 @@ class CloudAtlasChecksControl:
 
     def start_ec2(self):
         """Start EC2 Instance."""
-        logger.info("Starting the PBFShardGenerator EC2 instance.")
+        logger.info("Starting the EC2 instance.")
 
         try:
             logger.info("Start instance")
@@ -393,7 +393,7 @@ class CloudAtlasChecksControl:
 
     def stop_ec2(self):
         """Stop EC2 Instance."""
-        logger.info("Stopping the PBFShardGenerator EC2 instance.")
+        logger.info("Stopping the EC2 instance.")
 
         try:
             response = ec2.stop_instances(InstanceIds=[self.instanceId])
@@ -490,7 +490,7 @@ def parse_args(cloudctl):
 
     parser_check = subparsers.add_parser(
         "check",
-        help="Shard a pbf and, if '--output' is set, then push atlas checks output to S3 folder",
+        help="Execute Atlas Checks and, if '--output' is set, then push atlas check results to S3 folder",
     )
     parser_check.add_argument(
         "--id", help="ID - Indicates the ID of an existing EC2 instance to use"
@@ -510,7 +510,7 @@ def parse_args(cloudctl):
     parser_check.add_argument(
         "-o",
         "--output",
-        help="Out - The S3 Output directory. (e.g. '--out=atlas-bucket/PBF_Sharding')",
+        help="Out - The S3 Output directory. (e.g. '--out=atlas-bucket/atlas-checks/output')",
     )
     parser_check.add_argument(
         "-i",

--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -1,0 +1,663 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+execute atlas-checks on an EC2 instance
+"""
+import argparse
+import logging
+import os
+import sys
+import time
+
+import boto3.ec2
+import paramiko
+import scp
+from botocore.exceptions import ClientError
+from paramiko.auth_handler import AuthenticationException
+
+
+VERSION = "0.1.0"
+ec2 = boto3.client("ec2")
+
+
+def setup_logging(default_level=logging.INFO):
+    """
+    Setup logging configuration
+    """
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)-8s %(message)s",
+        level=default_level,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    return logging.getLogger("CloudAtlasChecksControl")
+
+
+def finish(error_message=None, status=0):
+    """exit the process
+
+    Method to exit the Python script. It will log the given message and then exit().
+
+    :param error_message: Error message to log upon exiting the process
+    :param status: return code to exit the process with
+    """
+    if error_message:
+        logger.error(error_message)
+    else:
+        logger.critical("Done")
+    exit(status)
+
+
+class CloudAtlasChecksControl:
+    """Main Class to control atlas checks spark job on EC2"""
+
+    def __init__(
+        self,
+        timeoutMinutes=6000,
+        key="",
+        instanceId="",
+        processes=32,
+        memory=256,
+        formats="flags",
+        countries="BRA",
+        s3InFolder=None,
+        s3OutFolder=None,
+        terminate=False,
+        templateName="atlas_checks-ec2-template",
+        atlasConfig="https://raw.githubusercontent.com/osmlab/atlas-checks/dev/config/configuration.json",
+    ):
+        self.timeoutMinutes = timeoutMinutes
+        self.key = key
+        self.instanceId = instanceId
+        self.s3InFolder = s3InFolder
+        self.processes = processes
+        self.memory = memory
+        self.formats = formats
+        self.countries = countries
+        self.s3OutFolder = s3OutFolder
+        self.terminate = terminate
+        self.templateName = templateName
+        self.homeDir = "/home/ubuntu/"
+        self.atlasCheckDir = os.path.join(self.homeDir, "atlas-checks/")
+        self.atlasOutDir = os.path.join(self.homeDir, "output/")
+        self.atlasLogDir = os.path.join(self.homeDir, "log/")
+        self.atlasCheckLogName = "atlasCheck.log"
+        self.atlasCheckLog = os.path.join(self.atlasLogDir, self.atlasCheckLogName)
+        self.atlasConfig = atlasConfig
+
+        self.client = None
+        self.instanceName = "AtlasChecks"
+
+    @property
+    def s3InBucket(self):
+        return self.s3InFolder.strip("/").split("/")[0]
+
+    @property
+    def atlasInDir(self):
+        return os.path.join(self.homeDir, self.s3InFolder)
+
+    def atlasCheck(self):
+        """Submit an spark job to perform atlas checks on an EC2 instance.
+
+        If the CloudAtlasChecksControl includes an instance ID then atlas checks will
+        be executed on that instance. If no instance ID is defined then it will
+        create a new instance.
+
+        Dependencies:
+          - self.instanceId - indicates a running instance or "" to create one
+          - self.S3Atlas - indicates the S3 bucket and path that contains atlas files
+        """
+        logger.info("Start Sharding Process...")
+        if self.instanceId == "":
+            self.create_instance()
+            self.get_instance_info()
+
+        if not self.is_process_running("SparkSubmit"):
+            cmd = "mkdir -p {} {}".format(self.atlasLogDir, self.atlasOutDir)
+            if self.ssh_cmd(cmd):
+                finish("Unable to create directory {}".format(cmd), -1)
+
+            # remove the success or failure files from any last run.
+            if self.ssh_cmd("rm -f {}/_*".format(self.atlasOutDir)):
+                finish("Unable to clean up old status files", -1)
+
+            # mount the s3 bucket
+            cmd = "mount |grep ~/{}".format(self.s3InBucket)
+            if not self.ssh_cmd(cmd, quiet=True):
+                cmd = "sudo umount ~/{}".format(self.s3InBucket)
+                if self.ssh_cmd(cmd, quiet=True):
+                    finish("Unable to unmount S3 bucket", -1)
+            else:
+                cmd = "mkdir -p ~/{}".format(self.s3InBucket)
+                if self.ssh_cmd(cmd):
+                    finish("Unable to create directory {}".format(cmd), -1)
+
+            cmd = "s3fs {0} ~/{0} -o ro,umask=222,gid=1000,uid=1000 -o use_cache=/tmp/atlas/ -o iam_role=auto".format(
+                self.s3InBucket
+            )
+            if self.ssh_cmd(cmd):
+                finish("Unable to mount S3 bucket", -1)
+
+            atlasConfig = self.atlasConfig
+            # if configuration.json is a file then copy it to the EC2 instance
+            if self.atlasConfig.find("http") < 0:
+                atlasConfig = "file://" + os.path.join(self.homeDir, self.atlasConfig)
+
+            # sync local input folder with S3 input bucket and directory
+            # cmd = "aws s3 sync s3://{} {}".format(self.s3InFolder, self.atlasInDir)
+            # if self.ssh_cmd(cmd):
+            #     finish("Unable to pull atlas input files from S3", -1)
+
+            # TODO Call command to submit job
+            cmd = (
+                "/opt/spark/bin/spark-submit"
+                + " --class=org.openstreetmap.atlas.checks.distributed.ShardedIntegrityChecksSparkJob"
+                + " --master=local[{}]".format(self.processes)
+                + " --conf='spark.driver.memory={}g'".format(self.memory)
+                + " --conf='spark.rdd.compress=true'"
+                + " /home/ubuntu/atlas-checks/build/libs/atlas-checks-6.1.3-SNAPSHOT-shadow.jar"
+                + " -inputFolder='{}'".format(self.atlasInDir)
+                + " -output='{}'".format(self.atlasOutDir)
+                + " -outputFormats='{}'".format(self.formats)
+                + " -countries='{}'".format(self.countries)
+                + " -configFiles='{}'".format(atlasConfig)
+                + " > {} 2>&1 &".format(self.atlasCheckLog)
+            )
+
+            logger.info("Submitting spark job: {}".format(cmd))
+            if self.ssh_cmd(cmd):
+                finish("Unable to execute spark job", -1)
+        else:
+            logger.info("Detected a running sharding process.")
+
+        # wait for script to complete
+        if self.wait_for_process_to_complete():
+            finish(
+                "Timeout waiting for script to complete. TODO - instructions to reconnect.",
+                -1,
+            )
+        # download log
+        self.get_files(self.atlasCheckLog, "./")
+
+        self.sync()
+
+    def sync(self):
+        """Sync an existing instance containing already generated atlas output with s3
+
+        Dependencies:
+          - self.instanceId - indicates a running instance or "" to create one
+          - self.s3OutFolder - the S3 bucket and folder path to push the output
+          - self.terminate - indicates if the EC2 instance should be terminated
+        """
+        if self.s3OutFolder is None:
+            logger.warning(
+                "No S3 output folder specified, skipping s3 sync. Use -o 's3folder/path' to sync to s3"
+            )
+            return
+        logger.info(
+            "Syncing EC2 instance atlas-checks output with S3 bucket {}.".format(
+                self.s3OutFolder
+            )
+        )
+
+        # push output to s3
+        cmd = "aws s3 sync --exclude *.crc {} s3://{} ".format(
+            self.atlasOutDir, self.s3OutFolder
+        )
+        if self.ssh_cmd(cmd):
+            finish("Unable to sync with S3", -1)
+        # terminate instance
+        if self.terminate:
+            self.terminate_instance()
+
+    def clean(self):
+        """Clean a running Instance of all produced folders and files
+
+        This readies the instance for a clean atlas check run or terminates an EC2
+        instance completely.
+
+        Dependencies:
+          - self.instanceId - indicates a running instance or "" to create one
+          - self.terminate - indicates if the EC2 instance should be terminated
+        """
+        if self.terminate:
+            logger.info("Terminating EC2 instance.")
+            self.terminate_instance()
+        else:
+            logger.info("Cleaning up EC2 instance.")
+            cmd = "rm -rf {}/* {}/* ".format(self.atlasOutDir, selfatlasLogDir)
+            if self.ssh_cmd(cmd):
+                finish("Unable to clean", -1)
+
+    def create_instance(self):
+        """Create Instance from atlas_checks-ec2-template template
+
+        Dependencies:
+          - self.templateId
+          - self.instanceName
+        :return:
+        """
+        logger.info("Creating EC2 instance from {} template.".format(self.templateName))
+        try:
+            logger.info("Create instance...")
+            response = ec2.run_instances(
+                LaunchTemplate={"LaunchTemplateName": self.templateName},
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": self.instanceName}],
+                    }
+                ],
+                MaxCount=1,
+                MinCount=1,
+                KeyName=self.key,
+            )
+            self.instanceId = response["Instances"][0]["InstanceId"]
+            logger.info("Instance {} was created".format(self.instanceId))
+        except ClientError as e:
+            finish(e, -1)
+
+    def terminate_instance(self):
+        """Terminate Instance
+
+        Dependencies:
+          - self.templateId
+        """
+        logger.info("Terminating EC2 instance {}".format(self.instanceId))
+        try:
+            response = ec2.terminate_instances(InstanceIds=[self.instanceId])
+            logger.info("Instance {} was terminated".format(self.instanceId))
+        except ClientError as e:
+            finish(e, -1)
+
+    def ssh_connect(self):
+        """Connect to an EC2 instance"""
+        for timeout in range(5):
+            try:
+                keyFile = "{}/.ssh/{}.pem".format(os.environ.get("HOME"), self.key)
+                key = paramiko.RSAKey.from_private_key_file(keyFile)
+                self.client = paramiko.SSHClient()
+                self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                logger.debug(
+                    "Connecting to {} ... ".format(self.instance["PublicDnsName"])
+                )
+                self.client.connect(
+                    self.instance["PublicDnsName"], username="ubuntu", pkey=key
+                )
+                logger.info(
+                    "Connected to {} ... ".format(self.instance["PublicDnsName"])
+                )
+                self.scpClient = scp.SCPClient(self.client.get_transport())
+                break
+            except AuthenticationException as error:
+                logger.error(
+                    "Authentication failed: did you remember to create an SSH key? {error}"
+                )
+                raise error
+            except paramiko.ssh_exception.NoValidConnectionsError:
+                time.sleep(15)
+                continue
+
+    def put_files(self, localFiles, remoteDirectory):
+        """Put files from local system onto running EC2 instance"""
+        if self.scpClient is None:
+            self.ssh_connect()
+        try:
+            self.scpClient.put(localFiles, remoteDirectory)
+        except scp.IOException as error:
+            logger.error("Unable to copy files. {error}")
+            raise error
+        logger.debug("Files: " + localFiles + " uploaded to: " + remoteDirectory)
+
+    def get_files(self, remoteFiles, localDirectory):
+        """Get files from running ec2 instance to local system"""
+        if self.scpClient is None:
+            self.ssh_connect()
+        try:
+            self.scpClient.get(remoteFiles, localDirectory)
+        except scp.SCPException as error:
+            logger.error("Unable to copy files. {error}")
+            raise error
+        logger.debug("Files: " + remoteFiles + " downloaded to: " + localDirectory)
+
+    def ssh_cmd(self, cmd, quiet=False):
+        """Issue an ssh command on the remote EC2 instance
+
+        :param cmd: the command string to execute on the remote system
+        :param quiet: If true, don't display errors on failures
+        :returns: Returns the status of the completed ssh command.
+        """
+        if self.client is None:
+            self.ssh_connect()
+        logger.debug("Issuing remote command: {} ... ".format(cmd))
+        ssh_stdin, ssh_stdout, ssh_stderr = self.client.exec_command(cmd)
+        if ssh_stdout.channel.recv_exit_status() and not quiet:
+            logger.error(" Remote command output:")
+            logger.error("\t".join(map(str, ssh_stderr.readlines())))
+        return ssh_stdout.channel.recv_exit_status()
+
+    def wait_for_process_to_complete(self):
+        """Wait for process to complete
+
+        Will block execution while waiting for the completion of the spark
+        submit on the EC2 instance. Upon completion of the scrip it will look
+        at the log file produced to see if it completed successfully. If the
+        sharding script failed then this function will exit.
+
+        :returns: 0 - if sharding process completed successfully
+        :returns: 1 - if sharding process timed out
+        """
+        logger.info("Waiting for Spark Submit process to complete...")
+        # wait for up to TIMEOUT seconds for the VM to be up and ready
+        for timeout in range(self.timeoutMinutes):
+            if not self.is_process_running("SparkSubmit"):
+                logger.info("Atlas Check spark job has completed.")
+                if self.ssh_cmd(
+                    "grep 'Success!' {}/_*".format(self.atlasOutDir), quiet=True
+                ):
+                    logger.error("Atlas Check spark job Failed.")
+                    self.get_files(self.atlasCheckLog, "./")
+                    logger.error(
+                        "---tail of Atlas Checks Spark job log output ({})--- \n".format(
+                            self.atlasCheckLogName
+                            + " ".join(
+                                map(
+                                    str,
+                                    open(self.atlasCheckLogName, "r").readlines()[-50:],
+                                )
+                            )
+                        )
+                    )
+                    finish(status=-1)
+                return 0
+            time.sleep(5)
+        return 1
+
+    def is_process_running(self, process):
+        """Indicate if process is actively running
+
+        Uses pgrep on the EC2 instance to detect if the process is
+        actively running.
+
+        :returns: 0 - if process is NOT running
+        :returns: 1 - if process is running
+        """
+        if self.ssh_cmd("pgrep -P1 -f {}".format(process), quiet=True):
+            return 0
+        logger.debug("{} is still running ... ".format(process))
+        return 1
+
+    def start_ec2(self):
+        """Start EC2 Instance."""
+        logger.info("Starting the PBFShardGenerator EC2 instance.")
+
+        try:
+            logger.info("Start instance")
+            ec2.start_instances(InstanceIds=[self.instanceId])
+            logger.info(response)
+        except ClientError as e:
+            logger.info(e)
+
+    def stop_ec2(self):
+        """Stop EC2 Instance."""
+        logger.info("Stopping the PBFShardGenerator EC2 instance.")
+
+        try:
+            response = ec2.stop_instances(InstanceIds=[self.instanceId])
+            logger.info(response)
+        except ClientError as e:
+            logger.error(e)
+
+    def get_instance_info(self):
+        """Get the info for an EC2 instance.
+
+        Given an EC2 instance ID this function will retrieve the instance info
+        for the instance and save it in self.instance.
+        """
+        logger.info("Getting EC2 Instance {} Info...".format(self.instanceId))
+        # wait for up to TIMEOUT seconds for the VM to be up and ready
+        for timeout in range(10):
+            response = ec2.describe_instances(InstanceIds=[self.instanceId])
+            if not response["Reservations"]:
+                finish("Instance {} not found".format(self.instanceId), -1)
+            if (
+                response["Reservations"][0]["Instances"][0].get("PublicIpAddress")
+                is None
+            ):
+                logger.info(
+                    "Waiting for EC2 instance {} to boot...".format(self.instanceId)
+                )
+                time.sleep(6)
+                continue
+            self.instance = response["Reservations"][0]["Instances"][0]
+            logger.info(
+                "EC2 instance: {} booted with name: {}".format(
+                    self.instanceId, self.instance["PublicDnsName"]
+                )
+            )
+            break
+        for timeout in range(100):
+            if self.ssh_cmd("systemctl is-system-running", quiet=True):
+                logger.debug(
+                    "Waiting for systemd on EC2 instance to complete initialization..."
+                )
+                time.sleep(6)
+                continue
+            return
+        finish("Timeout while waiting for EC2 instance to be ready", -1)
+
+
+def parse_args(cloudctl):
+    """Parse user parameters
+
+    :returns: args
+    """
+    parser = argparse.ArgumentParser(
+        description="This script automates the use of EC2 instance to execute "
+        "an atlas-checks spark job. It is meant to be executed on a laptop with "
+        "access to the EC2 instance"
+    )
+    parser.add_argument(
+        "-n",
+        "--name",
+        help="Set EC2 instance name. (Default: {})".format(cloudctl.instanceName),
+    )
+    parser.add_argument(
+        "-t",
+        "--template",
+        help="Set EC2 template name to create instance from. (Default: {})".format(
+            cloudctl.templateName
+        ),
+    )
+    parser.add_argument(
+        "-m",
+        "--minutes",
+        type=int,
+        help="Set process timeout to number of minutes. (Default: {})".format(
+            cloudctl.timeoutMinutes
+        ),
+    )
+    parser.add_argument(
+        "-v", "--version", help="Display the current version", action="store_true"
+    )
+    parser.add_argument(
+        "-T",
+        "--terminate",
+        default=False,
+        help="Terminate EC2 instance after successful execution",
+        action="store_true",
+    )
+    subparsers = parser.add_subparsers(
+        title="commands",
+        description="One of the following commands must be specified when executed. "
+        "To see more information about each command and the parameters that "
+        "are used for each command then specify the command and "
+        "the --help parameter.",
+    )
+
+    parser_check = subparsers.add_parser(
+        "check",
+        help="Shard a pbf and, if '--output' is set, then push atlas checks output to S3 folder",
+    )
+    parser_check.add_argument(
+        "--id", help="ID - Indicates the ID of an existing EC2 instance to use"
+    )
+    parser_check.add_argument(
+        "-k",
+        "--key",
+        required=True,
+        help="KEY - Instance key name to use to login to instance. This key "
+        "is expected to be the same name as the key as defined by AWS and the "
+        "corresponding pem file must be located in your local '~/.ssh/' "
+        "directory and should be a pem file. See the following URL for "
+        "instructions on creating a key: "
+        "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html. "
+        "(e.g. `--key=aws-key`)",
+    )
+    parser_check.add_argument(
+        "-o",
+        "--output",
+        help="Out - The S3 Output directory. (e.g. '--out=atlas-bucket/PBF_Sharding')",
+    )
+    parser_check.add_argument(
+        "-i",
+        "--input",
+        required=True,
+        help="IN - The S3 Input directory that contains atlas file directories and sharing.txt. ",
+    )
+    parser_check.add_argument(
+        "-c",
+        "--countries",
+        help="COUNTRIES - A comma separated list of ISO3 codes. (Default: {})".format(
+            cloudctl.countries
+        ),
+    )
+    parser_check.add_argument(
+        "-m",
+        "--memory",
+        type=int,
+        help="MEMORY - Gigs of memory for spark job. (Default: {})".format(
+            cloudctl.memory
+        ),
+    )
+    parser_check.add_argument(
+        "-f",
+        "--formats",
+        help="FORMATS - Output format (Default: {})".format(cloudctl.formats),
+    )
+    parser_check.add_argument(
+        "-j",
+        "--config",
+        help="CONFIG - Path within the S2 Input bucket or a URL to a json file to "
+        "use as configuration.json for atlas-checks (Default: Latest from atlas-config repo)",
+    )
+    parser_check.add_argument(
+        "-p",
+        "--processes",
+        type=int,
+        help="PROCESSES - Number of parallel jobs to start. (Default: {})".format(
+            cloudctl.processes
+        ),
+    )
+    parser_check.set_defaults(func=CloudAtlasChecksControl.atlasCheck)
+
+    parser_sync = subparsers.add_parser(
+        "sync", help="Sync Atlas Check output files from instance to S3 folder"
+    )
+    parser_sync.add_argument(
+        "--id",
+        required=True,
+        help="ID - Indicates the ID of an existing EC2 instance to use",
+    )
+    parser_sync.add_argument(
+        "-k",
+        "--key",
+        required=True,
+        help="KEY - Instance key name to use to login to instance. This key "
+        "is expected to be the same name as the key as defined by AWS and the "
+        "corresponding pem file must be located in your local '~/.ssh/' "
+        "directory and should be a pem file. See the following URL for "
+        "instructions on creating a key: "
+        "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html. "
+        "(e.g. `--key=aws-key`)",
+    )
+    parser_sync.add_argument(
+        "-o", "--output", required=True, help="Out - The S3 Output directory"
+    )
+    parser_sync.set_defaults(func=CloudAtlasChecksControl.sync)
+
+    parser_clean = subparsers.add_parser("clean", help="Clean up instance")
+    parser_clean.add_argument(
+        "--id",
+        required=True,
+        help="ID - Indicates the ID of an existing EC2 instance to use",
+    )
+    parser_clean.add_argument(
+        "-k",
+        "--key",
+        required=True,
+        help="KEY - Instance key name to use to login to instance. This key "
+        "is expected to be the same name as the key as defined by AWS and the "
+        "corresponding pem file must be located in your local '~/.ssh/' "
+        "directory and should be a pem file. See the following URL for "
+        "instructions on creating a key: "
+        "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html. "
+        "(e.g. `--key=aws-key`)",
+    )
+    parser_clean.set_defaults(func=CloudAtlasChecksControl.clean)
+
+    args = parser.parse_args()
+    return args
+
+
+def evaluate(args, cloudctl):
+    """Evaluate the given arguments.
+
+    :param args: The user's input.
+    :param cloudctl: An instance of CloudAtlasChecksControl to use.
+    """
+    if args.terminate:
+        cloudctl.terminate = args.terminate
+    if args.name:
+        cloudctl.instanceName = args.name
+    if args.template:
+        cloudctl.templateName = args.templateName
+    if args.minutes:
+        cloudctl.timeoutMinutes = args.minutes
+    if hasattr(args, "input") and args.input:
+        cloudctl.s3InFolder = args.input
+    if hasattr(args, "processes") and args.processes:
+        cloudctl.processes = args.processes
+    if hasattr(args, "key") and args.key:
+        cloudctl.key = args.key
+    if hasattr(args, "output") and args.output:
+        cloudctl.s3OutFolder = args.output
+    if hasattr(args, "pbf") and args.pbf:
+        cloudctl.pbfURL = args.pbf
+    if hasattr(args, "countries") and args.countries:
+        cloudctl.countries = args.countries
+    if hasattr(args, "formats") and args.formats:
+        cloudctl.formats = args.formats
+    if hasattr(args, "memory") and args.memory:
+        cloudctl.memory = args.memory
+    if hasattr(args, "config") and args.config:
+        cloudctl.atlasConfig = args.config
+    if hasattr(args, "id") and args.id:
+        cloudctl.instanceId = args.id
+        cloudctl.get_instance_info()
+    if args.version:
+        logger.critical("This is version {0}.".format(VERSION))
+        finish()
+
+    if hasattr(args, "func") and args.func:
+        args.func(cloudctl)
+    else:
+        finish("A command must be specified. Try '-h' for help.")
+
+
+logger = setup_logging()
+
+if __name__ == "__main__":
+    cloudctl = CloudAtlasChecksControl()
+    args = parse_args(cloudctl)
+    evaluate(args, cloudctl)
+    finish()


### PR DESCRIPTION
### Description:

Add a script that automates the execution of Atlas Checks on an EC2 Instance. Please see README.md for details

### Potential Impact:

No impact to Atlas Check code.

### Unit Test Approach:

No Unit tests performed.

### Test Results:

This change was tested with our AWS setup that includes a template for Atlas Checks that we use to start EC2 instances. To complete this script I plan on adding a "Prep" command that will create an EC2 instance from scratch and install necessary support components to make this script work from a native EC2 instance. Until that is completed this script assumes that the user has a launch template with the correct environment to execute the Atlas Checks spark job.
