### PR TITLE
CheckFlagDeserializer: use GeoJsonParserJacksonImpl

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
@@ -39,7 +39,7 @@ import org.openstreetmap.atlas.geography.geojson.parser.domain.base.GeoJsonItem;
 import org.openstreetmap.atlas.geography.geojson.parser.domain.feature.FeatureCollection;
 import org.openstreetmap.atlas.geography.geojson.parser.domain.geometry.MultiPolygon;
 import org.openstreetmap.atlas.geography.geojson.parser.domain.geometry.Point;
-import org.openstreetmap.atlas.geography.geojson.parser.impl.gson.GeoJsonParserGsonImpl;
+import org.openstreetmap.atlas.geography.geojson.parser.impl.jackson.GeoJsonParserJacksonImpl;
 
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
@@ -66,7 +66,7 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
     private static final String POSITION = "position";
     private static final String AFTER_VIEW = "afterView";
 
-    private static final GeoJsonParser GEOJSON_PARSER_GSON = GeoJsonParserGsonImpl.instance;
+    private static final GeoJsonParser GEOJSON_PARSER_JACKSON = GeoJsonParserJacksonImpl.instance;
     private static final Gson GSON = new Gson();
     private static final WKTReader WKT_READER = new WKTReader();
     private static final JtsCoordinateArrayConverter COORDINATE_ARRAY_CONVERTER = new JtsCoordinateArrayConverter();
@@ -114,7 +114,7 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
         flag.addInstructions(instructions);
         flag.setChallengeName(checkName);
 
-        final GeoJsonItem geojsonItem = GEOJSON_PARSER_GSON.deserialize(GSON.toJson(json));
+        final GeoJsonItem geojsonItem = GEOJSON_PARSER_JACKSON.deserialize(GSON.toJson(json));
 
         // This should never be the case
         if (!(geojsonItem instanceof FeatureCollection))

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/GeoJsonFeatureToAtlasEntityConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/GeoJsonFeatureToAtlasEntityConverter.java
@@ -165,7 +165,9 @@ public final class GeoJsonFeatureToAtlasEntityConverter
         {
             final Map<String, Object> memberMap = (Map<String, Object>) member;
             members.add(new RelationBean.RelationBeanItem(
-                    ((Double) memberMap.get(GeoJsonUtils.IDENTIFIER)).longValue(),
+                    memberMap.get(GeoJsonUtils.IDENTIFIER) instanceof Integer
+                            ? Long.valueOf((Integer) memberMap.get(GeoJsonUtils.IDENTIFIER))
+                            : (Long) memberMap.get(GeoJsonUtils.IDENTIFIER),
                     (String) memberMap.get("role"),
                     ItemType.valueOf((String) memberMap.get(GeoJsonUtils.ITEM_TYPE))));
         });


### PR DESCRIPTION
### Description:

This updates the usage of GeoJsonParserGsonImpl to GeoJsonParserJacksonImpl based on https://github.com/osmlab/atlas/pull/712 . 

The change in GeoJsonFeatureToAtlasEntityConverter.java is due Jackson parsing OSM feature identifiers as Longs or Integers, not always Doubles as before

### Potential Impact:

There may be a performance change, but initial testing raises no concerns

### Unit Test Approach:

Same unit tests and a sample MapRoulette upload using the MR upload command. The command makes use of the CheckFlagDeserializer

### Test Results:

Incoming

