### PR TITLE
InvalidMultiPolygonRelationCheck Max Shape Point Reduction

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -416,7 +416,7 @@
   "InvalidMultiPolygonRelationCheck": {
     "members.one.ignore": true,
     "overlap.points.minimum": 0,
-    "overlap.points.maximum": 2000000,
+    "overlap.points.maximum": 300000,
     "challenge": {
       "description": "Tasks containing improperly formed multipolygon relations.",
       "blurb": "Invalid Multipolygon Relations",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/InvalidMultiPolygonRelationCheck.java
@@ -86,7 +86,7 @@ public class InvalidMultiPolygonRelationCheck extends BaseCheck<Long>
 
     private static final JtsPolygonConverter JTS_POLYGON_CONVERTER = new JtsPolygonConverter();
     private static final long OVERLAP_MINIMUM_POINTS_DEFAULT = 0;
-    private static final long OVERLAP_MAMIMUM_POINTS_DEFAULT = 2000000;
+    private static final long OVERLAP_MAMIMUM_POINTS_DEFAULT = 300000;
 
     static
     {


### PR DESCRIPTION
### Description:

This reduces the default for the max shape points configurable in InvalidMultiPolygonRelationCheck from 2,000,000 to 300,000. This configurable controls which features are processed through the expensive overlap operations in the check. At the previous default the check took over 3.5 hours to process [this relation](https://www.openstreetmap.org/relation/5430065). By reducing the cap, all shards are now once again processed in under an hour each. 

### Potential Impact:
Nothing major. A few less features may be processed through the overlap portion of the check. 

### Unit Test Approach:

None

### Test Results:

Tested about 200 countries. With the configuration value all shards took less than an hour to run for InvalidMultiPolygonRelationCheck. There were no differences in the features flagged between pre and post value change. 

