### PR TITLE
Add externalDataInput switch for Checks and make externalData configurable

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -1247,5 +1247,10 @@
       "difficulty": "NORMAL",
       "defaultPriority": "LOW"
     }
+  },
+  "ElevationUtilities": {
+    "elevation.srtm_extent": 1.0,
+    "elevation.srtm_ext": "hgt.zip",
+    "elevation.path": "elevation"
   }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/base/BaseCheck.java
@@ -50,11 +50,13 @@ public abstract class BaseCheck<T> implements Check, Serializable
     public static final String PARAMETER_FLAG = "flags";
     public static final String PARAMETER_PERMITLIST_COUNTRIES = "countries.permitlist";
     public static final String PARAMETER_PERMITLIST_TAGS = "tags.filter";
+    public static final String PARAMETER_USE_EXTERNAL_DATA = "externalData.enabled";
     private static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
     private static final String PARAMETER_LOCALE_KEY = "locale";
     private static final Logger logger = LoggerFactory.getLogger(BaseCheck.class);
     private static final long serialVersionUID = 4427673331949586822L;
     private final boolean acceptPiers;
+    private final boolean useExternalData;
     private final List<String> denylistCountries;
     private final Challenge challenge;
     private final List<String> countries;
@@ -90,6 +92,9 @@ public abstract class BaseCheck<T> implements Check, Serializable
                 Collections.emptyMap());
         this.locale = this.configurationValue(configuration, PARAMETER_LOCALE_KEY,
                 DEFAULT_LOCALE.getLanguage(), Locale::new);
+        this.useExternalData = this.configurationValue(configuration, PARAMETER_USE_EXTERNAL_DATA,
+                true);
+
         if (challengeMap.isEmpty())
         {
             this.challenge = new Challenge(this.getClass().getSimpleName(), "", "", "",
@@ -464,6 +469,11 @@ public abstract class BaseCheck<T> implements Check, Serializable
     protected final void markAsFlagged(final T identifier)
     {
         this.getFlaggedIdentifiers().add(identifier);
+    }
+
+    protected final boolean useExternalData()
+    {
+        return this.useExternalData;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityCheckSparkJob.java
@@ -139,6 +139,8 @@ public class IntegrityCheckSparkJob extends IntegrityChecksCommandArguments
     {
         final String atlasDirectory = (String) commandMap.get(SparkJob.INPUT);
         final String input = Optional.ofNullable(this.input(commandMap)).orElse(atlasDirectory);
+        final String externalDataInput = Optional
+                .ofNullable((String) commandMap.get(EXTERNAL_DATA_INPUT)).orElse(atlasDirectory);
         final String output = this.output(commandMap);
         final Set<OutputFormats> outputFormats = (Set<OutputFormats>) commandMap
                 .get(OUTPUT_FORMATS);
@@ -169,7 +171,7 @@ public class IntegrityCheckSparkJob extends IntegrityChecksCommandArguments
 
         final Map<String, String> sparkContext = this.configurationMap();
 
-        final ExternalDataFetcher fileFetcher = new ExternalDataFetcher(input,
+        final ExternalDataFetcher fileFetcher = new ExternalDataFetcher(externalDataInput,
                 this.configurationMap());
         final CheckResourceLoader checkLoader = new CheckResourceLoader(checksConfiguration,
                 fileFetcher);

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityChecksCommandArguments.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/IntegrityChecksCommandArguments.java
@@ -94,6 +94,9 @@ public abstract class IntegrityChecksCommandArguments extends SparkJob
     static final Switch<Boolean> PBF_SAVE_INTERMEDIATE_ATLAS = new Switch<>("savePbfAtlas",
             "Saves intermediate atlas files created when processing OSM protobuf data.",
             Boolean::valueOf, Optionality.OPTIONAL, "false");
+    static final Switch<String> EXTERNAL_DATA_INPUT = new Switch<>("externalDataInput",
+            "Path to the root location that is common to all external data",
+            StringConverter.IDENTITY);
     private static final String ATLAS_FILENAME_PATTERN_FORMAT = "^%s_([0-9]+)-([0-9]+)-([0-9]+)";
     private static final Logger logger = LoggerFactory
             .getLogger(IntegrityChecksCommandArguments.class);
@@ -195,6 +198,6 @@ public abstract class IntegrityChecksCommandArguments extends SparkJob
     {
         return super.switches().with(ATLAS_FOLDER, MAP_ROULETTE, COUNTRIES, CONFIGURATION_FILES,
                 CONFIGURATION_JSON, PBF_BOUNDING_BOX, PBF_SAVE_INTERMEDIATE_ATLAS, OUTPUT_FORMATS,
-                CHECK_FILTER, MAX_POOL_MINUTES);
+                CHECK_FILTER, MAX_POOL_MINUTES, EXTERNAL_DATA_INPUT);
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -111,6 +111,8 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
         final Time start = Time.now();
         final String atlasDirectory = (String) commandMap.get(SparkJob.INPUT);
         final String input = Optional.ofNullable(this.input(commandMap)).orElse(atlasDirectory);
+        final String externalDataInput = Optional
+                .ofNullable((String) commandMap.get(EXTERNAL_DATA_INPUT)).orElse(atlasDirectory);
 
         // Gather arguments
         final String output = this.output(commandMap);
@@ -140,7 +142,7 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
         // File loading helpers
         final SparkFileHelper fileHelper = new SparkFileHelper(sparkContext);
         // Get the file fetcher
-        final ExternalDataFetcher fileFetcher = new ExternalDataFetcher(input,
+        final ExternalDataFetcher fileFetcher = new ExternalDataFetcher(externalDataInput,
                 this.configurationMap());
         final CheckResourceLoader checkLoader = new CheckResourceLoader(checksConfiguration,
                 fileFetcher);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/lines/WaterWayCheck.java
@@ -347,7 +347,10 @@ public class WaterWayCheck extends BaseCheck<Long>
         final Atlas atlas = line.getAtlas();
         CheckFlag flag = null;
         flag = this.flagCircularWaterway(flag, line);
-        flag = this.flagIncline(flag, line, first, last);
+        if (this.useExternalData())
+        {
+            flag = this.flagIncline(flag, line, first, last);
+        }
         flag = this.flagNoSink(flag, atlas, line, last);
         flag = this.flagCrossingWays(flag, atlas, line);
         if (flag != null)


### PR DESCRIPTION
### Description:

This makes the framework's external data input path configurable by adding a new Checks switch `externalDataInput`. This input path is fed into the ExternalDataFetcher (currently only used by WaterwayCheck for elevation data). Previously, external data was fetched from the SparkJob input path.

There is also a new configurable, `externalData.enabled`, which lives in BaseCheck and can be used to specify whether externalData should be used on a Check-by-Check basis. So in the configuration, you can decide if you want a certain Check to use externalData. This switch is largely symbolic, as the Check code itself must decide what to do given the switch value.

### Potential Impact:

With an empty `externalDataInput`, we get the same behavior as before. With a user-supplied `externalDataInput`, we are just fetching external data from the user-supplied location

`externalData.enabled` can now turn off WaterWayCheck's external data fetching if desired

### Unit Test Approach:

Tested some local runs with a custom externalDataInput input path and with true/false values for `externalData.enabled` 

### Test Results:

Satisfactory

