### PR TITLE
Atlas 6.3.4, Generator 5.2.3, Jackson bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ configurations
         resolutionStrategy {
             // Force the version compatible with the latest version
             // of Spark brought in by atlas generator
-            force 'com.fasterxml.jackson.core:jackson-core:2.6.7'
-            force 'com.fasterxml.jackson.core:jackson-databind:2.6.7'
+            force 'com.fasterxml.jackson.core:jackson-core:2.10.0'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
         }
     }
     compile

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,9 +1,9 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.3',
-    atlas: '6.3.3',
+    atlas: '6.3.4',
     commons:'2.6',
-    atlas_generator: '5.1.6',
+    atlas_generator: '5.2.3',
     atlas_checkstyle: '5.6.9',
     postgis: '2.1.7.2',
     postgres: '42.2.6',

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/BigNodeBadDataCheckTest.java
@@ -41,7 +41,7 @@ public class BigNodeBadDataCheckTest
     public void testBigNodeAtlas()
     {
         Assert.assertTrue(
-                this.runTest(this.setup.getBigNodeAtlas(), this.configNormalThreshold, 1));
+                this.runTest(this.setup.getBigNodeAtlas(), this.configNormalThreshold, 0));
     }
 
     @Test


### PR DESCRIPTION
### Description:

Bump atlas and atlas generator versions

Atlas: https://github.com/osmlab/atlas/compare/6.3.3...6.3.4
generator: https://github.com/osmlab/atlas-generator/compare/5.1.6...5.2.3
Jackson 2.6.7 -> 2.10.0 (dictated by new spark version brought in by generator)

Updated a unit test that was probably affected by https://github.com/osmlab/atlas/pull/708 from the new atlas version


### Potential Impact:

Confirmed to run stably. Potential flag changes. 

### Unit Test Approach:

NA

### Test Results:

NA
