### PR TITLE
[MapRouletteUploadCommand] Configurable project and challenge discoverability

### DIFF
--- a/docs/maproulette_upload.md
+++ b/docs/maproulette_upload.md
@@ -21,7 +21,9 @@ Each Challenge is added to the project provided in the MapRoulette connection ur
 * **outputPath** (optional) - Path to store text file of new challenge ids
 * **checkinComment** (optional) - Value of Changeset check in comment
 * **checkinCommentPrefix** (optional) - Prefix added to default check in comment of [prefix ISO - CheckName]
-
+* **undiscoverableChallenges** (optional) - Check names listed here are made into undiscoverable challenges. If you define this, leave discoverableChallenges undefined. Supply a comma-delimited list for cherry-picking undiscoverable challenges (in which case all other checks are converted to discoverable challenges), or an empty string to make all challenges undiscoverable, or do not define. If undefined, checks in discoverableChallenges are made discoverable, but if discoverableChallenges is null, all challenges are made undiscoverable. 
+* **discoverableChallenges** (optional) - Check names listed here are made into discoverable challenges. If you define this, leave undiscoverableChallenges undefined. Supply a comma-delimited list for cherry-picking discoverable challenges (in which case all other checks are converted to undiscoverable challenges), or an empty string to make all challenges discoverable, or do not define. If undefined, see undiscoverableChallenges.
+* **discoverableProject** (optional) - Whether the project is discoverable (enabled) in MapRoulette.
 ## Example
 
 The following command will upload EdgeCrossingEdge & SinkIsland checks to the `checks_example_project` Project on maproulette.org. 

--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -93,7 +93,7 @@ public abstract class BaseCheck<T> implements Check, Serializable
         if (challengeMap.isEmpty())
         {
             this.challenge = new Challenge(this.getClass().getSimpleName(), "", "", "",
-                    ChallengeDifficulty.EASY, "");
+                    ChallengeDifficulty.EASY, "", false);
         }
         else
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -48,7 +48,8 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
             throws UnsupportedEncodingException, URISyntaxException
     {
         this.mapRouletteClient.addTask(
-                new Challenge(challengeName, "", "", "", ChallengeDifficulty.EASY, ""), task);
+                new Challenge(challengeName, "", "", "", ChallengeDifficulty.EASY, "", false),
+                task);
     }
 
     protected synchronized void addTask(final Challenge challenge, final Task task)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -253,25 +253,25 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         result.setStatus(ChallengeStatus.READY.intValue());
         // Set update tasks to false
         result.setUpdateTasks(false);
+        if (result.getCheckName() == null)
+        {
+            // Store the name of the atlas check that generated this challenge
+            result.setCheckName(checkName);
+        }
         // Set challenge discoverability
-        if (discoverableChallenges.isPresent()
+        // Enabled if: Explicitly enabled by check name in discoverableChallenges, or implicitly
+        // enabled by
+        // absence in undiscoverableChallenges or "" in discoverableChallenges
+        // Disabled if: Explicitly disabled by check name in undiscoverableChallenges, or implicitly
+        // disabled
+        // by absence in discoverableChallenges or "" in undiscoverableChallenges or both
+        // discoverableChallenges and undiscoverableChallenges are null
+        result.setEnabled(discoverableChallenges.isPresent()
                 && (discoverableChallenges.get().get(0).equals(StringUtils.EMPTY)
                         || discoverableChallenges.get().contains(checkName))
                 || undiscoverableChallenges.isPresent()
                         && !undiscoverableChallenges.get().get(0).equals(StringUtils.EMPTY)
-                        && !undiscoverableChallenges.get().contains(checkName))
-        {
-            // Explicitly enabled by check name in discoverableChallenges, or implicitly enabled by
-            // absence in undiscoverableChallenges or "" in discoverableChallenges
-            result.setEnabled(true);
-        }
-        else
-        {
-            // Explicitly disabled by check name in undiscoverableChallenges, or implicitly disabled
-            // by absence in discoverableChallenges or "" in undiscoverableChallenges or both
-            // discoverableChallenges and undiscoverableChallenges are null
-            result.setEnabled(false);
-        }
+                        && !undiscoverableChallenges.get().contains(checkName));
         return result;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -75,11 +75,11 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             "true");
     private static final Switch<List<String>> DISCOVERABLE_CHALLENGES = new Switch<>(
             "discoverableChallenges",
-            "List of discoverable challenges. Leave empty for all, minus any in the undiscoverable list.",
+            "List of discoverable challenges. Supply \"\" for all. See the MR upload command docs for more info",
             string -> Arrays.asList(string.split(",")), Optionality.OPTIONAL, null);
     private static final Switch<List<String>> UNDISCOVERABLE_CHALLENGES = new Switch<>(
             "undiscoverableChallenges",
-            "List of undiscoverable challenges. All challenges except for those in this list are made discoverable",
+            "List of undiscoverable challenges. Supply \"\" for all. See the MR upload command docs for more info",
             string -> Arrays.asList(string.split(",")), Optionality.OPTIONAL, null);
 
     private static final String PARAMETER_CHALLENGE = "challenge";

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -135,7 +135,8 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         final Optional<List<String>> checks = (Optional<List<String>>) commandMap.getOption(CHECKS);
         final String checkinCommentPrefix = (String) commandMap.get(CHECKIN_COMMENT_PREFIX);
         final String checkinComment = (String) commandMap.get(CHECKIN_COMMENT);
-        final boolean discoverableProject = (boolean) commandMap.get(DISCOVERABLE_PROJECT);
+        configuration.getProjectConfiguration()
+                .setEnabled((boolean) commandMap.get(DISCOVERABLE_PROJECT));
         final Optional<List<String>> discoverableChallenges = (Optional<List<String>>) commandMap
                 .getOption(DISCOVERABLE_CHALLENGES);
         final Optional<List<String>> undiscoverableChallenges = (Optional<List<String>>) commandMap

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -255,15 +255,20 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
         // Set challenge discoverability
         if (discoverableChallenges.isPresent()
                 && (discoverableChallenges.get().get(0).equals(StringUtils.EMPTY)
-                        || discoverableChallenges.get().contains(checkName)))
+                        || discoverableChallenges.get().contains(checkName))
+                || undiscoverableChallenges.isPresent()
+                        && !undiscoverableChallenges.get().get(0).equals(StringUtils.EMPTY)
+                        && !undiscoverableChallenges.get().contains(checkName))
         {
+            // Explicitly enabled by check name in discoverableChallenges, or implicitly enabled by
+            // absence in undiscoverableChallenges or "" in discoverableChallenges
             result.setEnabled(true);
         }
-        else if (discoverableChallenges.isEmpty() && undiscoverableChallenges.isEmpty()
-                || undiscoverableChallenges.isPresent()
-                        && (undiscoverableChallenges.get().get(0).equals(StringUtils.EMPTY)
-                                || undiscoverableChallenges.get().contains(checkName)))
+        else
         {
+            // Explicitly disabled by check name in undiscoverableChallenges, or implicitly disabled
+            // by absence in discoverableChallenges or "" in undiscoverableChallenges or both
+            // discoverableChallenges and undiscoverableChallenges are null
             result.setEnabled(false);
         }
         return result;

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -61,6 +61,7 @@ public class Challenge implements Serializable
     private long status;
     private boolean enabled;
     private boolean updateTasks;
+    private String checkName;
 
     public Challenge(final Challenge challenge)
     {
@@ -78,6 +79,7 @@ public class Challenge implements Serializable
                 null, tags, enabled);
     }
 
+    @SuppressWarnings("squid:S107")
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final String checkinComment,
             final ChallengeDifficulty difficulty, final String tags, final boolean enabled)
@@ -87,6 +89,7 @@ public class Challenge implements Serializable
         this.checkinComment = checkinComment;
     }
 
+    @SuppressWarnings("squid:S107")
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty,
             final ChallengePriority defaultPriority, final String highPriorityRule,
@@ -111,6 +114,11 @@ public class Challenge implements Serializable
     public String getBlurb()
     {
         return this.blurb;
+    }
+
+    public String getCheckName()
+    {
+        return this.checkName;
     }
 
     public String getCheckinComment()
@@ -191,6 +199,11 @@ public class Challenge implements Serializable
     public boolean isUpdateTasks()
     {
         return this.updateTasks;
+    }
+
+    public void setCheckName(final String checkName)
+    {
+        this.checkName = checkName;
     }
 
     public void setCheckinComment(final String checkinComment)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -37,6 +37,7 @@ public class Challenge implements Serializable
     public static final String KEY_RULE_VALUE = "value";
     public static final String KEY_TAGS = "tags";
     public static final String DEFAULT_CHECKIN_COMMENT = "#maproulette";
+    public static final String DISCOVERABLE = "enabled";
 
     private static final long serialVersionUID = -8034692909431083341L;
     private static final Gson CHALLENGE_GSON = new GsonBuilder().disableHtmlEscaping()
@@ -65,29 +66,32 @@ public class Challenge implements Serializable
     {
         this(challenge.name, challenge.description, challenge.blurb, challenge.instruction,
                 challenge.difficulty, challenge.defaultPriority, challenge.highPriorityRule,
-                challenge.mediumPriorityRule, challenge.lowPriorityRule, challenge.tags);
+                challenge.mediumPriorityRule, challenge.lowPriorityRule, challenge.tags,
+                challenge.enabled);
     }
 
     public Challenge(final String name, final String description, final String blurb,
-            final String instruction, final ChallengeDifficulty difficulty, final String tags)
+            final String instruction, final ChallengeDifficulty difficulty, final String tags,
+            final boolean enabled)
     {
         this(name, description, blurb, instruction, difficulty, ChallengePriority.LOW, null, null,
-                null, tags);
+                null, tags, enabled);
     }
 
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final String checkinComment,
-            final ChallengeDifficulty difficulty, final String tags)
+            final ChallengeDifficulty difficulty, final String tags, final boolean enabled)
     {
         this(name, description, blurb, instruction, difficulty, ChallengePriority.LOW, null, null,
-                null, tags);
+                null, tags, enabled);
         this.checkinComment = checkinComment;
     }
 
     public Challenge(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty,
             final ChallengePriority defaultPriority, final String highPriorityRule,
-            final String mediumPriorityRule, final String lowPriorityRule, final String tags)
+            final String mediumPriorityRule, final String lowPriorityRule, final String tags,
+            final boolean enabled)
     {
         this.name = name;
         this.description = description;
@@ -101,6 +105,7 @@ public class Challenge implements Serializable
         this.tags = tags;
         this.checkinComment = DEFAULT_CHECKIN_COMMENT;
         this.updateTasks = true;
+        this.enabled = enabled;
     }
 
     public String getBlurb()
@@ -126,6 +131,11 @@ public class Challenge implements Serializable
     public ChallengeDifficulty getDifficulty()
     {
         return this.difficulty;
+    }
+
+    public boolean getEnabled()
+    {
+        return this.enabled;
     }
 
     public String getHighPriorityRule()
@@ -224,6 +234,7 @@ public class Challenge implements Serializable
         final JsonObject challengeJson = CHALLENGE_GSON.toJsonTree(this).getAsJsonObject();
         challengeJson.add(KEY_ACTIVE, new JsonPrimitive(true));
         challengeJson.add(KEY_UPDATE_TASKS, new JsonPrimitive(this.updateTasks));
+        challengeJson.add(DISCOVERABLE, new JsonPrimitive(this.enabled));
 
         // Do not override the name if it's already set
         if (this.name.isEmpty())

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/ProjectConfiguration.java
@@ -14,7 +14,7 @@ public class ProjectConfiguration implements Serializable
     private final String name;
     private final String description;
     private final String displayName;
-    private final boolean enabled;
+    private boolean enabled;
 
     /**
      * Defines a basic project, where all optional fields default to name.
@@ -79,5 +79,10 @@ public class ProjectConfiguration implements Serializable
     public boolean isEnabled()
     {
         return this.enabled;
+    }
+
+    public void setEnabled(final boolean enabled)
+    {
+        this.enabled = enabled;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Survey.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Survey.java
@@ -37,9 +37,9 @@ public class Survey extends Challenge
 
     public Survey(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty,
-            final List<String> answers, final String tags)
+            final List<String> answers, final String tags, final boolean enabled)
     {
-        super(name, description, blurb, instruction, difficulty, tags);
+        super(name, description, blurb, instruction, difficulty, tags, enabled);
         this.answers = answers;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Survey.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Survey.java
@@ -35,6 +35,7 @@ public class Survey extends Challenge
         return challenge.getJSONResourceObject(Survey.class);
     }
 
+    @SuppressWarnings("squid:S107")
     public Survey(final String name, final String description, final String blurb,
             final String instruction, final ChallengeDifficulty difficulty,
             final List<String> answers, final String tags, final boolean enabled)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/serializer/ChallengeDeserializer.java
@@ -62,7 +62,21 @@ public class ChallengeDeserializer implements JsonDeserializer<Challenge>
                 this.getValue(challengeObject, Challenge.KEY_HIGH_PRIORITY, null),
                 this.getValue(challengeObject, Challenge.KEY_MEDIUM_PRIORITY, null),
                 this.getValue(challengeObject, Challenge.KEY_LOW_PRIORITY, null),
-                this.getStringValue(challengeObject, Challenge.KEY_TAGS, ""));
+                this.getStringValue(challengeObject, Challenge.KEY_TAGS, ""),
+                this.getBooleanValue(challengeObject, Challenge.DISCOVERABLE, false));
+    }
+
+    private boolean getBooleanValue(final JsonObject object, final String key,
+            final boolean defaultValue)
+    {
+        if (object.has(key))
+        {
+            return object.get(key).getAsBoolean();
+        }
+        else
+        {
+            return defaultValue;
+        }
     }
 
     private String getStringValue(final JsonObject object, final String key,

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClientTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClientTest.java
@@ -33,7 +33,7 @@ public class MapRouletteClientTest
 
     private static final String CONFIGURATION = "server:123:project:api_key";
     private static final Challenge TEST_CHALLENGE = new Challenge("a name", "a description",
-            "a blurb", "an instruction", ChallengeDifficulty.EASY, "");
+            "a blurb", "an instruction", ChallengeDifficulty.EASY, "", false);
     private static final Optional<JsonArray> GEOJSON = getSampleGeojson();
 
     @Rule


### PR DESCRIPTION
### Description:

This addresses https://github.com/osmlab/atlas-checks/issues/429

3 new parameters are added to the MR Upload Command. They control project as well as fine-grained challenge discoverability (AKA enablement/visibility). 

### Potential Impact:

The following defaults are changed:

Challenges and Surveys are disabled (undiscoverable) by default

Challenges are by default disabled

### Unit Test Approach:

Same unit tests and sample project uploads using the MR upload command

### Test Results:

Unit tests pass

Sample uploads:

`-discoverableProject=true`
`-undiscoverableChallenges=WaterbodyAndIslandSizeCheck`
<img width="999" alt="image" src="https://user-images.githubusercontent.com/31253489/103819516-6eea7700-501f-11eb-9146-7f9cf66c9e54.png">

`-discoverableProject=true`
`-discoverableChallenges=WaterbodyAndIslandSizeCheck`
<img width="999" alt="image" src="https://user-images.githubusercontent.com/31253489/103819611-980b0780-501f-11eb-8baf-95eafdef401a.png">

`-discoverableProject=false`
`-discoverableChallenges=WaterbodyAndIslandSizeCheck`
<img width="999" alt="image" src="https://user-images.githubusercontent.com/31253489/103819802-f89a4480-501f-11eb-8589-8401fc413a47.png">

`-discoverableProject=false`
<img width="999" alt="image" src="https://user-images.githubusercontent.com/31253489/103819991-562e9100-5020-11eb-88a2-fbb36aa0eb41.png">

`-discoverableProject=true`
`-discoverableChallenges=""`
<img width="999" alt="image" src="https://user-images.githubusercontent.com/31253489/103820469-46fc1300-5021-11eb-821a-d71e1e2cc4ab.png">


