### PR TITLE
Fix Configuration Country Permitlist Bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/CheckResourceLoader.java
@@ -360,7 +360,7 @@ public class CheckResourceLoader
                         Collections.emptyList())
                 .value();
         return this.isEnabledByConfiguration(configuration, checkClass)
-                && countryPermitlist.isEmpty() ? !countryDenylist.contains(country)
-                        : countryPermitlist.contains(country);
+                && (countryPermitlist.isEmpty() ? !countryDenylist.contains(country)
+                        : countryPermitlist.contains(country));
     }
 }


### PR DESCRIPTION
### Description:

This fixes a bug where a check with a `countries.permitlist` (or the shortcut paramter `countries`) would always be enabled in those countries regardless of the global or their local `enabled` value. Thus when UnwalkableWaysCheck was run in SGP, even if it was set with `"enabled": false` it would still run. 

### Potential Impact:

The correct checks will always be run. 

### Unit Test Approach:

None

### Test Results:

Tested setting the global enabled value to false and running checks in SGP and RUS. Before this fix UnwalkableWaysCheck and InvalidSignBoardRelationCheck would continue to respectively run in those countries. Ran again post fix and the runs failed in both countries with a no checks enabled error as expected. 

