### PR TITLE
OSM Relation Member size fix

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -11,8 +11,17 @@ import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 public class CommonMethods
 {
 
+    private CommonMethods()
+    {
+        // constructor
+    }
+
     /**
      * Return OSM Relation Members size excluding Atlas reversed and sectioned Edges
+     *
+     * @param relation
+     *            {@link Relation} to get the members of
+     * @return A size of relations members as {@link Long}
      */
     public static long getOSMRelationMemberSize(final Relation relation)
     {

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -8,14 +8,8 @@ import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
  *
  * @author Vladimir Lemnberg
  */
-public class CommonMethods
+public final class CommonMethods
 {
-
-    private CommonMethods()
-    {
-        // constructor
-    }
-
     /**
      * Return OSM Relation Members size excluding Atlas reversed and sectioned Edges
      *
@@ -29,5 +23,10 @@ public class CommonMethods
                 .members().stream().map(RelationMember::getEntity).map(entity -> entity.getType()
                         .toString().concat(String.valueOf(entity.getOsmIdentifier())))
                 .distinct().count();
+    }
+
+    private CommonMethods()
+    {
+        // constructor
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -1,0 +1,24 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+
+/**
+ * Hold common Methods (should be used in more than one check)
+ *
+ * @author Vladimir Lemnberg
+ */
+public class CommonMethods
+{
+
+    /**
+     * Return OSM Relation Members size excluding Atlas reversed and sectioned Edges
+     */
+    public static long getOSMRelationMemberSize(final Relation relation)
+    {
+        return relation
+                .members().stream().map(RelationMember::getEntity).map(entity -> entity.getType()
+                        .toString().concat(String.valueOf(entity.getOsmIdentifier())))
+                .distinct().count();
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.checks.utility.CommonMethods;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.Location;
 import org.openstreetmap.atlas.geography.MultiPolygon;
@@ -133,7 +134,8 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
     {
         return object instanceof Relation
                 && Validators.isOfType(object, RelationTypeTag.class, RelationTypeTag.MULTIPOLYGON)
-                && !(this.ignoreOneMember && ((Relation) object).members().size() == 1)
+                && !(this.ignoreOneMember
+                        && CommonMethods.getOSMRelationMemberSize((Relation) object) == 1)
                 && !SyntheticRelationMemberAdded.hasAddedRelationMember(object);
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.checks.utility.CommonMethods;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.ItemType;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
@@ -52,7 +53,7 @@ public class OneMemberRelationCheck extends BaseCheck<Object>
         final RelationMemberList members = relation.members();
 
         // If the number of members in the relation is 1
-        if (members.size() == 1)
+        if (CommonMethods.getOSMRelationMemberSize(relation) == 1)
         {
             if (members.get(0).getEntity().getType().equals(ItemType.RELATION))
             {

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
@@ -18,23 +18,23 @@ public class CommonMethodsTest
     public CommonMethodsTestRule setup = new CommonMethodsTestRule();
 
     @Test
-    public void testValidRelation()
-    {
-        assertEquals(3,
-                CommonMethods.getOSMRelationMemberSize(setup.getValidRelation().relation(123)));
-    }
-
-    @Test
     public void testOneMemberRelationReversed()
     {
         assertEquals(1, CommonMethods
-                .getOSMRelationMemberSize(setup.getOneMemberRelationReversed().relation(123)));
+                .getOSMRelationMemberSize(this.setup.getOneMemberRelationReversed().relation(123)));
     }
 
     @Test
     public void testOneMemberRelationSectioned()
     {
-        assertEquals(1, CommonMethods
-                .getOSMRelationMemberSize(setup.getOneMemberRelationSectioned().relation(123)));
+        assertEquals(1, CommonMethods.getOSMRelationMemberSize(
+                this.setup.getOneMemberRelationSectioned().relation(123)));
+    }
+
+    @Test
+    public void testValidRelation()
+    {
+        assertEquals(3, CommonMethods
+                .getOSMRelationMemberSize(this.setup.getValidRelation().relation(123)));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
@@ -1,0 +1,40 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test for {@link CommonMethods}
+ *
+ * @author Vladimir Lemberg
+ */
+
+public class CommonMethodsTest
+{
+
+    @Rule
+    public CommonMethodsTestRule setup = new CommonMethodsTestRule();
+
+    @Test
+    public void testValidRelation()
+    {
+        assertEquals(3,
+                CommonMethods.getOSMRelationMemberSize(setup.getValidRelation().relation(123)));
+    }
+
+    @Test
+    public void testOneMemberRelationReversed()
+    {
+        assertEquals(1, CommonMethods
+                .getOSMRelationMemberSize(setup.getOneMemberRelationReversed().relation(123)));
+    }
+
+    @Test
+    public void testOneMemberRelationSectioned()
+    {
+        assertEquals(1, CommonMethods
+                .getOSMRelationMemberSize(setup.getOneMemberRelationSectioned().relation(123)));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
@@ -1,0 +1,92 @@
+package org.openstreetmap.atlas.checks.utility;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * Test Rule for {@link CommonMethodsTest}
+ *
+ * @author Vladimir Lemberg
+ */
+
+public class CommonMethodsTestRule extends CoreTestRule
+{
+
+    private static final String ONE = "18.4360044, -71.7194204";
+    private static final String TWO = "18.4360737, -71.6970306";
+    private static final String THREE = "18.4273807, -71.7052283";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            // edges
+            edges = {
+                    @Edge(id = "12000001", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000001", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000001", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12000001", type = "edge", role = ""),
+                    @Member(id = "2", type = "node", role = ""),
+                    @Member(id = "23000001", type = "edge", role = "") }) })
+    private Atlas validRelation;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)), },
+            // edges
+            edges = {
+                    @Edge(id = "12000001", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "-12000001", coordinates = { @Loc(value = TWO),
+                            @Loc(value = ONE) }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12000001", type = "edge", role = ""),
+                    @Member(id = "-12000001", type = "edge", role = "") }) })
+    private Atlas oneMemberRelationReversed;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            // edges
+            edges = {
+                    @Edge(id = "12000001", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "12000002", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "12000003", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) },
+            // relations
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "12000001", type = "edge", role = ""),
+                    @Member(id = "12000002", type = "edge", role = ""),
+                    @Member(id = "12000003", type = "edge", role = "") }) })
+    private Atlas oneMemberRelationSectioned;
+
+    public Atlas getValidRelation()
+    {
+        return this.validRelation;
+    }
+
+    public Atlas getOneMemberRelationReversed()
+    {
+        return this.oneMemberRelationReversed;
+    }
+
+    public Atlas getOneMemberRelationSectioned()
+    {
+        return this.oneMemberRelationSectioned;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
@@ -75,11 +75,6 @@ public class CommonMethodsTestRule extends CoreTestRule
                     @Member(id = "12000003", type = "edge", role = "") }) })
     private Atlas oneMemberRelationSectioned;
 
-    public Atlas getValidRelation()
-    {
-        return this.validRelation;
-    }
-
     public Atlas getOneMemberRelationReversed()
     {
         return this.oneMemberRelationReversed;
@@ -88,5 +83,10 @@ public class CommonMethodsTestRule extends CoreTestRule
     public Atlas getOneMemberRelationSectioned()
     {
         return this.oneMemberRelationSectioned;
+    }
+
+    public Atlas getValidRelation()
+    {
+        return this.validRelation;
     }
 }


### PR DESCRIPTION
### Description:
Please refer: https://github.com/osmlab/atlas-checks/issues/442
1) Calculate OSM Relation Member size **excluding** Atlas `Reversed` and `Sectioned` edges
2) Creating CommonMethods Utility Class for using same logic in different Checks 

### Potential Impact:
OneMemberRelationCheck - to flag more relations
InvalidMultiPolygonRelation - to flag less relations

### Unit Test Approach:
Simulate relation to cover all cases:
1) Relation with edges and nodes
2) OneMemberRelation with reverse edge
3) OneMemberRelation with sectioned edges 

### Test Results:
OneMemberRelationCheck - passed
InvalidMultiPolygonRelation - passed
CommonMethods - passed
