### PR TITLE
ExternalData: Use ResourceCache to get data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,13 @@ dependencies
     checkstyle packages.atlas_checkstyle
 
     shaded project.configurations.getByName('compile')
+
+    // Support Junit 5 tests
+    testImplementation packages.junit.api
+    testRuntimeOnly packages.junit.engine
+    // Support JUnit 3/4 tests
+    testCompileOnly packages.junit.junit4
+    testRuntimeOnly packages.junit.vintage
 }
 
 /**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,8 @@ project.ext.versions = [
     postgres: '42.2.6',
     spring: '4.2.2.RELEASE',
     mockito: '2.23.0',
+    junit4: '4.13.1',
+    junit: '5.7.0',
     log4j: '1.2.17'
 ]
 
@@ -22,5 +24,11 @@ project.ext.packages = [
     postgres: "org.postgresql:postgresql:${versions.postgres}",
     spring: "org.springframework:spring-jdbc:${versions.spring}",
     mockito: "org.mockito:mockito-core:${versions.mockito}",
+    junit: [
+        junit4: "junit:junit:${versions.junit4}",
+        vintage: "org.junit.vintage:junit-vintage-engine:${versions.junit}",
+        api: "org.junit.jupiter:junit-jupiter-api:${versions.junit}",
+        engine: "org.junit.jupiter:junit-jupiter-engine:${versions.junit}",
+    ],
     log4j: "log4j:log4j:${versions.log4j}"
 ]

--- a/docs/checks/waterWayChecks.md
+++ b/docs/checks/waterWayChecks.md
@@ -21,6 +21,8 @@ This check identifies waterways that are closed (i.e., would have a circular wat
     }
 }
 ```
+If you are using the NASA SRTM elevation files, their resolution is either 30m or 90m. _This means that the elevation checks will ignore uphill waterways by default when using the NASA SRTM files_.
+
 You may also want to look at [ElevationUtilities](../utilities/elevationUtilities.md).
 
 #### Code Review

--- a/docs/externalData.md
+++ b/docs/externalData.md
@@ -1,0 +1,42 @@
+# External Data
+## Common information
+External data is defined as any data that is not an atlas file. External data
+_MUST_ be placed in the same directory as the atlas files, with the name
+`extra`.
+
+In some cases, if the external data file is _very large_, the data transfer
+may be interrupted, and the process will fail, absent error handling.
+
+## Using external data in a check
+There must be a constructor for the check that follows this definition:
+`public Check(Configuration configuration, ExternalDataFetcher fetcher)`
+
+At this point, the `ExternalDataFetcher` can be used to prefetch data, or
+stored later to be used to dynamically get data as the check progresses.
+The latter is generally recommended, since the data is cached as it is needed.
+This means that the data will not be transferred if the check is cancelled or
+has an error prior to needing the data.
+
+### Example code
+```java
+public Check(Configuration configuration, ExternalDataFetcher fetcher) {
+    super(configuration);
+    Optional<Resource> optionalResource = fetcher.apply("filename");
+    if (optionalResource.isPresent()) {
+        // Congratulations, you have the data
+        Resource resource = optionalResource.get();
+        // At this point, you can get an InputStream.
+        InputStream inputStream = resource.read();
+        /* Currently, there is no good way to get the actual file on the local
+         * filesystem. This should be implemented as soon as that functionality
+         * is required.
+         *
+         * Implementation note: The returned resource will most likely be a
+         * InputStreamResource. This, however, can change.
+         */
+    } else {
+        // You don't have the data. Either error out or log, depending upon
+        // how critical the data is.
+    }
+}
+```

--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -24,6 +24,7 @@ sourceSets
 
 test
 {
+    useJUnitPlatform()
     testLogging
     {
         events "failed"

--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -61,6 +61,7 @@ public class CheckResourceLoader
             + BaseCheck.PARAMETER_DENYLIST_COUNTRIES;
     private final Class<?> checkType;
     private final Configuration configuration;
+    private final ExternalDataFetcher fileFetcher;
     private final MultiMap<String, String> countryGroups = new MultiMap<>();
     private final Boolean enabledByDefault;
     private final String enabledKeyTemplate;
@@ -74,18 +75,30 @@ public class CheckResourceLoader
      * @param configuration
      *            the {@link Configuration} for loaded checks
      */
-    @SuppressWarnings("unchecked")
     public CheckResourceLoader(final Configuration configuration)
+    {
+        this(configuration, null);
+    }
+
+    /**
+     * Default constructor
+     *
+     * @param configuration
+     *            the {@link Configuration} for loaded checks
+     * @param fileFetcher
+     *            the {@link ExternalDataFetcher} to load additional data with
+     */
+    @SuppressWarnings("unchecked")
+    public CheckResourceLoader(final Configuration configuration,
+            final ExternalDataFetcher fileFetcher)
     {
         this.packages = Collections.unmodifiableSet(Iterables.asSet((Iterable<String>) configuration
                 .get("CheckResourceLoader.scanUrls", Collections.singletonList(DEFAULT_PACKAGE))
                 .value()));
         final Map<String, List<String>> groups = configuration.get("groups", Collections.emptyMap())
                 .value();
-        groups.keySet().forEach(group ->
-        {
-            groups.get(group).forEach(country -> this.countryGroups.add(country, group));
-        });
+        groups.keySet().forEach(group -> groups.get(group)
+                .forEach(country -> this.countryGroups.add(country, group)));
 
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
         try
@@ -106,6 +119,7 @@ public class CheckResourceLoader
         this.checkPermitList = configuration.get("CheckResourceLoader.checks.permitlist")
                 .valueOption();
         this.checkDenyList = configuration.get("CheckResourceLoader.checks.denylist").valueOption();
+        this.fileFetcher = fileFetcher;
     }
 
     public Configuration getConfiguration()
@@ -137,14 +151,38 @@ public class CheckResourceLoader
         return specializedConfiguration;
     }
 
-    public <T extends Check> Set<T> loadChecks(final Predicate<Class> isEnabled)
+    public <T extends Check> Set<T> loadChecks(final Predicate<Class<?>> isEnabled)
     {
-        return this.loadChecks(isEnabled, this.configuration);
+        return this.loadChecks(isEnabled, this.configuration, this.fileFetcher);
     }
 
     public <T extends Check> Set<T> loadChecks(final Configuration configuration)
     {
-        return this.loadChecks(this::isEnabledByConfiguration, configuration);
+        return this.loadChecks(this::isEnabledByConfiguration, configuration, this.fileFetcher);
+    }
+
+    /**
+     * Loads checks that are enabled by some other means, defined by {@code isEnabled}
+     *
+     * @param isEnabled
+     *            {@link Predicate} used to determine if a check is enabled
+     * @param configuration
+     *            {@link Configuration} used to loadChecks {@link CheckResourceLoader}
+     * @param fileFetcher
+     *            {@link ExternalDataFetcher} used to load additional data
+     * @param <T>
+     *            check type
+     * @return a {@link Set} of checks
+     */
+    public <T extends Check> Set<T> loadChecks(final Predicate<Class<?>> isEnabled,
+            final Configuration configuration, final ExternalDataFetcher fileFetcher)
+    {
+        final Class<?>[][] constructorArgumentTypes = new Class<?>[][] {
+                { Configuration.class, ExternalDataFetcher.class }, { Configuration.class }, {} };
+        final Object[][] constructorArguments = new Object[][] { { configuration, fileFetcher },
+                { configuration }, {} };
+        return this.loadChecksUsingConstructors(isEnabled, constructorArgumentTypes,
+                constructorArguments);
     }
 
     /**
@@ -158,15 +196,10 @@ public class CheckResourceLoader
      *            check type
      * @return a {@link Set} of checks
      */
-    @SuppressWarnings("unchecked")
-    public <T extends Check> Set<T> loadChecks(final Predicate<Class> isEnabled,
+    public <T extends Check> Set<T> loadChecks(final Predicate<Class<?>> isEnabled,
             final Configuration configuration)
     {
-        final Class<?>[][] constructorArgumentTypes = new Class<?>[][] { { Configuration.class },
-                {} };
-        final Object[][] constructorArguments = new Object[][] { { configuration }, {} };
-        return this.loadChecksUsingConstructors(isEnabled, constructorArgumentTypes,
-                constructorArguments);
+        return this.loadChecks(isEnabled, configuration, this.fileFetcher);
     }
 
     /**
@@ -178,14 +211,15 @@ public class CheckResourceLoader
      */
     public <T extends Check> Set<T> loadChecks()
     {
-        return this.loadChecks(this::isEnabledByConfiguration, this.configuration);
+        return this.loadChecks(this::isEnabledByConfiguration, this.configuration,
+                this.fileFetcher);
     }
 
     public <T extends Check> Set<T> loadChecksForCountry(final String country)
     {
         final Configuration countryConfiguration = this.getConfigurationForCountry(country);
         return this.loadChecks(checkClass -> this.isEnabledByConfiguration(countryConfiguration,
-                checkClass, country), countryConfiguration);
+                checkClass, country), countryConfiguration, this.fileFetcher);
     }
 
     public <T extends Check> Set<T> loadChecksUsingConstructors(
@@ -217,7 +251,8 @@ public class CheckResourceLoader
      *            Any class that extends Check.
      * @return A set of enabled, initialized checks.
      */
-    public <T extends Check> Set<T> loadChecksUsingConstructors(final Predicate<Class> isEnabled,
+    @SuppressWarnings("unchecked")
+    public <T extends Check> Set<T> loadChecksUsingConstructors(final Predicate<Class<?>> isEnabled,
             final Class<?>[][] constructorArgumentTypes, final Object[][] constructorArguments)
     {
         final Set<T> checks = new HashSet<>();
@@ -301,20 +336,20 @@ public class CheckResourceLoader
         return Optional.empty();
     }
 
-    private boolean isEnabledByConfiguration(final Class checkClass)
+    private boolean isEnabledByConfiguration(final Class<?> checkClass)
     {
         return this.isEnabledByConfiguration(this.configuration, checkClass);
     }
 
     private boolean isEnabledByConfiguration(final Configuration configuration,
-            final Class checkClass)
+            final Class<?> checkClass)
     {
         final String key = String.format(this.enabledKeyTemplate, checkClass.getSimpleName());
         return configuration.get(key, this.enabledByDefault).value();
     }
 
     private boolean isEnabledByConfiguration(final Configuration configuration,
-            final Class checkClass, final String country)
+            final Class<?> checkClass, final String country)
     {
         final List<String> countryPermitlist = configuration
                 .get(String.format(COUNTRY_PERMITLIST_TEMPLATE, checkClass.getSimpleName()),

--- a/src/main/java/org/openstreetmap/atlas/checks/base/ExternalDataFetcher.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/ExternalDataFetcher.java
@@ -1,0 +1,179 @@
+package org.openstreetmap.atlas.checks.base;
+
+import java.io.InputStream;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.annotation.Nonnull;
+
+import org.openstreetmap.atlas.checks.distributed.ShardedIntegrityChecksSparkJob;
+import org.openstreetmap.atlas.exception.CoreException;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
+import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
+import org.openstreetmap.atlas.streaming.resource.Resource;
+import org.openstreetmap.atlas.utilities.caching.ConcurrentResourceCache;
+import org.openstreetmap.atlas.utilities.caching.strategies.NamespaceCachingStrategy;
+import org.openstreetmap.atlas.utilities.runtime.Retry;
+import org.openstreetmap.atlas.utilities.scalars.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The fetcher to use for generic resources. The fetcher uses hadoop cache to reduce remote reads.
+ * See {@link ShardedIntegrityChecksSparkJob#atlasFetcher}. This a separate class so that it can
+ * implement {@link Serializable}
+ *
+ * @author Taylor Smock
+ */
+public class ExternalDataFetcher implements Function<String, Optional<Resource>>, Serializable
+{
+    /**
+     * Cache external data sources locally. Does not implement {@link Serializable} since
+     * {@link ConcurrentResourceCache} does not offer a no-args constructor, and is not serializable
+     * itself.
+     *
+     * @author Taylor Smock
+     */
+    private class ExternalDataResourceCache extends ConcurrentResourceCache
+    {
+        ExternalDataResourceCache()
+        {
+            super(new NamespaceCachingStrategy(GLOBAL_HADOOP_FILECACHE_NAMESPACE),
+                    new ExternalFileFetcher());
+        }
+    }
+
+    /**
+     * Create a serializable function to get external files for use with a
+     * {@link org.openstreetmap.atlas.utilities.caching.ResourceCache}.
+     *
+     * @author Taylor Smock
+     */
+    private class ExternalFileFetcher implements Function<URI, Optional<Resource>>, Serializable
+    {
+        private static final long serialVersionUID = 1721253891315559418L;
+
+        @Override
+        public Optional<Resource> apply(final URI uri)
+        {
+            final Retry retry = new Retry(RETRY_ATTEMPTS, Duration.ONE_SECOND).withQuadratic(true);
+            final boolean exists = retry.run(() ->
+            {
+                try (InputStream inputStream = FileSystemHelper
+                        .resource(uri.toString(), ExternalDataFetcher.this.configuration).read())
+                {
+                    return true;
+                }
+                catch (final Exception e)
+                {
+                    if (e.getMessage().contains(FileSystemHelper.FILE_NOT_FOUND))
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        throw new CoreException("Unable to test existence of {}", uri, e);
+                    }
+                }
+            });
+            if (!exists)
+            {
+                if (!ExternalDataFetcher.this.silent)
+                {
+                    logger.warn("Fetcher: resource {} does not exist!", uri);
+                }
+                return Optional.empty();
+            }
+            return Optional.ofNullable(FileSystemHelper.resource(uri.toString(),
+                    ExternalDataFetcher.this.configuration));
+        }
+    }
+
+    private static final long serialVersionUID = 724339604023082195L;
+    private static final String GLOBAL_HADOOP_FILECACHE_NAMESPACE = "__HadoopExternalFileCache_global_namespace__";
+    private static final Logger logger = LoggerFactory.getLogger(ExternalDataFetcher.class);
+    /** Maximum number of retries for where an error occurs when getting a file */
+    private static final int RETRY_ATTEMPTS = 5;
+    /** The input folder path (same as the atlas file paths) */
+    private final String input;
+    /** The configuration used to create the cache */
+    private final Map<String, String> configuration;
+    /** The actual caching object */
+    private transient ExternalDataResourceCache cache;
+    /**
+     * {@code true} implies that the caller does not want to log that files are not present
+     */
+    private boolean silent;
+
+    /**
+     * Create the fetcher to use for generic resources. The fetcher uses hadoop cache to reduce
+     * remote reads. See {@link ShardedIntegrityChecksSparkJob#atlasFetcher}.
+     *
+     * @param input
+     *            {@link String} input folder path
+     * @param configuration
+     *            {@link org.openstreetmap.atlas.generator.tools.spark.SparkJob} configuration map
+     */
+    public ExternalDataFetcher(final String input, final Map<String, String> configuration)
+    {
+        this.input = input;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Optional<Resource> apply(final String string)
+    {
+        return this.getCache().get(this.getUri(string));
+    }
+
+    /**
+     * Make missed file messages silent (use when checking for files -- please log actual issues
+     * when this is used) Unfortunately, this does not suppress <i>all</i> messages from missed
+     * files.
+     *
+     * @param silent
+     *            {@code true} suppresses some logging messages from non-existent files
+     */
+    public void setSilent(final boolean silent)
+    {
+        this.silent = silent;
+    }
+
+    /**
+     * @return The resource cacher to use
+     */
+    @Nonnull
+    private ExternalDataResourceCache getCache()
+    {
+        if (this.cache == null)
+        {
+            this.cache = new ExternalDataResourceCache();
+        }
+        return this.cache;
+    }
+
+    /**
+     * Get a URI for a path string
+     *
+     * @param string
+     *            The path
+     * @return A URI for the string
+     */
+    private URI getUri(final String string)
+    {
+        final String atlasURIString = SparkFileHelper.combine(this.input, string);
+        try
+        {
+            return new URI(atlasURIString);
+        }
+        catch (final URISyntaxException exception)
+        {
+            throw new CoreException("Bad URI syntax: {}", atlasURIString, exception);
+        }
+    }
+
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.base.ExternalDataFetcher;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.utility.CommonTagFilters;
 import org.openstreetmap.atlas.checks.utility.ElevationUtilities;
@@ -158,11 +159,13 @@ public class WaterWayCheck extends BaseCheck<Long>
      *
      * @param configuration
      *            the JSON configuration for this check
+     * @param fileFetcher
+     *            The file fetcher to use to get data files
      */
-    public WaterWayCheck(final Configuration configuration)
+    public WaterWayCheck(final Configuration configuration, final ExternalDataFetcher fileFetcher)
     {
         super(configuration);
-        this.elevationUtils = new ElevationUtilities(configuration);
+        this.elevationUtils = new ElevationUtilities(configuration, fileFetcher);
         this.waterwaySinkTagFilter = this.configurationValue(configuration,
                 "waterway.sink.tags.filters", WATERWAY_SINK_TAG_FILTER_DEFAULT,
                 TaggableFilter::forDefinition);
@@ -584,5 +587,4 @@ public class WaterWayCheck extends BaseCheck<Long>
         }
         return !locations.isEmpty();
     }
-
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJobTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJobTest.java
@@ -122,8 +122,7 @@ public class ShardedIntegrityChecksSparkJobTest
      */
     private void runShardedIntegrityChecksSparkJob()
     {
-        final String[] arguments = {
-                String.format("-inputFolder=%s", INPUT.getAbsolutePathString()),
+        final String[] arguments = { String.format("-input=%s", INPUT.getAbsolutePathString()),
                 String.format("-startedFolder=%s", INPUT.getAbsolutePathString()),
                 String.format("-output=%s", OUTPUT.getAbsolutePathString()),
                 String.format("-sharding=slippy@%s", ZOOM_LEVEL), "-maxShardLoad=1",

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/ElevationUtilitiesTestRule.java
@@ -1,0 +1,42 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Create test atlases for use with {@link ElevationUtilitiesTest}.
+ *
+ * @author Taylor Smock
+ */
+public class ElevationUtilitiesTestRule extends CoreTestRule
+{
+    @TestAtlas(nodes = {
+            @Node(id = "-101752", coordinates = @Loc(value = "28.92414725033,-89.42596868149")),
+            @Node(id = "-101754", coordinates = @Loc(value = "28.93350332367,-89.41806350699")),
+            @Node(id = "-101755", coordinates = @Loc(value = "28.92996541203,-89.40144467423")),
+            @Node(id = "-101756", coordinates = @Loc(value = "28.91942958225,-89.39012590165")),
+            @Node(id = "-101757", coordinates = @Loc(value = "28.91345356126,-89.40234298952")),
+            @Node(id = "-101758", coordinates = @Loc(value = "28.91376809726,-89.43081958402")) }, lines = {
+                    @Line(id = "-101782", coordinates = {
+                            @Loc(value = "28.92414725033,-89.42596868149"),
+                            @Loc(value = "28.93350332367,-89.41806350699"),
+                            @Loc(value = "28.92996541203,-89.40144467423"),
+                            @Loc(value = "28.91942958225,-89.39012590165"),
+                            @Loc(value = "28.91345356126,-89.40234298952"),
+                            @Loc(value = "28.91376809726,-89.43081958402"),
+                            @Loc(value = "28.92414725033,-89.42596868149") }, tags = {
+                                    "waterway=river" }) })
+    private Atlas circularWaterway;
+
+    /**
+     * @return A circular waterway (reused from WaterWayCheckTestRule)
+     */
+    public Atlas getCircularWaterway()
+    {
+        return this.circularWaterway;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheckTest.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.checks.validation.linear.lines;
 
 import java.lang.reflect.Field;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
@@ -24,14 +25,22 @@ public class WaterWayCheckTest
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
+    private WaterWayCheck defaultWaterWayCheck;
+
+    @Before
+    public void setUp()
+    {
+        this.defaultWaterWayCheck = new WaterWayCheck(ConfigurationResolver.emptyConfiguration(),
+                null);
+    }
+
     /**
      * Look for waterways that connect with themselves
      */
     @Test
     public void testCircularWaterway()
     {
-        this.verifier.actual(this.atlases.getCircularWaterway(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.actual(this.atlases.getCircularWaterway(), this.defaultWaterWayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 
@@ -41,8 +50,7 @@ public class WaterWayCheckTest
     @Test
     public void testCoastWaterway()
     {
-        this.verifier.actual(this.atlases.getCoastlineWaterway(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.actual(this.atlases.getCoastlineWaterway(), this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -53,7 +61,7 @@ public class WaterWayCheckTest
     public void testCoastWaterwayConnected()
     {
         this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -62,8 +70,10 @@ public class WaterWayCheckTest
     {
         final short[][] map = new short[][] { { 15, 14, 13, 12 }, { 11, 10, 9, 8 }, { 7, 6, 5, 4 },
                 { 3, 2, 1, 0 } };
-        final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.inlineConfiguration(
-                "{\"WaterWayCheck.waterway.elevation.resolution.min.uphill\": 30000.0}"));
+        final WaterWayCheck check = new WaterWayCheck(
+                ConfigurationResolver.inlineConfiguration(
+                        "{\"WaterWayCheck.waterway.elevation.resolution.min.uphill\": 30000.0}"),
+                null);
         final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
         elevationUtilsField.setAccessible(true);
         final ElevationUtilities elevationUtils = (ElevationUtilities) elevationUtilsField
@@ -78,8 +88,10 @@ public class WaterWayCheckTest
     {
         final short[][] map = new short[][] { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 8, 9, 10, 11 },
                 { 12, 13, 14, 15 } };
-        final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.inlineConfiguration(
-                "{\"WaterWayCheck.waterway.elevation.resolution.min.uphill\": 30000.0}"));
+        final WaterWayCheck check = new WaterWayCheck(
+                ConfigurationResolver.inlineConfiguration(
+                        "{\"WaterWayCheck.waterway.elevation.resolution.min.uphill\": 30000.0}"),
+                null);
 
         final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
         elevationUtilsField.setAccessible(true);
@@ -97,7 +109,8 @@ public class WaterWayCheckTest
         final short[][] map = new short[][] { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 8, 9, 10, 11 },
                 { 12, 13, 14, 15 } };
         final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.inlineConfiguration(
-                "{\"WaterWayCheck\": {\"waterway.elevation.resolution.min.uphill\": 30000.0, \"waterway.elevation.distance.min.start.end\": 1.0}}"));
+                "{\"WaterWayCheck\": {\"waterway.elevation.resolution.min.uphill\": 30000.0, \"waterway.elevation.distance.min.start.end\": 1.0}}"),
+                null);
 
         final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
         elevationUtilsField.setAccessible(true);
@@ -114,14 +127,14 @@ public class WaterWayCheckTest
     {
         final short[][] map = new short[][] { { 0, 1, 2, 3 }, { 4, 5, 6, 7 }, { 8, 9, 10, 11 },
                 { 12, 13, 14, 15 } };
-        final WaterWayCheck check = new WaterWayCheck(ConfigurationResolver.emptyConfiguration());
 
         final Field elevationUtilsField = WaterWayCheck.class.getDeclaredField("elevationUtils");
         elevationUtilsField.setAccessible(true);
         final ElevationUtilities elevationUtils = (ElevationUtilities) elevationUtilsField
-                .get(check);
+                .get(this.defaultWaterWayCheck);
         elevationUtils.putMap(Location.forString("16.9906416,-88.3188021"), map);
-        this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(), check);
+        this.verifier.actual(this.atlases.getCoastlineWaterwayConnected(),
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -132,7 +145,7 @@ public class WaterWayCheckTest
     public void testCoastWaterwayReversed()
     {
         this.verifier.actual(this.atlases.getCoastlineWaterwayReversed(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 
@@ -142,8 +155,7 @@ public class WaterWayCheckTest
     @Test
     public void testCrossingWaterway()
     {
-        this.verifier.actual(this.atlases.getCrossingWaterways(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.actual(this.atlases.getCrossingWaterways(), this.defaultWaterWayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 
@@ -154,7 +166,7 @@ public class WaterWayCheckTest
     public void testCrossingWaterwayConnected()
     {
         this.verifier.actual(this.atlases.getCrossingWaterwaysConnected(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -165,7 +177,7 @@ public class WaterWayCheckTest
     public void testCrossingWaterwayDifferentLayers()
     {
         this.verifier.actual(this.atlases.getCrossingWaterwaysDifferentLayers(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -175,8 +187,7 @@ public class WaterWayCheckTest
     @Test
     public void testDeadendWaterway()
     {
-        this.verifier.actual(this.atlases.getDeadendWaterway(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.actual(this.atlases.getDeadendWaterway(), this.defaultWaterWayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 
@@ -186,8 +197,7 @@ public class WaterWayCheckTest
     @Test
     public void testDeadendWaterways()
     {
-        this.verifier.actual(this.atlases.getDeadendWaterways(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.actual(this.atlases.getDeadendWaterways(), this.defaultWaterWayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 
@@ -199,7 +209,7 @@ public class WaterWayCheckTest
     public void testDifferingLayersConnectedWaterway()
     {
         this.verifier.actual(this.atlases.getDifferingLayersConnectedWaterway(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -209,8 +219,7 @@ public class WaterWayCheckTest
     @Test
     public void testSinkholeAreaWaterway()
     {
-        this.verifier.actual(this.atlases.getSinkholeArea(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.actual(this.atlases.getSinkholeArea(), this.defaultWaterWayCheck);
         this.verifier.verifyExpectedSize(1);
     }
 
@@ -220,8 +229,7 @@ public class WaterWayCheckTest
     @Test
     public void testSinkholePointWaterway()
     {
-        this.verifier.actual(this.atlases.getSinkholePoint(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.actual(this.atlases.getSinkholePoint(), this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -232,7 +240,7 @@ public class WaterWayCheckTest
     public void testWaterwayEndingInOceanArea()
     {
         this.verifier.actual(this.atlases.getWaterwayEndingInOceanArea(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -243,7 +251,7 @@ public class WaterWayCheckTest
     public void testWaterwayEndingInStraitArea()
     {
         this.verifier.actual(this.atlases.getWaterwayEndingInStraitArea(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 
@@ -254,7 +262,7 @@ public class WaterWayCheckTest
     public void testWaterwayEndingOnOtherWaterway()
     {
         this.verifier.actual(this.atlases.getWaterwayEndingOnOtherWaterway(),
-                new WaterWayCheck(ConfigurationResolver.emptyConfiguration()));
+                this.defaultWaterWayCheck);
         this.verifier.verifyEmpty();
     }
 }


### PR DESCRIPTION
### Description:

This uses the same methods that the atlas files use to distribute additional data files.

Checks which use external data _must_ implement the ExternalDataUser interface. Depending upon needs, the implementer can either fetch locally immediately, fetch and parse, or do nothing (why would someone implement the interface and do nothing?).

### Unit Test Approach:

Tested with HDFS (manually). Test setup for this consisted of a Raspberry Pi 4 with HDFS and a Mac to actually run the checks (I found that I needed to allocate a _lot_ of memory for external data, ~15G -- this only seemed to become an issue about the time that the geojson files were being written, most likely during the `reduceByKey` function).

To replicate errors/issues found during those tests, unit tests were written for `WaterWayCheck`, since that check can use external data files.

What was specifically tested for:
* Retrieving data after serialization and deserialization (NPE was found here)

What is not Unit tested:
* Initialization from the Spark Jobs

What was specifically not tested for:
* Correctness of read data

### Test Results:

WaterWayCheck/InvalidTagsCheck, only NZL flags are considered and only WaterWayCheck flags are counted under Total Flags/Different flags.
| FS | ISO | Total Flags | Different flags  | Time | Checks/second |
|------|-----|-------------|----------| ------- | -------- |
| previous hdfs |  NZL   |    12378         |    N/A      | 1h 38m 20s | 2.10 |
| previous local | NZL | 16296 | N/A | 38m 27s | 7.06 |
| hdfs |  NZL   |    16296         |  +3918  | 3h 7m 35s      | 1.45 |
| local |  NZL   |    16296         |  0  | 1h 48m 42s      | 2.50 |

Notes:
* The following configuration should be set for `WaterWayCheck`: `"resolution.min.uphill": 100.0`. This is due to the default minimum resolution being 1.0m, which is too small for publicly available NASA SRTM files.
* JVM Args were set in gradle for the hdfs run to `jvmArgs(["-Xmx15g","-Xms15g"])`
* hdfs was run on a Raspberry Pi 4, where networking was wireless only. Real world runtimes is likely to be much lower.
* Added JUnit5 as a dependency for tests -- the assertions for exceptions are a lot nicer in JUnit5 as compared to JUnit4. If needed, I can probably do something similar to what I did for JOSM and modify the JUnit Rules in Atlas to implement the appropriate callbacks while still maintaining compatibility with JUnit4.

From https://spark.apache.org/docs/latest/cloud-integration.html , valid cloud object storages include S3, Azure, and Google Cloud Storage. (`s3a`, `wasb`, `abfs`, and `gs`).
From https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/filesystem/introduction.html , additional filesystems include Swift (from OpenStack) and local (which may have surprising behavior, apparently).


### Further investigation
Memory leaks. I've run `./gradlew clean run` with the same settings for checks, _but_ with the following jvmargs: `jvmArgs(["-Xmx1g","-Xms1g", "-XX:+HeapDumpOnOutOfMemoryError"])`
From MAT, the primary suspects are:
* `org.apache.spark.util.UninterruptibleThread` with a total size of 288.96 MB
* `org.apache.hadoop.conf.Configuration` with a total size of 691.40 MB . From the stack trace, it is likely that `org.apache.hadoop.fs.FileSystem` is not being properly closed by `org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper`. ~I'll be making some modifications in `FileSystemHelper` to see if that helps with the memory leak.~

`FileSystemHelper` is modified in https://github.com/osmlab/atlas-generator/pull/167, which, when applied, allowed me to run NZL with 1G of ram (`spark.{driver,executor}.memory->1g`, `-Xmx1g`, `-Xms1g`). This also reduced runtime from 1h 48m 42s to 1h 2m 31s for the `local` row in Test Results.