### PR TITLE
Autofix RoundaboutMissingTag

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheck.java
@@ -113,6 +113,7 @@ public class RoundaboutMissingTagCheck extends BaseCheck<Long>
 
         if (maxOffendingAngles.isEmpty() && minOffendingAngles.isEmpty())
         {
+            this.markAsFlagged(object.getOsmIdentifier());
             // AutoFix candidate: proposing add junction=roundabout tag
             return Optional.of(this
                     .createFlag(new OsmWayWalker(edge).collectEdges(),

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheck.java
@@ -113,7 +113,9 @@ public class RoundaboutMissingTagCheck extends BaseCheck<Long>
 
         if (maxOffendingAngles.isEmpty() && minOffendingAngles.isEmpty())
         {
-            this.markAsFlagged(object.getOsmIdentifier());
+            // Mark all Roundabout edges as flagged.
+            new OsmWayWalker(edge).collectEdges()
+                    .forEach(roundaboutEdge -> this.markAsFlagged(roundaboutEdge.getIdentifier()));
             // AutoFix candidate: proposing add junction=roundabout tag
             return Optional.of(this
                     .createFlag(new OsmWayWalker(edge).collectEdges(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/RoundaboutMissingTagCheckTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -22,6 +23,11 @@ public class RoundaboutMissingTagCheckTest
 
     private final Configuration inlineConfiguration = ConfigurationResolver.inlineConfiguration(
             "{\"RoundaboutMissingTagCheck\":{\"ignore.tags.filter\":\"motor_vehicle->!no&foot->!yes&footway->!&access->!private&construction->!\"}}");
+
+    private static void verifyFixSuggestions(final CheckFlag flag, final int count)
+    {
+        Assert.assertEquals(count, flag.getFixSuggestions().size());
+    }
 
     @Test
     public void closedWayMalformedShape()
@@ -45,6 +51,7 @@ public class RoundaboutMissingTagCheckTest
         this.verifier.actual(this.setup.closedWayRoundShape(),
                 new RoundaboutMissingTagCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> verifyFixSuggestions(flag, 1));
     }
 
     @Test


### PR DESCRIPTION
### Description:

Convert RoundaboutMissingTag Check to AutoFix https://github.com/osmlab/atlas-checks/issues/416

### Potential Impact:

This Check is no longer available for regular editing after conversion to AutoFix

### Unit Test Approach:

Verify that flag include the AutoFix suggestion

### Test Results:

Passed