### PR TITLE
[Improvement] MalformedRoundaboutCheck: Minimum OSM Nodes/Angles

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -631,6 +631,7 @@
     }
   },
   "MalformedRoundaboutCheck" : {
+    "min.nodes": 8.0,
     "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
       "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
       "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -631,7 +631,8 @@
     }
   },
   "MalformedRoundaboutCheck" : {
-    "min.nodes": 8.0,
+    "angle.threshold.maximum_degree": 60.0,
+    "min.nodes": 9.0,
     "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
       "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
       "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -71,8 +71,8 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
     private static final int MIN_NODES_INSTRUCTION_INDEX = 3;
     private static final int SHARP_ANGLE_INSTRUCTION_INDEX = 4;
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            ENCLOSED_ROADS_INSTRUCTIONS, WRONG_WAY_INSTRUCTIONS, BASIC_INSTRUCTION, MINIMUM_NODES_INSTRUCTION,
-            SHARP_ANGLE_INSTRUCTION);
+            ENCLOSED_ROADS_INSTRUCTIONS, WRONG_WAY_INSTRUCTIONS, BASIC_INSTRUCTION,
+            MINIMUM_NODES_INSTRUCTION, SHARP_ANGLE_INSTRUCTION);
     private final List<String> leftDrivingCountries;
     private final double minNodes;
     private final Angle maxAngleThreshold;
@@ -177,15 +177,19 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
                 instructions.add(this.getLocalizedInstruction(0));
             }
 
-            final Optional<PolyLine> originalGeometryOptional = this.buildOriginalOsmWayGeometry((Edge) object);
+            final Optional<PolyLine> originalGeometryOptional = this
+                    .buildOriginalOsmWayGeometry((Edge) object);
             if (originalGeometryOptional.isPresent())
             {
                 final PolyLine originalGeometry = originalGeometryOptional.get();
-                // There should be a minimum amount of OSM nodes in a roundabout to have good visuals.
-                // Only count nodes when we have the full roundabout, some are split into multiple ways.
+                // There should be a minimum amount of OSM nodes in a roundabout to have good
+                // visuals.
+                // Only count nodes when we have the full roundabout, some are split into multiple
+                // ways.
                 if (originalGeometry.size() < this.minNodes && ((Edge) object).isClosed())
                 {
-                    instructions.add(this.getLocalizedInstruction(MIN_NODES_INSTRUCTION_INDEX, this.minNodes));
+                    instructions.add(this.getLocalizedInstruction(MIN_NODES_INSTRUCTION_INDEX,
+                            this.minNodes));
                 }
 
                 // Check for sharp angles, roundabouts should be smooth curves
@@ -197,7 +201,8 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
                             .map(t -> "(" + t.getSecond().getLatitude() + ", "
                                     + t.getSecond().getLongitude() + ")")
                             .collect(Collectors.joining(", ")) + ")";
-                    instructions.add(this.getLocalizedInstruction(SHARP_ANGLE_INSTRUCTION_INDEX, angleLocations));
+                    instructions.add(this.getLocalizedInstruction(SHARP_ANGLE_INSTRUCTION_INDEX,
+                            angleLocations));
                 }
             }
         }
@@ -239,7 +244,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
             }
             return Optional.of(geometry);
         }
-            catch (final CoreException coreException)
+        catch (final CoreException coreException)
         {
             return Optional.empty();
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -51,6 +51,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
     private static final String BASIC_INSTRUCTION = "This roundabout is malformed.";
     private static final String ENCLOSED_ROADS_INSTRUCTIONS = "This roundabout has car navigable ways inside it.";
     private static final String WRONG_WAY_INSTRUCTIONS = "This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.";
+    private static final String MINIMUM_NODES_INSTRUCTION = "This roundabout has less than or equal to {0,number,#} nodes.";
     private static final List<String> LEFT_DRIVING_COUNTRIES_DEFAULT = Arrays.asList("AIA", "ATG",
             "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA", "CCK", "COK", "CXR", "CYM",
             "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD", "GUY", "HKG", "IDN", "IMN", "IND",
@@ -59,15 +60,18 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
             "PAK", "PCN", "PNG", "SGP", "SGS", "SHN", "SLB", "SUR", "SWZ", "SYC", "TCA", "THA",
             "TKL", "TLS", "TON", "TTO", "TUV", "TZA", "UGA", "VCT", "VGB", "VIR", "WSM", "ZAF",
             "ZMB", "ZWE");
+    private static final double MIN_NODES_DEFAULT = 8.0;
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList(ENCLOSED_ROADS_INSTRUCTIONS, WRONG_WAY_INSTRUCTIONS, BASIC_INSTRUCTION);
+            .asList(ENCLOSED_ROADS_INSTRUCTIONS, WRONG_WAY_INSTRUCTIONS, BASIC_INSTRUCTION, MINIMUM_NODES_INSTRUCTION);
     private final List<String> leftDrivingCountries;
+    private final double minNodes;
 
     public MalformedRoundaboutCheck(final Configuration configuration)
     {
         super(configuration);
         this.leftDrivingCountries = configurationValue(configuration, "traffic.countries.left",
                 LEFT_DRIVING_COUNTRIES_DEFAULT);
+        this.minNodes = configurationValue(configuration, "min.nodes", MIN_NODES_DEFAULT);
     }
 
     @Override
@@ -157,6 +161,10 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
                 && this.roundaboutEnclosesRoads(roundaboutEdges))
         {
             instructions.add(this.getLocalizedInstruction(0));
+        }
+
+        if (roundaboutEdges != null && roundaboutEdges.asPolyLine().size() <= minNodes) {
+            instructions.add(this.getLocalizedInstruction(2, minNodes));
         }
 
         if (!instructions.isEmpty())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -183,7 +183,8 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
             // visuals.
             // Only count nodes when we have the full roundabout, some are split into multiple
             // ways.
-            if (originalGeometry.size() < this.minNodes && !this.isMultiWayRoundabout(roundaboutEdgeSet))
+            if (originalGeometry.size() < this.minNodes
+                    && !this.isMultiWayRoundabout(roundaboutEdgeSet))
             {
                 instructions.add(
                         this.getLocalizedInstruction(MIN_NODES_INSTRUCTION_INDEX, this.minNodes));

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -1,6 +1,5 @@
 package org.openstreetmap.atlas.checks.validation.linear.edges;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -178,15 +177,16 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
 
         try
         {
-            final PolyLine originalGeometry = CommonMethods.buildOriginalOsmWayGeometry((Edge) object);
+            final PolyLine originalGeometry = CommonMethods
+                    .buildOriginalOsmWayGeometry((Edge) object);
             // There should be a minimum amount of OSM nodes in a roundabout to have good
             // visuals.
             // Only count nodes when we have the full roundabout, some are split into multiple
             // ways.
             if (originalGeometry.size() < this.minNodes && ((Edge) object).isClosed())
             {
-                instructions.add(this.getLocalizedInstruction(MIN_NODES_INSTRUCTION_INDEX,
-                        this.minNodes));
+                instructions.add(
+                        this.getLocalizedInstruction(MIN_NODES_INSTRUCTION_INDEX, this.minNodes));
             }
 
             // Check for sharp angles, roundabouts should be smooth curves
@@ -202,7 +202,10 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
                         angleLocations));
             }
         }
-        catch (CoreException ignored) { }
+        catch (final CoreException ignored)
+        {
+            /* Do Nothing */
+        }
 
         if (!instructions.isEmpty())
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheck.java
@@ -183,7 +183,7 @@ public class MalformedRoundaboutCheck extends BaseCheck<Long>
             // visuals.
             // Only count nodes when we have the full roundabout, some are split into multiple
             // ways.
-            if (originalGeometry.size() < this.minNodes && ((Edge) object).isClosed())
+            if (originalGeometry.size() < this.minNodes && !this.isMultiWayRoundabout(roundaboutEdgeSet))
             {
                 instructions.add(
                         this.getLocalizedInstruction(MIN_NODES_INSTRUCTION_INDEX, this.minNodes));

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -33,7 +33,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -47,7 +47,7 @@ public class MalformedRoundaboutCheckTest
                 this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -60,7 +60,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutBridgeRightDrivingEnclosedAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -78,7 +78,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedBridgeAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -88,7 +88,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedPathAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -99,7 +99,7 @@ public class MalformedRoundaboutCheckTest
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -112,7 +112,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -134,7 +134,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingWrongEdgesTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -159,7 +159,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -201,7 +201,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -255,7 +255,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.enclosedNavigableRoad(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -268,7 +268,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.enclosedNavigableRoadArea(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + "}}")));
+                                + ",\"min.nodes\":"+ 0.0 +"}}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -28,23 +28,12 @@ public class MalformedRoundaboutCheckTest
     }
 
     @Test
-    public void testAngleGreaterThanThreshold()
-    {
-        this.verifier.actual(this.setup.angleGreaterThanThreshold(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"+ 60.0 + ", \"min.nodes\":"+ 1.0 +"}}"))));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(
-                "1. This roundabout is malformed.\n2. This roundabout has too sharp of an angle at ((-27.4512972, 153.0120204), (-27.4512764, 153.0121637), (-27.4513581, 153.0121916), (-27.4512564, 153.0120857)), consider adding more nodes or rearranging the roundabout to fix this.",
-                flags.get(0).getInstructions()));
-    }
-
-    @Test
     public void clockwiseRoundaboutLeftDrivingMissingTagTest()
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -68,8 +57,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutBridgeRightDrivingEnclosedAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -86,8 +75,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedBridgeAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -96,8 +85,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedPathAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -107,8 +96,8 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -140,11 +129,22 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingWrongEdgesTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
+                flags.get(0).getInstructions()));
+    }
+
+    @Test
+    public void testAngleGreaterThanThreshold()
+    {
+        this.verifier.actual(this.setup.angleGreaterThanThreshold(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"+ 60.0 + ", \"min.nodes\":"+ 1.0 +"}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n2. This roundabout has too sharp of an angle at ((-27.4512972, 153.0120204), (-27.4512764, 153.0121637), (-27.4513581, 153.0121916), (-27.4512564, 153.0120857)), consider adding more nodes or rearranging the roundabout to fix this.",
                 flags.get(0).getInstructions()));
     }
 
@@ -153,8 +153,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -195,8 +195,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -250,8 +250,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.enclosedNavigableRoad(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -263,8 +263,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.enclosedNavigableRoadArea(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}"))));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -33,7 +33,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -47,7 +47,7 @@ public class MalformedRoundaboutCheckTest
                 this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -60,7 +60,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutBridgeRightDrivingEnclosedAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -78,7 +78,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedBridgeAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -88,7 +88,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedPathAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -99,7 +99,7 @@ public class MalformedRoundaboutCheckTest
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -112,7 +112,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -134,7 +134,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingWrongEdgesTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -159,7 +159,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -201,7 +201,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -255,7 +255,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.enclosedNavigableRoad(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -268,7 +268,7 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(this.setup.enclosedNavigableRoadArea(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
-                                + ",\"min.nodes\":"+ 0.0 +"}}")));
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -45,7 +45,9 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(
                 this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -108,7 +110,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingOneWayNoTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -212,7 +216,6 @@ public class MalformedRoundaboutCheckTest
                 "1. This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.",
                 flags.get(0).getInstructions()));
         this.verifier.verify(flag -> verifyFixSuggestions(flag, 1));
-
     }
 
     @Test
@@ -236,7 +239,6 @@ public class MalformedRoundaboutCheckTest
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
                 flags.get(0).getInstructions()));
-
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -32,8 +32,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -57,8 +57,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutBridgeRightDrivingEnclosedAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -75,8 +75,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedBridgeAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -85,8 +85,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedPathAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -96,8 +96,8 @@ public class MalformedRoundaboutCheckTest
         this.verifier.actual(
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -129,8 +129,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingWrongEdgesTagAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -142,7 +142,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.angleGreaterThanThreshold(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"+ 60.0 + ", \"min.nodes\":"+ 1.0 +"}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 60.0
+                                + ", \"min.nodes\":" + 1.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n2. This roundabout has too sharp of an angle at ((-27.4512972, 153.0120204), (-27.4512764, 153.0121637), (-27.4513581, 153.0121916), (-27.4512564, 153.0120857)), consider adding more nodes or rearranging the roundabout to fix this.",
                 flags.get(0).getInstructions()));
@@ -153,8 +154,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -195,8 +196,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -218,8 +219,9 @@ public class MalformedRoundaboutCheckTest
     public void testFewerThanMinOSMNodesRoundaboutAtlas()
     {
         this.verifier.actual(this.setup.fewerThanMinOSMNodesRoundaboutAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"min.nodes\":" + 9.0 + ", \"angle.threshold.maximum_degree\":" + 179.0 + "}}")));
+                new MalformedRoundaboutCheck(ConfigurationResolver
+                        .inlineConfiguration("{\"MalformedRoundaboutCheck\":{\"min.nodes\":" + 9.0
+                                + ", \"angle.threshold.maximum_degree\":" + 179.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n2. This roundabout has less than 9 nodes.",
                 flags.get(0).getInstructions()));
@@ -250,8 +252,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.enclosedNavigableRoad(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -263,8 +265,8 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(this.setup.enclosedNavigableRoadArea(),
                 new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
-                                + 179.0 + "}}")));
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + "}}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -28,10 +28,23 @@ public class MalformedRoundaboutCheckTest
     }
 
     @Test
+    public void testAngleGreaterThanThreshold()
+    {
+        this.verifier.actual(this.setup.angleGreaterThanThreshold(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"+ 60.0 + ", \"min.nodes\":"+ 1.0 +"}}"))));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n2. This roundabout has too sharp of an angle at ((-27.4512972, 153.0120204), (-27.4512764, 153.0121637), (-27.4513581, 153.0121916), (-27.4512564, 153.0120857)), consider adding more nodes or rearranging the roundabout to fix this.",
+                flags.get(0).getInstructions()));
+    }
+
+    @Test
     public void clockwiseRoundaboutLeftDrivingMissingTagTest()
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -54,7 +67,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutBridgeRightDrivingEnclosedTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutBridgeRightDrivingEnclosedAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -70,7 +85,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingEnclosedBridgeTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedBridgeAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -78,7 +95,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingEnclosedPathTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedPathAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -87,7 +106,9 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -118,7 +139,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingWrongEdgesTagTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingWrongEdgesTagAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -129,7 +152,9 @@ public class MalformedRoundaboutCheckTest
     public void testClockwiseRoundaboutLeftDrivingAtlas()
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.verifyEmpty();
     }
 
@@ -169,7 +194,9 @@ public class MalformedRoundaboutCheckTest
     public void testCounterClockwiseRoundaboutRightDrivingAtlas()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.verifyEmpty();
     }
 
@@ -185,6 +212,17 @@ public class MalformedRoundaboutCheckTest
                 flags.get(0).getInstructions()));
         this.verifier.verify(flag -> verifyFixSuggestions(flag, 1));
 
+    }
+
+    @Test
+    public void testFewerThanMinOSMNodesRoundaboutAtlas()
+    {
+        this.verifier.actual(this.setup.fewerThanMinOSMNodesRoundaboutAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"min.nodes\":" + 9.0 + ", \"angle.threshold.maximum_degree\":" + 179.0 + "}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n2. This roundabout has less than 9 nodes.",
+                flags.get(0).getInstructions()));
     }
 
     @Test
@@ -211,7 +249,9 @@ public class MalformedRoundaboutCheckTest
     public void testRoundaboutWithEnclosedNavigableRoad()
     {
         this.verifier.actual(this.setup.enclosedNavigableRoad(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -222,7 +262,9 @@ public class MalformedRoundaboutCheckTest
     public void testRoundaboutWithEnclosedNavigableRoadArea()
     {
         this.verifier.actual(this.setup.enclosedNavigableRoadArea(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        ("{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":"
+                                + 179.0 + "}}"))));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
@@ -36,6 +36,7 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
     private static final String MIN_NODE_6 = "-27.4513581, 153.0121916";
     private static final String MIN_NODE_7 = "-27.4512564, 153.0120857";
 
+    // Contain angle greater than threshold
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = MIN_NODE_1)),
             @Node(coordinates = @Loc(value = MIN_NODE_2)),
             @Node(coordinates = @Loc(value = MIN_NODE_3)),
@@ -43,12 +44,12 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
             @Node(coordinates = @Loc(value = MIN_NODE_5)),
             @Node(coordinates = @Loc(value = MIN_NODE_6)),
             @Node(coordinates = @Loc(value = MIN_NODE_7)), }, edges = {
-            @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
-                    @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
-                    @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
-                    @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
-                    @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
-                    "highway=primary", "iso_country_code=USA" }) })
+                    @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
+                            @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
+                            @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
+                            @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
+                            @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
+                                    "highway=primary", "iso_country_code=USA" }) })
     private Atlas angleGreaterThanThresholdAtlas;
 
     // Clockwise roundabout, left driving country
@@ -159,6 +160,7 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
                                     "iso_country_code=USA", "highway=primary" }) })
     private Atlas counterClockwiseRoundaboutRightDrivingAtlas;
 
+    // Fewer than 9 nodes
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = MIN_NODE_1)),
             @Node(coordinates = @Loc(value = MIN_NODE_2)),
             @Node(coordinates = @Loc(value = MIN_NODE_3)),
@@ -166,12 +168,12 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
             @Node(coordinates = @Loc(value = MIN_NODE_5)),
             @Node(coordinates = @Loc(value = MIN_NODE_6)),
             @Node(coordinates = @Loc(value = MIN_NODE_7)), }, edges = {
-            @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
-                    @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
-                    @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
-                    @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
-                    @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
-                    "highway=primary", "iso_country_code=USA" }) })
+                    @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
+                            @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
+                            @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
+                            @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
+                            @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
+                                    "highway=primary", "iso_country_code=USA" }) })
     private Atlas fewerThanMinOSMNodesRoundaboutAtlas;
 
     // Multi-directional Atlas

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
@@ -28,6 +28,29 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
     private static final String COUNTER_CLOCKWISE_4 = "38.90588716371307,-77.03230261802673";
     private static final String COUNTER_CLOCKWISE_5 = "38.90551980892527,-77.03236699104309";
 
+    private static final String MIN_NODE_1 = "-27.4514156, 153.0121326";
+    private static final String MIN_NODE_2 = "-27.4514168, 153.0120745";
+    private static final String MIN_NODE_3 = "-27.4513729, 153.0120172";
+    private static final String MIN_NODE_4 = "-27.4512972, 153.0120204";
+    private static final String MIN_NODE_5 = "-27.4512764, 153.0121637";
+    private static final String MIN_NODE_6 = "-27.4513581, 153.0121916";
+    private static final String MIN_NODE_7 = "-27.4512564, 153.0120857";
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = MIN_NODE_1)),
+            @Node(coordinates = @Loc(value = MIN_NODE_2)),
+            @Node(coordinates = @Loc(value = MIN_NODE_3)),
+            @Node(coordinates = @Loc(value = MIN_NODE_4)),
+            @Node(coordinates = @Loc(value = MIN_NODE_5)),
+            @Node(coordinates = @Loc(value = MIN_NODE_6)),
+            @Node(coordinates = @Loc(value = MIN_NODE_7)), }, edges = {
+            @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
+                    @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
+                    @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
+                    @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
+                    @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
+                    "highway=primary", "iso_country_code=USA" }) })
+    private Atlas angleGreaterThanThresholdAtlas;
+
     // Clockwise roundabout, left driving country
     @TestAtlas(
             // nodes
@@ -135,6 +158,21 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
                             @Loc(value = COUNTER_CLOCKWISE_1) }, tags = { "junction=roundabout",
                                     "iso_country_code=USA", "highway=primary" }) })
     private Atlas counterClockwiseRoundaboutRightDrivingAtlas;
+
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = MIN_NODE_1)),
+            @Node(coordinates = @Loc(value = MIN_NODE_2)),
+            @Node(coordinates = @Loc(value = MIN_NODE_3)),
+            @Node(coordinates = @Loc(value = MIN_NODE_4)),
+            @Node(coordinates = @Loc(value = MIN_NODE_5)),
+            @Node(coordinates = @Loc(value = MIN_NODE_6)),
+            @Node(coordinates = @Loc(value = MIN_NODE_7)), }, edges = {
+            @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
+                    @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
+                    @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
+                    @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
+                    @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
+                    "highway=primary", "iso_country_code=USA" }) })
+    private Atlas fewerThanMinOSMNodesRoundaboutAtlas;
 
     // Multi-directional Atlas
     @TestAtlas(
@@ -642,6 +680,11 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
                                     "iso_country_code=SGP", "highway=primary" }) })
     private Atlas syntheticNode;
 
+    public Atlas angleGreaterThanThreshold()
+    {
+        return this.angleGreaterThanThresholdAtlas;
+    }
+
     public Atlas clockwiseRoundaboutLeftDrivingAtlas()
     {
         return this.clockwiseRoundaboutLeftDrivingAtlas;
@@ -730,6 +773,11 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
     public Atlas enclosedNavigableRoadArea()
     {
         return this.enclosedNavigableRoadArea;
+    }
+
+    public Atlas fewerThanMinOSMNodesRoundaboutAtlas()
+    {
+        return this.fewerThanMinOSMNodesRoundaboutAtlas;
     }
 
     public Atlas multiDirectionalRoundaboutAtlas()


### PR DESCRIPTION
### Description:

Checks amount of OSM nodes in roundabout are at or above a certain number.
This is a request from our editors to flag roundabouts that are made of fewer than 9 OSM nodes.
We are also checking the angle between the segments of the roundabout.

### Potential Impact:

None

### Unit Test Approach:

Test for roundabouts with fewer than {threshold} OSM nodes
Test for roundabouts with angles greater than {threshold}
Fixed old tests that didn't account for OSM nodes/angles.

### Test Results:
All results gathered were of just the new flags, old flags were commented out while gathering results.
A  note on the FP's: they are all due to Teardrop roundabouts.

|   ISO  | Total Flags | Sampled  | Sampling % | TP  |  FP | False Positive Rate |
|-------|-------------|------------|--------------|-----|-----| ------------------- |
|  ARG  |    51          |      24       |         47%      |  23 |   1  |             4%            |
|  AUS  |    95          |      41        |       49%       |  40 |   1  |             2%            |
|  NZL  |    8            |      8          |       100%     |   7  |   1  |            12%           |
|  SWE |     16         |      16        |       100%     |   12 |   4  |           25%            |


Resolves: #459 
