### PR TITLE
ConstructionCheck Use Atlas Generation Date

### DIFF
--- a/docs/checks/constructionCheck.md
+++ b/docs/checks/constructionCheck.md
@@ -29,14 +29,16 @@ We first validate that the incoming object is:
 ##### Flagging the Object
 There are 3 ways we check if the object should be flagged:
 1. We get one of the valid date tags (see DATE_TAGS in ConstructionCheck.java)
-    * If one is present we attempt to parse the date string and compare it to today's date.
-    * If it is before today's date we flag the object.
+    * If one is present we attempt to parse the date string and compare it to the atlas generation date.
+    * If it is before the atlas generation date we flag the object.
 2. We check the "check_date" tag
-    * If present we parse the date string and find how many months it is between the check_date and today's date
+    * If present we parse the date string and find how many months it is between the check_date and the atlas generation date
     * If it is more than the oldCheckDateMonths, as defined in the config, we flag the object
 3. If all else fails we check the tag "last_edit_time"
-    * We convert the timestamp to a date and find the days between that and today's date
+    * We convert the timestamp to a date and find the days between that and the atlas generation date
     * If it is more than the oldConstructionDays, as defined in the config, we flag the object
+    
+In all cases if the atlas generation date in not available, the the current date is used instead. 
     
 ##### Parsing the date string
 While there is one specified way people should be tagging dates, ISO 8601 (yyyy-mm-dd, ie. 2020-01-16), but it is not always


### PR DESCRIPTION
### Description:

This alters the ConstructionCheck to use the Atlas generation date instead of the current date for comparing against feature dates. 

Using the current date was causing false positive cases because of the time differential between when the data was cut and when the check was being run. It also made it so that running the check with the same input parameters on different days would result in different flags. This causes issues for software validation. 

If the atlas generation date is not available the check defaults back to using the current date. 

### Potential Impact:

Should make the flags produced by ConstrucitonCheck more accurate and stable.

### Unit Test Approach:

none

### Test Results:

Ran the check on a year old atlas and compared the differences in results for pre and post enhancement. The only differences were flags dropped post enhancement, and sampling those showed that they were features that went out of date in between when the data was cut and when it was run. 

