### PR TITLE
Add AutoFix suggestion to "wrong direction" cases only.

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -1,7 +1,13 @@
 package org.openstreetmap.atlas.checks.utility;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
 
 /**
  * Hold common Methods (should be used in more than one check)
@@ -10,6 +16,27 @@ import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
  */
 public final class CommonMethods
 {
+    /**
+     * Build original (before Atlas sectioning) OSW way geometry from all Main {@link Edge}s
+     * sections
+     *
+     * @param edge
+     *            entity to check
+     * @return original Way geometry {@link PolyLine}
+     */
+    public static PolyLine buildOriginalOsmWayGeometry(final Edge edge)
+    {
+        // Identify and sort by IDs all sections of original OSM way
+        final List<Edge> sortedEdges = new ArrayList<>(new OsmWayWalker(edge).collectEdges());
+        // Build original OSM polyline
+        PolyLine geometry = new PolyLine(sortedEdges.get(0).getRawGeometry());
+        for (int index = 1; index < sortedEdges.size(); index++)
+        {
+            geometry = geometry.append(sortedEdges.get(index).asPolyLine());
+        }
+        return geometry;
+    }
+
     /**
      * Return OSM Relation Members size excluding Atlas reversed and sectioned Edges
      *

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -209,21 +209,8 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
     }
 
     /**
-     * Checks if {@link ComplexRoundabout} is MultiWay Roundabout. MultiWay Roundabout formed of
-     * several unique OSM Ids. Example: https://www.openstreetmap.org/way/349400768
-     * 
-     * @param roundaboutEdges
-     *            the {@link Set} to check
-     * @return true if roundabout is MultiWay
-     */
-    private boolean isMultiWayRoundabout(final Set<Edge> roundaboutEdges)
-    {
-        return roundaboutEdges.stream().map(Edge::getOsmIdentifier).distinct().count() > 1;
-    }
-
-    /**
      * Checks if {@link AtlasObject} contains synthetic boundary Node
-     * 
+     *
      * @param object
      *            the {@link AtlasObject} to check
      * @return true if roundabout contains synthetic boundary Node.
@@ -233,6 +220,19 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
         return new SimpleEdgeWalker((Edge) object, this.isRoundaboutEdge()).collectEdges().stream()
                 .anyMatch(roundaboutEdge -> roundaboutEdge.connectedNodes().stream()
                         .anyMatch(SyntheticBoundaryNodeTag::isSyntheticBoundaryNode));
+    }
+
+    /**
+     * Checks if {@link ComplexRoundabout} is MultiWay Roundabout. MultiWay Roundabout formed of
+     * several unique OSM Ids. Example: https://www.openstreetmap.org/way/349400768
+     *
+     * @param roundaboutEdges
+     *            the {@link Set} to check
+     * @return true if roundabout is MultiWay
+     */
+    private boolean isMultiWayRoundabout(final Set<Edge> roundaboutEdges)
+    {
+        return roundaboutEdges.stream().map(Edge::getOsmIdentifier).distinct().count() > 1;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -48,7 +48,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
     private static final long serialVersionUID = -3018101860747289836L;
     private static final String BASIC_INSTRUCTION = "This roundabout is malformed.";
     private static final String ENCLOSED_ROADS_INSTRUCTIONS = "This roundabout has car navigable ways inside it.";
-    private static final String WRONG_WAY_INVALIDATION = "This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.";
+    private static final String WRONG_WAY_INSTRUCTIONS = "This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.";
     private static final List<String> LEFT_DRIVING_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
             "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM",
             "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD", "GUY", "HKG", "IDN", "IMN", "IND",
@@ -58,7 +58,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
             "TKL", "TLS", "TON", "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF",
             "ZMB", "ZWE");
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList(ENCLOSED_ROADS_INSTRUCTIONS, WRONG_WAY_INVALIDATION, BASIC_INSTRUCTION);
+            .asList(ENCLOSED_ROADS_INSTRUCTIONS, WRONG_WAY_INSTRUCTIONS, BASIC_INSTRUCTION);
     private final List<String> leftDrivingCountries;
 
     public MalformedRoundaboutCheck(final Configuration configuration)
@@ -114,7 +114,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
         {
             // AutoFix candidate only for wrong direction case.
             if (complexRoundabout.getAllInvalidations().size() == 1 && complexRoundabout
-                    .getAllInvalidations().get(0).getReason().equals(WRONG_WAY_INVALIDATION))
+                    .getAllInvalidations().get(0).getReason().equals(WRONG_WAY_INSTRUCTIONS))
             {
                 // Mark that the Edges have been processed
                 roundaboutEdgeSet.forEach(

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -22,7 +22,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Route;
 import org.openstreetmap.atlas.geography.atlas.items.complex.ComplexEntity;
 import org.openstreetmap.atlas.geography.atlas.items.complex.roundabout.ComplexRoundabout;
-import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
 import org.openstreetmap.atlas.geography.atlas.walker.SimpleEdgeWalker;
 import org.openstreetmap.atlas.tags.AreaTag;
 import org.openstreetmap.atlas.tags.BridgeTag;
@@ -122,7 +121,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
                         roundaboutEdge -> this.markAsFlagged(roundaboutEdge.getIdentifier()));
 
                 return Optional.of(this
-                        .createFlag(new OsmWayWalker((Edge) object).collectEdges(),
+                        .createFlag(roundaboutEdgeSet,
                                 this.getLocalizedInstruction(1, object.getOsmIdentifier()))
                         .addFixSuggestion(FeatureChange.add(
                                 (AtlasEntity) ((CompleteEntity) CompleteEntity

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -13,12 +13,16 @@ import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.Polygon;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteEntity;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.items.Route;
 import org.openstreetmap.atlas.geography.atlas.items.complex.ComplexEntity;
 import org.openstreetmap.atlas.geography.atlas.items.complex.roundabout.ComplexRoundabout;
+import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
 import org.openstreetmap.atlas.geography.atlas.walker.SimpleEdgeWalker;
 import org.openstreetmap.atlas.tags.AreaTag;
 import org.openstreetmap.atlas.tags.BridgeTag;
@@ -45,6 +49,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
     private static final long serialVersionUID = -3018101860747289836L;
     private static final String BASIC_INSTRUCTION = "This roundabout is malformed.";
     private static final String ENCLOSED_ROADS_INSTRUCTIONS = "This roundabout has car navigable ways inside it.";
+    private static final String WRONG_WAY_INVALIDATION = "This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.";
     private static final List<String> LEFT_DRIVING_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
             "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM",
             "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD", "GUY", "HKG", "IDN", "IMN", "IND",
@@ -54,7 +59,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
             "TKL", "TLS", "TON", "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF",
             "ZMB", "ZWE");
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList(ENCLOSED_ROADS_INSTRUCTIONS, BASIC_INSTRUCTION);
+            .asList(ENCLOSED_ROADS_INSTRUCTIONS, WRONG_WAY_INVALIDATION, BASIC_INSTRUCTION);
     private final List<String> leftDrivingCountries;
 
     public MalformedRoundaboutCheck(final Configuration configuration)
@@ -99,17 +104,43 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
         // Create a ComplexRoundabout based on object
         final ComplexRoundabout complexRoundabout = new ComplexRoundabout((Edge) object,
                 this.leftDrivingCountries);
-        // If the ComplexRoundbaout is invalid add the reasons why to the instructions, so that it
-        // will be flagged
-        if (!complexRoundabout.isValid())
-        {
-            instructions.addAll(complexRoundabout.getAllInvalidations().stream()
-                    .map(ComplexEntity.ComplexEntityError::getReason).collect(Collectors.toSet()));
-        }
         // Get the roundabout Edges
         final Set<Edge> roundaboutEdgeSet = complexRoundabout.getRoundaboutEdgeSet();
         // Get the roundabout Route
         final Route roundaboutEdges = complexRoundabout.getRoundaboutRoute();
+
+        // If the ComplexRoundabout is invalid add the reasons why to the instructions, so that it
+        // will be flagged
+        if (!complexRoundabout.isValid())
+        {
+            // AutoFix candidate only for wrong direction case.
+            if (complexRoundabout.getAllInvalidations().size() == 1 && complexRoundabout
+                    .getAllInvalidations().get(0).getReason().equals(WRONG_WAY_INVALIDATION))
+            {
+                // Mark that the Edges have been processed
+                roundaboutEdgeSet.forEach(
+                        roundaboutEdge -> this.markAsFlagged(roundaboutEdge.getIdentifier()));
+
+                return Optional.of(this
+                        .createFlag(new OsmWayWalker((Edge) object).collectEdges(),
+                                this.getLocalizedInstruction(1, object.getOsmIdentifier()))
+                        .addFixSuggestion(FeatureChange.add(
+                                (AtlasEntity) ((CompleteEntity) CompleteEntity
+                                        .from((AtlasEntity) object))
+                                                .withGeometry(((Edge) object).asPolyLine().reversed()),
+                                object.getAtlas())));
+            }
+            else
+            {
+                // All other cases.
+                // Note: some cases might also include "wrong direction" when multiple issues
+                // detected.
+                instructions.addAll(complexRoundabout.getAllInvalidations().stream()
+                        .map(ComplexEntity.ComplexEntityError::getReason)
+                        .collect(Collectors.toSet()));
+            }
+        }
+
         // Mark that the Edges have been processed
         roundaboutEdgeSet
                 .forEach(roundaboutEdge -> this.markAsFlagged(roundaboutEdge.getIdentifier()));
@@ -126,7 +157,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
         if (!instructions.isEmpty())
         {
             final CheckFlag flag = this.createFlag(roundaboutEdgeSet,
-                    this.getLocalizedInstruction(1));
+                    this.getLocalizedInstruction(2));
             instructions.forEach(flag::addInstruction);
             return Optional.of(flag);
         }
@@ -191,7 +222,8 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
      * have been excluded because they commonly act differently from car navigable roundabouts.
      *
      * @param object
-     * @return
+     *            the {@link AtlasObject} to check
+     * @return true if {@link AtlasObject} is not vehicle navigable
      */
     private boolean isExcludedHighway(final AtlasObject object)
     {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -126,8 +126,8 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
                                 this.getLocalizedInstruction(1, object.getOsmIdentifier()))
                         .addFixSuggestion(FeatureChange.add(
                                 (AtlasEntity) ((CompleteEntity) CompleteEntity
-                                        .from((AtlasEntity) object))
-                                                .withGeometry(((Edge) object).asPolyLine().reversed()),
+                                        .from((AtlasEntity) object)).withGeometry(
+                                                ((Edge) object).asPolyLine().reversed()),
                                 object.getAtlas())));
             }
             else

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -223,19 +223,6 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
     }
 
     /**
-     * Checks if {@link ComplexRoundabout} is MultiWay Roundabout. MultiWay Roundabout formed of
-     * several unique OSM Ids. Example: https://www.openstreetmap.org/way/349400768
-     *
-     * @param roundaboutEdges
-     *            the {@link Set} to check
-     * @return true if roundabout is MultiWay
-     */
-    private boolean isMultiWayRoundabout(final Set<Edge> roundaboutEdges)
-    {
-        return roundaboutEdges.stream().map(Edge::getOsmIdentifier).distinct().count() > 1;
-    }
-
-    /**
      * Checks if an {@link AtlasObject} has a highway value that excludes it from this check. These
      * have been excluded because they commonly act differently from car navigable roundabouts.
      *
@@ -247,6 +234,19 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
     {
         return Validators.isOfType(object, HighwayTag.class, HighwayTag.CYCLEWAY,
                 HighwayTag.PEDESTRIAN, HighwayTag.FOOTWAY);
+    }
+
+    /**
+     * Checks if {@link ComplexRoundabout} is MultiWay Roundabout. MultiWay Roundabout formed of
+     * several unique OSM Ids. Example: https://www.openstreetmap.org/way/349400768
+     *
+     * @param roundaboutEdges
+     *            the {@link Set} to check
+     * @return true if roundabout is MultiWay
+     */
+    private boolean isMultiWayRoundabout(final Set<Edge> roundaboutEdges)
+    {
+        return roundaboutEdges.stream().map(Edge::getOsmIdentifier).distinct().count() > 1;
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -144,7 +144,7 @@ public class MalformedRoundaboutCheckTest
     @Test
     public void testClockwiseRoundaboutRightDrivingAtlas()
     {
-        //AutoFix Case
+        // AutoFix Case
         this.verifier.actual(this.setup.clockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
@@ -156,7 +156,7 @@ public class MalformedRoundaboutCheckTest
     @Test
     public void testCounterClockwiseRoundaboutLeftDrivingAtlas()
     {
-        //AutoFix Case
+        // AutoFix Case
         this.verifier.actual(this.setup.counterClockwiseRoundaboutLeftDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
@@ -176,7 +176,7 @@ public class MalformedRoundaboutCheckTest
     @Test
     public void testCounterClockwiseRoundaboutRightDrivingMadeLeftAtlas()
     {
-        //AutoFix Case
+        // AutoFix Case
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"traffic.countries.left\":[\"USA\"]}}")));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
 
 /**
@@ -11,6 +12,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
  *
  * @author savannahostrowski
  * @author bbreithaupt
+ * @author vlemberg
  */
 public class MalformedRoundaboutCheckTest
 {
@@ -20,12 +22,20 @@ public class MalformedRoundaboutCheckTest
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
+    private static void verifyFixSuggestions(final CheckFlag flag, final int count)
+    {
+        Assert.assertEquals(count, flag.getFixSuggestions().size());
+    }
+
     @Test
     public void clockwiseRoundaboutLeftDrivingMissingTagTest()
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n"
+                        + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
+                flags.get(0).getInstructions()));
     }
 
     @Test
@@ -34,7 +44,10 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(
                 this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n"
+                        + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
+                flags.get(0).getInstructions()));
     }
 
     @Test
@@ -75,7 +88,10 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n"
+                        + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
+                flags.get(0).getInstructions()));
     }
 
     @Test
@@ -83,7 +99,10 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n"
+                        + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
+                flags.get(0).getInstructions()));
     }
 
     @Test
@@ -100,7 +119,10 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingWrongEdgesTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n"
+                        + "2. This roundabout has car navigable ways inside it.",
+                flags.get(0).getInstructions()));
     }
 
     @Test
@@ -122,17 +144,25 @@ public class MalformedRoundaboutCheckTest
     @Test
     public void testClockwiseRoundaboutRightDrivingAtlas()
     {
+        //AutoFix Case
         this.verifier.actual(this.setup.clockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.",
+                flags.get(0).getInstructions()));
+        this.verifier.verify(flag -> verifyFixSuggestions(flag, 1));
     }
 
     @Test
     public void testCounterClockwiseRoundaboutLeftDrivingAtlas()
     {
+        //AutoFix Case
         this.verifier.actual(this.setup.counterClockwiseRoundaboutLeftDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.",
+                flags.get(0).getInstructions()));
+        this.verifier.verify(flag -> verifyFixSuggestions(flag, 1));
     }
 
     @Test
@@ -146,10 +176,15 @@ public class MalformedRoundaboutCheckTest
     @Test
     public void testCounterClockwiseRoundaboutRightDrivingMadeLeftAtlas()
     {
+        //AutoFix Case
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"traffic.countries.left\":[\"USA\"]}}")));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.",
+                flags.get(0).getInstructions()));
+        this.verifier.verify(flag -> verifyFixSuggestions(flag, 1));
+
     }
 
     @Test
@@ -157,7 +192,11 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.multiDirectionalRoundaboutAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n"
+                        + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
+                flags.get(0).getInstructions()));
+
     }
 
     @Test


### PR DESCRIPTION
### Description:
AutoFix suggestion to "wrong roundabout direction" cases only. Please refer https://github.com/osmlab/atlas-checks/issues/387

### Potential Impact:
Roundabouts with wrong direction will be suggested with AutoFix

### Unit Test Approach:
1. Modify all existent cases for precise error handling
2. Add AutoFix verifier to "wrong direction" test cases

### Test Results:
Passed