### PR TITLE
Fix one member relation size

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -6,7 +6,7 @@ import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 /**
  * Hold common Methods (should be used in more than one check)
  *
- * @author Vladimir Lemnberg
+ * @author Vladimir Lemberg
  */
 public final class CommonMethods
 {
@@ -24,7 +24,7 @@ public final class CommonMethods
             // De-duplicating either Point or Node with same OSM Id
             if (entity.getType().toString().matches("POINT|NODE"))
             {
-                return String.valueOf("PointNone")
+                return String.valueOf("PointNode")
                         .concat(String.valueOf(entity.getOsmIdentifier()));
             }
             return entity.getType().toString().concat(String.valueOf(entity.getOsmIdentifier()));

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.checks.utility;
 
-import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 
@@ -20,8 +19,16 @@ public final class CommonMethods
      */
     public static long getOSMRelationMemberSize(final Relation relation)
     {
-        return relation.members().stream().map(RelationMember::getEntity)
-                .map(AtlasEntity::getOsmIdentifier).distinct().count();
+        return relation.members().stream().map(RelationMember::getEntity).map(entity ->
+        {
+            // De-duplicating either Point or Node with same OSM Id
+            if (entity.getType().toString().matches("POINT|NODE"))
+            {
+                return String.valueOf("PointNone")
+                        .concat(String.valueOf(entity.getOsmIdentifier()));
+            }
+            return entity.getType().toString().concat(String.valueOf(entity.getOsmIdentifier()));
+        }).distinct().count();
     }
 
     private CommonMethods()

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -19,10 +19,8 @@ public final class CommonMethods
      */
     public static long getOSMRelationMemberSize(final Relation relation)
     {
-        return relation
-                .members().stream().map(RelationMember::getEntity).map(entity -> entity.getType()
-                        .toString().concat(String.valueOf(entity.getOsmIdentifier())))
-                .distinct().count();
+        return relation.members().stream().map(RelationMember::getEntity)
+                .map(entity -> entity.getOsmIdentifier()).distinct().count();
     }
 
     private CommonMethods()

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -1,5 +1,6 @@
 package org.openstreetmap.atlas.checks.utility;
 
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 
@@ -20,7 +21,7 @@ public final class CommonMethods
     public static long getOSMRelationMemberSize(final Relation relation)
     {
         return relation.members().stream().map(RelationMember::getEntity)
-                .map(entity -> entity.getOsmIdentifier()).distinct().count();
+                .map(AtlasEntity::getOsmIdentifier).distinct().count();
     }
 
     private CommonMethods()

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
@@ -18,6 +18,13 @@ public class CommonMethodsTest
     public CommonMethodsTestRule setup = new CommonMethodsTestRule();
 
     @Test
+    public void testOneMemberRelationArtificialMember()
+    {
+        assertEquals(1, CommonMethods.getOSMRelationMemberSize(
+                this.setup.getOneMemberRelationArtificialMember().relation(123)));
+    }
+
+    @Test
     public void testOneMemberRelationEdge()
     {
         assertEquals(1, CommonMethods

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
@@ -6,6 +6,7 @@ import org.openstreetmap.atlas.utilities.testing.TestAtlas;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
 import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
 
@@ -40,6 +41,16 @@ public class CommonMethodsTestRule extends CoreTestRule
                     @Member(id = "2", type = "node", role = ""),
                     @Member(id = "23000001", type = "edge", role = "") }) })
     private Atlas validRelation;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)) }, points = {
+                    @Point(id = "1", coordinates = @Loc(value = ONE)) },
+            // relations
+            relations = {
+                    @Relation(id = "123", members = { @Member(id = "1", type = "node", role = ""),
+                            @Member(id = "1", type = "point", role = "") }) })
+    private Atlas oneMemberRelationArtificialMember;
 
     @TestAtlas(
             // nodes
@@ -94,6 +105,11 @@ public class CommonMethodsTestRule extends CoreTestRule
                     @Member(id = "12000002", type = "edge", role = ""),
                     @Member(id = "12000003", type = "edge", role = "") }) })
     private Atlas oneMemberRelationSectionedEdge;
+
+    public Atlas getOneMemberRelationArtificialMember()
+    {
+        return this.oneMemberRelationArtificialMember;
+    }
 
     public Atlas getOneMemberRelationEdge()
     {

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
@@ -25,9 +25,9 @@ public class CommonMethodsTestRule extends CoreTestRule
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)),
-                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3000000", coordinates = @Loc(value = THREE)) },
             // edges
             edges = {
                     @Edge(id = "12000001", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
@@ -38,24 +38,24 @@ public class CommonMethodsTestRule extends CoreTestRule
             // relations
             relations = { @Relation(id = "123", members = {
                     @Member(id = "12000001", type = "edge", role = ""),
-                    @Member(id = "2", type = "node", role = ""),
+                    @Member(id = "2000000", type = "node", role = ""),
                     @Member(id = "23000001", type = "edge", role = "") }) })
     private Atlas validRelation;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)) }, points = {
-                    @Point(id = "1", coordinates = @Loc(value = ONE)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)) }, points = {
+                    @Point(id = "1000000", coordinates = @Loc(value = ONE)) },
             // relations
-            relations = {
-                    @Relation(id = "123", members = { @Member(id = "1", type = "node", role = ""),
-                            @Member(id = "1", type = "point", role = "") }) })
+            relations = { @Relation(id = "123", members = {
+                    @Member(id = "1000000", type = "node", role = ""),
+                    @Member(id = "1000000", type = "point", role = "") }) })
     private Atlas oneMemberRelationArtificialMember;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)) },
             // edges
             edges = { @Edge(id = "12000001", coordinates = { @Loc(value = ONE),
                     @Loc(value = TWO) }) },
@@ -66,16 +66,16 @@ public class CommonMethodsTestRule extends CoreTestRule
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "1", type = "node", role = ""), }) })
+                    @Member(id = "1000000", type = "node", role = ""), }) })
     private Atlas oneMemberRelationNode;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)), },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)), },
             // edges
             edges = {
                     @Edge(id = "12000001", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
@@ -89,9 +89,9 @@ public class CommonMethodsTestRule extends CoreTestRule
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)),
-                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3000000", coordinates = @Loc(value = THREE)) },
             // edges
             edges = {
                     @Edge(id = "12000001", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/MissingRelationTypeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/MissingRelationTypeCheckTestRule.java
@@ -19,61 +19,63 @@ public class MissingRelationTypeCheckTestRule extends CoreTestRule
     private static final String ONE = "18.4360044, -71.7194204";
     private static final String TWO = "18.4360737, -71.6970306";
     private static final String THREE = "18.4273807, -71.7052283";
-    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-            @Node(id = "2", coordinates = @Loc(value = TWO)),
-            @Node(id = "3", coordinates = @Loc(value = THREE)) }, edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
-                    @Edge(id = "23", coordinates = { @Loc(value = TWO), @Loc(value = THREE) }),
-                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
                             @Loc(value = ONE) }) }, relations = {
                                     @Relation(id = "123", members = {
-                                            @Member(id = "12", type = "edge", role = "any"),
-                                            @Member(id = "2", type = "node", role = "any"),
-                                            @Member(id = "23", type = "edge", role = "any") }, tags = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
                                                     "type=any" }) })
     private Atlas validRelation;
 
-    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-            @Node(id = "2", coordinates = @Loc(value = TWO)),
-            @Node(id = "3", coordinates = @Loc(value = THREE)) }, edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
-                    @Edge(id = "23", coordinates = { @Loc(value = TWO), @Loc(value = THREE) }),
-                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
                             @Loc(value = ONE) }) }, relations = {
                                     @Relation(id = "123", members = {
-                                            @Member(id = "12", type = "edge", role = "any"),
-                                            @Member(id = "2", type = "node", role = "any"),
-                                            @Member(id = "23", type = "edge", role = "any") }) })
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }) })
     private Atlas missingRelationType;
 
-    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-            @Node(id = "2", coordinates = @Loc(value = TWO)),
-            @Node(id = "3", coordinates = @Loc(value = THREE)) }, edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
-                    @TestAtlas.Edge(id = "23", coordinates = { @Loc(value = TWO),
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @TestAtlas.Edge(id = "23000000", coordinates = { @Loc(value = TWO),
                             @Loc(value = THREE) }),
-                    @TestAtlas.Edge(id = "31", coordinates = { @Loc(value = THREE),
+                    @TestAtlas.Edge(id = "31000000", coordinates = { @Loc(value = THREE),
                             @Loc(value = ONE) }) }, relations = {
                                     @Relation(id = "123", members = {
-                                            @Member(id = "12", type = "edge", role = "any"),
-                                            @Member(id = "2", type = "node", role = "any"),
-                                            @Member(id = "23", type = "edge", role = "any") }, tags = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
                                                     "disused:type=any" }) })
     private Atlas missingRelationTypeDisused;
 
-    @TestAtlas(nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-            @Node(id = "2", coordinates = @Loc(value = TWO)),
-            @Node(id = "3", coordinates = @Loc(value = THREE)) }, edges = {
-                    @TestAtlas.Edge(id = "12", coordinates = { @Loc(value = ONE),
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @TestAtlas.Edge(id = "12000000", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }),
-                    @TestAtlas.Edge(id = "23", coordinates = { @Loc(value = TWO),
+                    @TestAtlas.Edge(id = "23000000", coordinates = { @Loc(value = TWO),
                             @Loc(value = THREE) }),
-                    @TestAtlas.Edge(id = "31", coordinates = { @Loc(value = THREE),
+                    @TestAtlas.Edge(id = "31000000", coordinates = { @Loc(value = THREE),
                             @Loc(value = ONE) }) }, relations = {
                                     @Relation(id = "123", members = {
-                                            @Member(id = "12", type = "edge", role = "any"),
-                                            @Member(id = "2", type = "node", role = "any"),
-                                            @Member(id = "23", type = "edge", role = "any") }, tags = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
                                                     "disabled:type=any" }) })
     private Atlas missingRelationTypeDisabled;
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheckTestRule.java
@@ -23,103 +23,103 @@ public class OneMemberRelationCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)),
-                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3000000", coordinates = @Loc(value = THREE)) },
             // edges
             edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }, tags = { "highway=road" }),
-                    @Edge(id = "23", coordinates = { @Loc(value = TWO),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
                             @Loc(value = THREE) }, tags = { "highway=road" }),
-                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
                             @Loc(value = ONE) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
-                    @Member(id = "2", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
-                    @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
+                    @Member(id = "12000000", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
+                    @Member(id = "2000000", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
+                    @Member(id = "23000000", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
                             "restriction=no_u_turn" }) })
     private Atlas validRelation;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)) },
             // edges
-            edges = { @Edge(id = "12", coordinates = { @Loc(value = ONE),
+            edges = { @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
                     @Loc(value = TWO) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM) }, tags = {
+                    @Member(id = "12000000", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM) }, tags = {
                             "restriction=no_u_turn" }) })
     private Atlas oneMemberRelation;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)) },
             // edges
-            edges = { @Edge(id = "12", coordinates = { @Loc(value = ONE),
+            edges = { @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
                     @Loc(value = TWO) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER) }, tags = {
+                    @Member(id = "12000000", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER) }, tags = {
                             "restriction=no_u_turn", "type=multipolygon" }) })
     private Atlas oneMemberRelationMultipolygonInner;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)) },
             // edges
-            edges = { @Edge(id = "12", coordinates = { @Loc(value = ONE),
+            edges = { @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
                     @Loc(value = TWO) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                    @Member(id = "12000000", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
                             "restriction=no_u_turn", "type=multipolygon" }) })
     private Atlas oneMemberRelationMultipolygonOuter;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)),
-                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3000000", coordinates = @Loc(value = THREE)) },
             // edges
             edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }, tags = { "highway=road" }),
-                    @Edge(id = "23", coordinates = { @Loc(value = TWO),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
                             @Loc(value = THREE) }, tags = { "highway=road" }),
-                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
                             @Loc(value = ONE) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
-                    @Member(id = "2", type = "node", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER),
-                    @Member(id = "23", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
+                    @Member(id = "12000000", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_INNER),
+                    @Member(id = "2000000", type = "node", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER),
+                    @Member(id = "23000000", type = "edge", role = RelationTypeTag.MULTIPOLYGON_ROLE_OUTER) }, tags = {
                             "restriction=no_u_turn", "type=multipolygon" }) })
     private Atlas validRelationMultipolygon;
 
     @TestAtlas(
             // nodes
-            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
-                    @Node(id = "2", coordinates = @Loc(value = TWO)),
-                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3000000", coordinates = @Loc(value = THREE)) },
             // edges
             edges = {
-                    @Edge(id = "12", coordinates = { @Loc(value = ONE),
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
                             @Loc(value = TWO) }, tags = { "highway=road" }),
-                    @Edge(id = "23", coordinates = { @Loc(value = TWO),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
                             @Loc(value = THREE) }, tags = { "highway=road" }),
-                    @Edge(id = "31", coordinates = { @Loc(value = THREE),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
                             @Loc(value = ONE) }, tags = { "highway=road" }) },
             // relations
             relations = { @Relation(id = "123", members = {
-                    @Member(id = "12", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
-                    @Member(id = "2", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
-                    @Member(id = "23", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
+                    @Member(id = "12000000", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_FROM),
+                    @Member(id = "2000000", type = "node", role = RelationTypeTag.RESTRICTION_ROLE_VIA),
+                    @Member(id = "23000000", type = "edge", role = RelationTypeTag.RESTRICTION_ROLE_TO) }, tags = {
                             "restriction=no_u_turn" }),
                     @Relation(id = "1231", members = {
                             @Member(id = "123", type = "relation", role = RelationTypeTag.RESTRICTION_ROLE_FROM) }, tags = {


### PR DESCRIPTION
### Description:

Please refer to https://github.com/osmlab/atlas-checks/issues/460

### Potential Impact:
MissingRelationTypeCheck - to generate less flags
OneMemberRelationCheck - to generate more flags

### Unit Test Approach:
Create One Member Relation with Artificial Member (same OSM id)

### Test Results:
CommonMethods - passed
MissingRelationTypeCheck - passed
OneMemberRelationCheck - passed