### PR TITLE
Bump Atlas Version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '6.3.2',
+    atlas: '6.3.3',
     commons:'2.6',
     atlas_generator: '5.1.6',
     atlas_checkstyle: '5.6.9',

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheckTest.java
@@ -168,10 +168,8 @@ public class InvalidMultiPolygonRelationCheckTest
         this.verifier.verify(flag ->
         {
             final List<Location> openLocations = new ArrayList<>();
-            openLocations.add(Location.forString(InvalidMultiPolygonRelationCheckTestRule.TWO));
-            openLocations.add(Location.forString(InvalidMultiPolygonRelationCheckTestRule.THREE));
             openLocations.add(Location.forString(InvalidMultiPolygonRelationCheckTestRule.ONE));
-            openLocations.add(Location.forString(InvalidMultiPolygonRelationCheckTestRule.TWO));
+            openLocations.add(Location.forString(InvalidMultiPolygonRelationCheckTestRule.THREE));
             final Relation relation = this.setup.getAtlas().relation(Long.valueOf(
                     InvalidMultiPolygonRelationCheckTestRule.RELATION_ID_OPEN_MULTIPOLYGON));
             final Set<Long> memberIds = relation.members().stream()
@@ -194,8 +192,6 @@ public class InvalidMultiPolygonRelationCheckTest
                         InvalidMultiPolygonRelationCheck.CLOSED_LOOP_INSTRUCTION_FORMAT_INDEX,
                         39569L, Stream.of(39766L, 39565L).collect(Collectors.toSet()),
                         Arrays.asList(Location.forWkt("POINT (103.9145902 1.4119302)"),
-                                Location.forWkt("POINT (103.9462109 1.4263886)"),
-                                Location.forWkt("POINT (103.9462109 1.4263886)"),
                                 Location.forWkt("POINT (103.9256395 1.4483904)")))));
     }
 


### PR DESCRIPTION
### Description:

Bumps the atlas version to 6.3.3. 

This required reverting the changes to InvalidMultiPolygonRelationCheckTest made in https://github.com/osmlab/atlas-checks/pull/400, due to https://github.com/osmlab/atlas/pull/705.

This fixes https://github.com/osmlab/atlas-checks/issues/427

### Potential Impact:
Just the standard atlas version bump. 

### Unit Test Approach:
Had to update the 2 InvalidMultiPolygonRelationCheck unit tests that were changed recently due to issues discovered that cause nondeterminism. 

### Test Results:

None

