### PR TITLE
[WaterbodyAndIslandSizeCheck] waterbody configurable

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/areas/WaterbodyAndIslandSizeCheck.java
@@ -45,7 +45,7 @@ public class WaterbodyAndIslandSizeCheck extends BaseCheck<Long>
             + "of {1,number,#.##} meters squared, which is outside of the expected surface area range"
             + " of {2} square meters to {3} square kilometers. Islets greater than {3} square "
             + "kilometers should likely be tagged as place=ISLAND.";
-    private static final double WATERBODY_MIN_AREA_DEFAULT = 0.5;
+    private static final double WATERBODY_MIN_AREA_DEFAULT = 10;
     // Waterbody maximum is based on the Caspian Sea surface area, the largest island waterbody in
     // OSM that is tagged with natural=water.
     private static final double WATERBODY_MAX_AREA_DEFAULT = 337000;


### PR DESCRIPTION
### Description:

The main thing this PR does is make the definition of waterbodies configurable. It also strives for more uniform flagging when encountering Relation members and Areas so that resulting flags are not nondeterministic. Other changes are just sonar fixes; e.g. collapsing nested conditionals. Also, Polygon's `surfaceOnSphere()` is used now instead of `surface()` to estimate square meterage of features of interest, as there are orders of magnitude differences between the two methods. When setting limits to feature sizes for flagging, the accuracy of these estimates down to the 10th or 100th of a sq. meter become important.

### Potential Impact:

WaterbodyAndIslandSizeCheck should produce different flags for waterbodies based on the new waterbody definition being passed in. We may also get more flags for other features the check looks at (island, islet) if the new `surfaceOnSphere()` method determines they offend a feature size limit

### Unit Test Approach:

Same unit tests

### Test Results:

Passing unit tests
Analysis shows a 100% TP rate for flags sampled from ARG, CHN, GLP, GRL, UKR

