### PR TITLE
WaterWayCheck: Add autofix suggestion (geometry)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies
 
     // Support Junit 5 tests
     testImplementation packages.junit.api
+    testImplementation packages.junit.params
     testRuntimeOnly packages.junit.engine
     // Support JUnit 3/4 tests
     testCompileOnly packages.junit.junit4

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,6 +30,7 @@ project.ext.packages = [
         vintage: "org.junit.vintage:junit-vintage-engine:${versions.junit}",
         api: "org.junit.jupiter:junit-jupiter-api:${versions.junit}",
         engine: "org.junit.jupiter:junit-jupiter-engine:${versions.junit}",
+        params: "org.junit.jupiter:junit-jupiter-params:${versions.junit}",
     ],
     sqlite: "org.xerial:sqlite-jdbc:${versions.sqlite}",
     log4j: "log4j:log4j:${versions.log4j}"

--- a/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/serializer/CheckFlagDeserializer.java
@@ -354,11 +354,16 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
         {
             return Optional.empty();
         }
+        // Get the OSC if present
+        final Optional<String> osc = Optional.ofNullable(fixSuggestion.get("osc"))
+                .map(JsonElement::getAsString);
         // Create a remove FeatureChange from a shallow copy of the before view
         if (ChangeDescriptorType.REMOVE.equals(suggestionType))
         {
-            return Optional.of(new FeatureChange(ChangeType.REMOVE,
-                    CompleteEntity.shallowFrom(beforeView), beforeView));
+            final FeatureChange featureChange = new FeatureChange(ChangeType.REMOVE,
+                    CompleteEntity.shallowFrom(beforeView), beforeView);
+            osc.ifPresent(featureChange::withOsc);
+            return Optional.of(featureChange);
         }
 
         // Create a full copy for the after view
@@ -402,6 +407,9 @@ public class CheckFlagDeserializer implements JsonDeserializer<CheckFlag>
             this.applyGeometryChanges(afterView, geometryChangeDescriptors);
         }
 
-        return Optional.of(new FeatureChange(ChangeType.ADD, (AtlasEntity) afterView, beforeView));
+        final var featureChange = new FeatureChange(ChangeType.ADD, (AtlasEntity) afterView,
+                beforeView);
+        osc.ifPresent(featureChange::withOsc);
+        return Optional.of(featureChange);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/cooperative_challenge/GeometryChangeOperation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/cooperative_challenge/GeometryChangeOperation.java
@@ -1,0 +1,69 @@
+package org.openstreetmap.atlas.checks.maproulette.data.cooperative_challenge;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.openstreetmap.atlas.geography.atlas.change.description.ChangeDescription;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptor;
+import org.openstreetmap.atlas.geography.atlas.change.description.descriptors.ChangeDescriptorName;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Support geometry change operations
+ *
+ * @author Taylor Smock
+ */
+public class GeometryChangeOperation extends CooperativeChallengeOperation
+{
+    private static final String CONTENT = "content";
+    private static final Map<String, String> FILE_MAP = new HashMap<>(3);
+    static
+    {
+        FILE_MAP.put("type", "xml");
+        FILE_MAP.put("format", "osc");
+        FILE_MAP.put("encoding", "base64");
+    }
+
+    /** The OSC for the geometry change */
+    private final String osc;
+
+    public GeometryChangeOperation(final ChangeDescription changeDescription)
+    {
+        super(changeDescription);
+        final var optionalOsc = changeDescription.getOsc();
+        if (optionalOsc.isPresent())
+        {
+            this.osc = optionalOsc.get();
+        }
+        else if (changeDescription.toJsonElement().getAsJsonObject().has("osc"))
+        {
+            this.osc = changeDescription.toJsonElement().getAsJsonObject().get("osc").getAsString();
+        }
+        else
+        {
+            this.osc = null;
+        }
+    }
+
+    @Override
+    public GeometryChangeOperation create()
+    {
+        final var json = new JsonObject();
+        if (this.osc != null && !this.osc.isBlank())
+        {
+            FILE_MAP.forEach((key, value) -> json.add(key, new JsonPrimitive(value)));
+            json.add(CONTENT, new JsonPrimitive(this.osc));
+        }
+        this.setJson(json);
+        return this;
+    }
+
+    @Override
+    protected Predicate<ChangeDescriptor> operationFilter()
+    {
+        return changeDescriptor -> changeDescriptor.getName() == ChangeDescriptorName.GEOMETRY;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/OpenStreetMapCheckFlagConverter.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/OpenStreetMapCheckFlagConverter.java
@@ -128,6 +128,8 @@ public final class OpenStreetMapCheckFlagConverter
                     final Optional<PolyLine> concatenatedAfterPolyline = entry.getValue().stream()
                             .map(FeatureChange::getAfterView)
                             .sorted(Comparator.comparing(AtlasEntity::getIdentifier))
+                            // Removed edges may not have a polyline
+                            .filter(entity -> ((Edge) entity).asPolyLine() != null)
                             .map(entity -> ((Edge) entity).asPolyLine()).reduce(PolyLine::append);
                     if (concatenatedBeforePolyline.isPresent()
                             && concatenatedAfterPolyline.isPresent())

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/TaskTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/TaskTest.java
@@ -1,0 +1,107 @@
+package org.openstreetmap.atlas.checks.maproulette.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteLine;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+
+/**
+ * Test class for {@link Task}.
+ *
+ * @author Taylor Smock
+ */
+public class TaskTest
+{
+    @Rule
+    public TaskTestRule rule = new TaskTestRule();
+
+    /**
+     * Create a basic task
+     *
+     * @param points
+     *            The points
+     * @return The created task
+     */
+    private static Task createTaskSkeleton(final Location... points)
+    {
+        return createTaskSkeleton(Stream.of(points).collect(Collectors.toSet()));
+    }
+
+    /**
+     * Create a basic task
+     *
+     * @param points
+     *            The points
+     * @return The created task
+     */
+    private static Task createTaskSkeleton(final Set<Location> points)
+    {
+        final var task = new Task();
+        // Need to see challenge/identifier to avoid NPE
+        task.setChallengeName("Test challenge");
+        task.setTaskIdentifier("Test identifier");
+
+        task.setPoints(points);
+        task.setInstruction("Test instruction");
+        return task;
+    }
+
+    /**
+     * Test for the private inner class FixSuggestionToCooperativeWorkConverter (Geometry)
+     */
+    @Test
+    public void testChangeDescriptionCreationGeometry()
+    {
+        final var line = this.rule.getAtlas().line(1000000L);
+        final var linePoints = Iterables.asList(line.asPolyLine());
+        Collections.reverse(linePoints);
+        final var task = createTaskSkeleton(linePoints.get(0));
+        task.setCooperativeWork(Collections.singleton(FeatureChange.add(
+                (AtlasEntity) CompleteLine.shallowFrom(line).withGeometry(linePoints),
+                line.getAtlas(), FeatureChange.Options.OSC_IF_POSSIBLE)));
+        final var taskJson = task.generateTask(1);
+        final var cooperativeWork = taskJson.getAsJsonObject("geometries")
+                .getAsJsonObject("cooperativeWork");
+        assertEquals(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?><osmChange generator=\"atlas ChangeDescription v0.0.1\" version=\"0.6\"><modify><way action=\"modify\" id=\"1\" version=\"1\" visible=\"true\"><nd ref=\"2\"/><nd ref=\"1\"/></way></modify></osmChange>",
+                new String(Base64.getDecoder().decode(cooperativeWork.getAsJsonObject("file")
+                        .getAsJsonPrimitive("content").getAsString())));
+        assertEquals(2, cooperativeWork.getAsJsonObject("meta").get("type").getAsByte());
+    }
+
+    @Test
+    public void testChangeDescriptionCreationTag()
+    {
+        final var line = this.rule.getAtlas().line(1000000L);
+        final var linePoints = Iterables.asList(line.asPolyLine());
+        Collections.reverse(linePoints);
+        final var task = createTaskSkeleton(linePoints.get(0));
+        task.setCooperativeWork(Collections.singleton(
+                FeatureChange.add(CompleteLine.shallowFrom(line).withAddedTag("test", "tag"),
+                        line.getAtlas(), FeatureChange.Options.OSC_IF_POSSIBLE)));
+        final var taskJson = task.generateTask(1);
+        final var cooperativeWork = taskJson.getAsJsonObject("geometries")
+                .getAsJsonObject("cooperativeWork");
+        assertEquals(1, cooperativeWork.getAsJsonObject("meta").get("type").getAsByte());
+        final var operations = cooperativeWork.getAsJsonArray("operations");
+        assertEquals(1, operations.size());
+        final var operation = operations.get(0).getAsJsonObject().getAsJsonObject("data")
+                .getAsJsonArray("operations").get(0).getAsJsonObject();
+        assertEquals("setTags", operation.get("operation").getAsString());
+        final var entries = operation.getAsJsonObject("data").entrySet();
+        assertEquals(1, entries.size());
+        assertEquals("test", entries.iterator().next().getKey());
+        assertEquals("tag", entries.iterator().next().getValue().getAsString());
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/TaskTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/TaskTestRule.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.checks.maproulette.data;
+
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Point;
+
+/**
+ * Atlases for {@link TaskTest}
+ *
+ * @author Taylor Smock
+ */
+public class TaskTestRule extends CoreTestRule
+{
+    @TestAtlas(points = { @Point(id = "1000000", coordinates = @Loc(Location.TEST_1_COORDINATES)),
+            @Point(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)) }, lines = @Line(id = "1000000", coordinates = {
+                    @Loc(Location.TEST_1_COORDINATES), @Loc(Location.TEST_2_COORDINATES) }))
+    private Atlas atlas;
+
+    public Atlas getAtlas()
+    {
+        return this.atlas;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/cooperative_challenge/GeometryChangeOperationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/cooperative_challenge/GeometryChangeOperationTest.java
@@ -1,0 +1,117 @@
+package org.openstreetmap.atlas.checks.maproulette.data.cooperative_challenge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
+import org.openstreetmap.atlas.geography.atlas.complete.CompleteEdge;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+
+import com.google.gson.JsonObject;
+
+/**
+ * Test class for {@link GeometryChangeOperationTestRule}
+ *
+ * @author Taylor Smock
+ */
+public class GeometryChangeOperationTest
+{
+    private static final String EDGE_ATLAS_OSC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><osmChange generator=\"atlas ChangeDescription v0.0.1\" version=\"0.6\"><modify><way action=\"modify\" id=\"-1\" version=\"1\" visible=\"true\"><tag k=\"random\" v=\"probably\"/><nd ref=\"2\"/><nd ref=\"1\"/></way></modify></osmChange>";
+    @Rule
+    public final GeometryChangeOperationTestRule setup = new GeometryChangeOperationTestRule();
+
+    /**
+     * Check that an OSC is generated and/or returned properly
+     */
+    @Test
+    public void testCreationOfOscTask()
+    {
+        final CompleteEdge edge = CompleteEdge.from(this.setup.getEdgeAtlas().edge(1L));
+        final List<Location> locationCollection = new ArrayList<>(edge.asPolyLine());
+        Collections.reverse(locationCollection);
+        final FeatureChange featureChange = FeatureChange.add(
+                (AtlasEntity) CompleteEdge.shallowFrom(edge).withGeometry(locationCollection)
+                        .withAddedTag("random", "probably"),
+                this.setup.getEdgeAtlas(), FeatureChange.Options.OSC_IF_POSSIBLE);
+        final GeometryChangeOperation geometryChangeOperation = new GeometryChangeOperation(
+                featureChange.explain()).create();
+        final JsonObject json = geometryChangeOperation.getJson();
+
+        assertEquals("xml", json.get("type").getAsString());
+        assertEquals("osc", json.get("format").getAsString());
+        assertEquals("base64", json.get("encoding").getAsString());
+        // Decode the content so that if it breaks, a human can see what changed between the
+        // expected osm change and the actual osm change
+        assertEquals(EDGE_ATLAS_OSC,
+                new String(Base64.getDecoder().decode(json.get("content").getAsString())));
+    }
+
+    /**
+     * This check ensures that an empty OSC is reflected in the generated json
+     */
+    @Test
+    public void testEmptyOscTask()
+    {
+        final CompleteEdge edge = CompleteEdge.from(this.setup.getEdgeAtlas().edge(1L));
+        final FeatureChange featureChange = FeatureChange.add(
+                CompleteEdge.shallowFrom(edge).withAddedTag("random", "probably"),
+                this.setup.getEdgeAtlas(), FeatureChange.Options.OSC_IF_POSSIBLE);
+        featureChange.withOsc("");
+        final GeometryChangeOperation geometryChangeOperation = new GeometryChangeOperation(
+                featureChange.explain()).create();
+        final JsonObject json = geometryChangeOperation.getJson();
+
+        assertTrue(json.entrySet().isEmpty());
+    }
+
+    /**
+     * This check ensures that there isn't a crash due to a missing "osc" entry
+     */
+    @Test
+    public void testNoCreationOfOscTask()
+    {
+        final CompleteEdge edge = CompleteEdge.from(this.setup.getEdgeAtlas().edge(1L));
+        final FeatureChange featureChange = FeatureChange.add(
+                CompleteEdge.shallowFrom(edge).withAddedTag("random", "probably"),
+                this.setup.getEdgeAtlas(), FeatureChange.Options.OSC_IF_POSSIBLE);
+        final GeometryChangeOperation geometryChangeOperation = new GeometryChangeOperation(
+                featureChange.explain()).create();
+        final JsonObject json = geometryChangeOperation.getJson();
+
+        assertTrue(json.entrySet().isEmpty(), json.toString());
+    }
+
+    /**
+     * This check ensures that there isn't a crash due to a missing "osc" entry
+     */
+    @Test
+    public void testSetOfOscTask()
+    {
+        final CompleteEdge edge = CompleteEdge.from(this.setup.getEdgeAtlas().edge(1L));
+        final FeatureChange featureChange = FeatureChange.add(
+                CompleteEdge.shallowFrom(edge).withAddedTag("random", "probably"),
+                this.setup.getEdgeAtlas(), FeatureChange.Options.OSC_IF_POSSIBLE);
+        featureChange.withOsc(Base64.getEncoder()
+                .encodeToString(EDGE_ATLAS_OSC.getBytes(StandardCharsets.UTF_8)));
+        final GeometryChangeOperation geometryChangeOperation = new GeometryChangeOperation(
+                featureChange.explain()).create();
+        final JsonObject json = geometryChangeOperation.getJson();
+
+        assertEquals("xml", json.get("type").getAsString());
+        assertEquals("osc", json.get("format").getAsString());
+        assertEquals("base64", json.get("encoding").getAsString());
+        // Decode the content so that if it breaks, a human can see what changed between the
+        // expected osm change and the actual osm change
+        assertEquals(EDGE_ATLAS_OSC,
+                new String(Base64.getDecoder().decode(json.get("content").getAsString())));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/cooperative_challenge/GeometryChangeOperationTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/cooperative_challenge/GeometryChangeOperationTestRule.java
@@ -1,0 +1,27 @@
+package org.openstreetmap.atlas.checks.maproulette.data.cooperative_challenge;
+
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Test rule for {@link GeometryChangeOperationTest}
+ *
+ * @author Taylor Smock
+ */
+public class GeometryChangeOperationTestRule extends CoreTestRule
+{
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_1_COORDINATES)),
+            @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)) }, edges = @Edge(id = "1", tags = "highway=residential", coordinates = {
+                    @Loc(Location.TEST_1_COORDINATES), @Loc(Location.TEST_2_COORDINATES) }))
+    private Atlas edgeAtlas;
+
+    public Atlas getEdgeAtlas()
+    {
+        return this.edgeAtlas;
+    }
+}


### PR DESCRIPTION
### Description:

Add fix suggestions for wrong way waterways, when elevation data suggests that it is going in the wrong direction.
This fixes #403 .

~This depends upon https://github.com/osmlab/atlas/pull/729 (without this PR, only \~8 points can actually be changed).~

~This depends upon https://github.com/osmlab/atlas-generator/pull/179 and https://github.com/osmlab/atlas/pull/750 for OSC upload functionality.~

### Potential Impact:

N/A

### Unit Test Approach:

All current unit tests now check to ensure that there is or is not a fix suggestion present. When there is a fix suggestion present, the before/after views are compared, and are expected to be different. Due to the change between the before/after views, it is expected that reversing a collection of points will cause the before/after view collections to be equal.

### Test Results:
MapRoulette testing mostly showcased issues with SRTM data accuracy -- this is not an issue, since (by default), the portion of the check with the fix will not run without higher quality data.
