### PR TITLE
Update levelCrossingOnRailwayCheck auto-fix suggestions

### DIFF
--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -48,7 +48,7 @@ This document is a list of tables with a description and link to documentation f
 | ConnectivityCheck | This check identifies nodes that should be connected to nearby nodes or edges. |
 | [DuplicateNodeCheck](checks/duplicateNodeCheck.md) | The purpose of this check is to identify Nodes that are in the exact same location. |
 | [InvalidMiniRoundaboutCheck](checks/invalidMiniRoundaboutCheck.md) | The purpose of this check is to identify invalid mini-roundabouts (i.e. roundabouts that share the same rules as other roundabouts, but present as painted circles rather than physical circles). |
-| [LevelCrossingOnRailwayCheck](checks/LevelCrossingOnRailwayCheck.md) | This check identifies incorrectly tagged or missing nodes at railway/highway intersections. |
+| [LevelCrossingOnRailwayCheck](checks/levelCrossingOnRailwayCheck.md) | This check identifies incorrectly tagged or missing nodes at railway/highway intersections. |
 | NodeValenceCheck | This check identifies nodes with too many connections. |
 | [OrphanNodeCheck](tutorials/tutorial2-OrphanNodeCheck.md) | The purpose of this check is to identify untagged and unconnected Nodes in OSM. |
 

--- a/docs/checks/levelCrossingOnRailwayCheck.md
+++ b/docs/checks/levelCrossingOnRailwayCheck.md
@@ -45,10 +45,10 @@ Nodes & Relations; in our case, we’re working with
 In OpenStreetMap, railways are [Ways](https://wiki.openstreetmap.org/wiki/Way) classified with
 the `railway=rail`, `railway=tram`, `railway=disused`, `railway=miniature`, or `railway=preserved` tags. Highways are
 [Ways](https://wiki.openstreetmap.org/wiki/Way) classified with `highway=*` tags. In this check we are interested in
-the intersection of highweays and railways. These are represented by [Nodes](https://wiki.openstreetmap.org/wiki/Node).
+the intersection of highways and railways. These are represented by [Nodes](https://wiki.openstreetmap.org/wiki/Node).
 We’ll use this information to filter our potential flag candidates.
 
-A Car Navigable highway is any higway tagged with any of the following "highway:" tag values: MOTORWAY, TRUNK,
+A Car Navigable highway is any highway tagged with any of the following "highway:" tag values: MOTORWAY, TRUNK,
 PRIMARY, SECONDARY, TERTIARY, UNCLASSIFIED, RESIDENTIAL, SERVICE, MOTORWAY_LINK, TRUNK_LINK, PRIMARY_LINK,
 SECONDARY_LINK, TERTIARY_LINK, LIVING_STREET, TRACK, ROAD.
 
@@ -56,8 +56,8 @@ A valid intersection of a car navigable highway and railway should have a [Node]
 at the intersection of the ways that is classified with a `railway=level_crossing`. Nodes at intersections are only
 necessary if the railway and highway ways are on the same layer. It is common for a way that is classified with a
 `bridge=yes` or `tunnel=yes` to go over or under another way without an intersection node. In those cases a node at the
-intersection is not necessary, and if a node does exist at that intersection then the `railway=level_crossing` tag 
-should not be used. This check assumes that if a highway or railway has been tagged to indicate that this way is a 
+intersection is not necessary, and if a node does exist at that intersection then the `railway=level_crossing` tag
+should not be used. This check assumes that if a highway or railway has been tagged to indicate that this way is a
 bridge or tunnel and the layer tag has not been set, then there is an implied layer of 1 for bridges and -1 for
 tunnels.
 
@@ -68,12 +68,13 @@ The code has three major sections to check for all possible types of railway/hig
 
 1. The first section is specifically designed to look at all [Nodes](https://wiki.openstreetmap.org/wiki/Node). Each
 node is examined to count the number of highways and railways that contain this node.
-    1. If a node is contained in at least one highway and at least one railway on the same layer and is not tagged 
-    with `railway=level_crossing` then it is flagged. A fix suggestion exists for this type of issue and will suggest 
+    1. If a node is contained in at least one highway and at least one railway on the same layer and is not tagged
+    with `railway=level_crossing` then it is flagged. A fix suggestion exists for this type of issue and will suggest
     to add a railway=level_crossing tag to the Node.
-    1. If a node is tagged with `railway=level_crossing` but is not contained in any railways or highways or all
-highways and railways are on separate layers then it is flagged. A fix suggestion exists for this issue and will suggest
-to remove the invalid tag.
+    1. If a node is tagged with `railway=level_crossing` but is not contained in any railways or car navigable highways
+or all highways and railways are on separate layers then it is flagged. Two fix suggestions exists for these issues and
+will suggest to remove the invalid tag if no pedestrian ways cross at this node. If a pedestrian way crosses at this
+node then the suggestion will suggest to change the railway=level_crossing tag to railway=crossing.
 
 2. The second section examines all objects that are not Nodes or Points. If any non-node or point object is tagged
 with `railway=level_crossing` then it is flagged. A fix suggestion exists for this issue and it will suggest to remove

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTest.java
@@ -62,6 +62,15 @@ public class LevelCrossingOnRailwayCheckTest
     }
 
     @Test
+    public void invalidIntersectionPedNoHighwayTest()
+    {
+        this.verifier.actual(this.setup.getInvalidIntersectionPedNoHighway(),
+                new LevelCrossingOnRailwayCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> verifyObjectsAndSuggestions(flag, 1, 1));
+    }
+
+    @Test
     public void invalidIntersectionNoRailwayTest()
     {
         this.verifier.actual(this.setup.getInvalidIntersectionNoRailway(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTestRule.java
@@ -205,6 +205,28 @@ public class LevelCrossingOnRailwayCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             /*
+             * Test invalid level crossing with ped highway and no car highway
+             */
+            // nodes
+            nodes = {
+                    @Node(id = "123456789000000", coordinates = @Loc(value = R_NODE_1), tags = {}),
+                    @Node(id = "223456789000000", coordinates = @Loc(value = R_NODE_2), tags = {}),
+                    @Node(id = "323456789000000", coordinates = @Loc(value = H1_NODE_1), tags = {}),
+                    @Node(id = "423456789000000", coordinates = @Loc(value = H1_NODE_2), tags = {}),
+                    @Node(id = "523456789000000", coordinates = @Loc(value = INT1), tags = {
+                            "railway=level_crossing" }) },
+            // edges
+            edges = { @Edge(id = "113456789000000", coordinates = { @Loc(value = H1_NODE_1),
+                @Loc(value = H1_NODE_2),
+                @Loc(value = INT1) }, tags = { "highway=footway" }) },
+            // lines
+            lines = { @Line(id = "133456789000000", coordinates = { @Loc(value = R_NODE_1),
+                    @Loc(value = R_NODE_2), @Loc(value = INT1) }, tags = { "railway=rail" }) })
+
+    private Atlas invalidIntersectionPedNoHighway;
+
+    @TestAtlas(
+            /*
              * Ignore intersections with construction. Generally this would fail because the node
              * should be tagged but is not. This test should pass because we want to ignore
              * construction.
@@ -320,6 +342,11 @@ public class LevelCrossingOnRailwayCheckTestRule extends CoreTestRule
     public Atlas getInvalidIntersectionNoHighway()
     {
         return this.invalidIntersectionNoHighway;
+    }
+
+    public Atlas getInvalidIntersectionPedNoHighway()
+    {
+        return this.invalidIntersectionPedNoHighway;
     }
 
     public Atlas getInvalidIntersectionNoRailway()


### PR DESCRIPTION
### Description:

Fixed the auto-fix suggestions for level crossing on railway check. The old auto-fix suggestion suggested to the user to remove the railway=level_crossing tag if the node was not a railway crossing. The new auto-fix suggestion detects if there are pedestrian ways going through this node. If that is the case then the new suggestion will be to change the railway=level_crossing tag to railway=crossing.

### Potential Impact:

Changes the autofix suggestion for some of the issues founf in the level Crossing on Railway check.

### Unit Test Approach:

Created challenge from NZL and verified that the new suggestions looked correct.
https://maproulette.org/challenge/15923/

Here is an example of the new suggestion:
https://maproulette.org/challenge/15923/task/75734873

### Test Results:

Since this is only fixing the auto-fix suggestions I did not test that many. Just NZL

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
|  NZL   |    99         |    10      |     10%       |   10 |   0 | 0%   |

