### PR TITLE
BuildOriginalOsmGeometry handling reversed edges.

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -631,6 +631,8 @@
     }
   },
   "MalformedRoundaboutCheck" : {
+    "angle.threshold.maximum_degree": 60.0,
+    "min.nodes": 9.0,
     "traffic.countries.left":["AIA", "ATG", "AUS", "BGD", "BHS", "BMU", "BRB", "BRN", "BTN", "BWA",
       "CCK", "COK", "CXR", "CYM", "CYP", "DMA", "FJI", "FLK", "GBR", "GGY", "GRD",
       "GUY", "HKG", "IDN", "IMN", "IND", "IRL", "JAM", "JEY", "JPN", "KEN", "KIR",

--- a/docs/checks/RoadNameGapCheck.md
+++ b/docs/checks/RoadNameGapCheck.md
@@ -14,14 +14,18 @@ i) This check should flag the edges who has NO name tag with below conditions:
          1. TERTIARY_LINK, SECONDARY_LINK, PRIMARY_LINK, TRUNK_LINK, or MOTORWAY_LINK
       c. junction=ROUNDABOUT
    
+   For this case a fix suggestion to add the name tag with the same value as the connected edges is issued.
+   
 ii) This check should flag the edges which has different Name Tag:
     1. Is an Edge
     2. Has the Tag,
         1. highway=TERTIARY, SECONDARY, PRIMARY, TRUNK, or MOTORWAY.
     3. name=* but is not the same as the other Edges it is connected to
     4. Does NOT have the Tag,
-            a. highway=*_LINK
-            b. junction=ROUNDABOUT
+        a. highway=*_LINK
+        b. junction=ROUNDABOUT
+
+For this case a fix suggestion to modify the name tag with the value from the connected edges is issued.  
     
 ### Live Examples
 

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -75,8 +75,7 @@ public final class CommonMethods
             // De-duplicating either Point or Node with same OSM Id
             if (entity.getType().toString().matches("POINT|NODE"))
             {
-                return "PointNode"
-                        .concat(String.valueOf(entity.getOsmIdentifier()));
+                return "PointNode".concat(String.valueOf(entity.getOsmIdentifier()));
             }
             return entity.getType().toString().concat(String.valueOf(entity.getOsmIdentifier()));
         }).distinct().count();

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/CommonMethods.java
@@ -4,12 +4,16 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.PolyLine;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.items.Relation;
 import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
 import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
+import org.openstreetmap.atlas.tags.oneway.OneWayTag;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hold common Methods (should be used in more than one check)
@@ -18,6 +22,8 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
  */
 public final class CommonMethods
 {
+    private static final Logger logger = LoggerFactory.getLogger(CommonMethods.class);
+
     /**
      * Build original (before Atlas sectioning) OSW way geometry from all Main {@link Edge}s
      * sections
@@ -30,11 +36,27 @@ public final class CommonMethods
     {
         // Identify and sort by IDs all sections of original OSM way
         final List<Edge> sortedEdges = new ArrayList<>(new OsmWayWalker(edge).collectEdges());
-        // Build original OSM polyline
-        PolyLine geometry = new PolyLine(sortedEdges.get(0).getRawGeometry());
-        for (int index = 1; index < sortedEdges.size(); index++)
+
+        // Build original OSM polyline.
+        PolyLine geometry = null;
+
+        try
         {
-            geometry = geometry.append(sortedEdges.get(index).asPolyLine());
+            geometry = OneWayTag.isOneWayReversed(edge)
+                    ? new PolyLine(sortedEdges.get(0).getRawGeometry()).reversed()
+                    : new PolyLine(sortedEdges.get(0).getRawGeometry());
+
+            for (int index = 1; index < sortedEdges.size(); index++)
+            {
+                geometry = OneWayTag.isOneWayReversed(edge)
+                        ? geometry.append(sortedEdges.get(index).asPolyLine().reversed())
+                        : geometry.append(sortedEdges.get(index).asPolyLine());
+            }
+        }
+        catch (final CoreException exception)
+        {
+            logger.warn("Unable to build geometry for edge {}({}): {}", edge.getIdentifier(),
+                    edge.getOsmIdentifier(), exception.getMessage());
         }
         return geometry;
     }
@@ -53,7 +75,7 @@ public final class CommonMethods
             // De-duplicating either Point or Node with same OSM Id
             if (entity.getType().toString().matches("POINT|NODE"))
             {
-                return String.valueOf("PointNode")
+                return "PointNode"
                         .concat(String.valueOf(entity.getOsmIdentifier()));
             }
             return entity.getType().toString().concat(String.valueOf(entity.getOsmIdentifier()));

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTest.java
@@ -70,6 +70,17 @@ public class CommonMethodsTest
     }
 
     @Test
+    public void testOriginalWayGeometryReversed()
+    {
+        final String origGeom = "LINESTRING (-71.7194204 18.4360044, -71.6970306 18.4360737, -71.7052283 18.4273807, -71.7194204 18.4360044)";
+        assertEquals(origGeom,
+                CommonMethods
+                        .buildOriginalOsmWayGeometry(
+                                this.setup.getOriginalWayGeometryReversed().edge(12000003))
+                        .toString());
+    }
+
+    @Test
     public void testUnClosedWay()
     {
         assertFalse(CommonMethods.isClosedWay(this.setup.getUnClosedWay().edge(12000002)));

--- a/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/utility/CommonMethodsTestRule.java
@@ -146,6 +146,21 @@ public class CommonMethodsTestRule extends CoreTestRule
                             @Loc(value = ONE) }) })
     private Atlas originalWayGeometry;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1", coordinates = @Loc(value = ONE)),
+                    @Node(id = "2", coordinates = @Loc(value = TWO)),
+                    @Node(id = "3", coordinates = @Loc(value = THREE)) },
+            // edges
+            edges = {
+                    @Edge(id = "12000001", coordinates = { @Loc(value = TWO),
+                            @Loc(value = ONE) }, tags = { "oneway=-1" }),
+                    @Edge(id = "12000002", coordinates = { @Loc(value = THREE),
+                            @Loc(value = TWO) }, tags = { "oneway=-1" }),
+                    @Edge(id = "12000003", coordinates = { @Loc(value = ONE),
+                            @Loc(value = THREE) }, tags = { "oneway=-1" }) })
+    private Atlas originalWayGeometryReversed;
+
     public Atlas getClosedWay()
     {
         return this.closedWay;
@@ -179,6 +194,11 @@ public class CommonMethodsTestRule extends CoreTestRule
     public Atlas getOriginalWayGeometry()
     {
         return this.originalWayGeometry;
+    }
+
+    public Atlas getOriginalWayGeometryReversed()
+    {
+        return this.originalWayGeometryReversed;
     }
 
     public Atlas getUnClosedWay()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -31,7 +31,9 @@ public class MalformedRoundaboutCheckTest
     public void clockwiseRoundaboutLeftDrivingMissingTagTest()
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingMissingTagAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -43,7 +45,9 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(
                 this.setup.counterClockwiseConnectedDoubleRoundaboutRightDrivingAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -54,7 +58,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutBridgeRightDrivingEnclosedTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutBridgeRightDrivingEnclosedAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -70,7 +76,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingEnclosedBridgeTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedBridgeAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -78,7 +86,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingEnclosedPathTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingEnclosedPathAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -87,7 +97,9 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(
                 this.setup.counterClockwiseRoundaboutRightDrivingNonCarNavigableAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -98,7 +110,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingOneWayNoTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingOneWayNoAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -118,7 +132,9 @@ public class MalformedRoundaboutCheckTest
     public void counterClockwiseRoundaboutRightDrivingWrongEdgesTagTest()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingWrongEdgesTagAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -126,10 +142,24 @@ public class MalformedRoundaboutCheckTest
     }
 
     @Test
+    public void testAngleGreaterThanThreshold()
+    {
+        this.verifier.actual(this.setup.angleGreaterThanThreshold(),
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 60.0
+                                + ", \"min.nodes\":" + 1.0 + "}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n2. This roundabout has too sharp of an angle at ((-27.4512972, 153.0120204), (-27.4512764, 153.0121637), (-27.4513581, 153.0121916), (-27.4512564, 153.0120857)), consider adding more nodes or rearranging the roundabout to fix this.",
+                flags.get(0).getInstructions()));
+    }
+
+    @Test
     public void testClockwiseRoundaboutLeftDrivingAtlas()
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -169,7 +199,9 @@ public class MalformedRoundaboutCheckTest
     public void testCounterClockwiseRoundaboutRightDrivingAtlas()
     {
         this.verifier.actual(this.setup.counterClockwiseRoundaboutRightDrivingAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 
@@ -184,7 +216,18 @@ public class MalformedRoundaboutCheckTest
                 "1. This roundabout is going the wrong direction, or has been improperly tagged as a roundabout.",
                 flags.get(0).getInstructions()));
         this.verifier.verify(flag -> verifyFixSuggestions(flag, 1));
+    }
 
+    @Test
+    public void testFewerThanMinOSMNodesRoundaboutAtlas()
+    {
+        this.verifier.actual(this.setup.fewerThanMinOSMNodesRoundaboutAtlas(),
+                new MalformedRoundaboutCheck(ConfigurationResolver
+                        .inlineConfiguration("{\"MalformedRoundaboutCheck\":{\"min.nodes\":" + 9.0
+                                + ", \"angle.threshold.maximum_degree\":" + 179.0 + "}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(
+                "1. This roundabout is malformed.\n2. This roundabout has less than 9 nodes.",
+                flags.get(0).getInstructions()));
     }
 
     @Test
@@ -196,7 +239,6 @@ public class MalformedRoundaboutCheckTest
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
                 flags.get(0).getInstructions()));
-
     }
 
     @Test
@@ -211,7 +253,9 @@ public class MalformedRoundaboutCheckTest
     public void testRoundaboutWithEnclosedNavigableRoad()
     {
         this.verifier.actual(this.setup.enclosedNavigableRoad(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout has car navigable ways inside it.",
@@ -222,7 +266,9 @@ public class MalformedRoundaboutCheckTest
     public void testRoundaboutWithEnclosedNavigableRoadArea()
     {
         this.verifier.actual(this.setup.enclosedNavigableRoadArea(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTest.java
@@ -124,7 +124,9 @@ public class MalformedRoundaboutCheckTest
     {
         this.verifier.actual(
                 this.setup.counterClockwiseRoundaboutRightDrivingOutsideConnectionAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -167,7 +169,9 @@ public class MalformedRoundaboutCheckTest
     public void testClockwiseRoundaboutLeftDrivingConcave()
     {
         this.verifier.actual(this.setup.clockwiseRoundaboutLeftDrivingConcaveAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
@@ -234,7 +238,9 @@ public class MalformedRoundaboutCheckTest
     public void testMultiDirectionalRoundaboutAtlas()
     {
         this.verifier.actual(this.setup.multiDirectionalRoundaboutAtlas(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(
                 "1. This roundabout is malformed.\n"
                         + "2. This roundabout does not form a single, one-way, complete, car navigable route.",
@@ -245,7 +251,9 @@ public class MalformedRoundaboutCheckTest
     public void testRoundaboutWithEnclosedMultiLayerNavigableRoad()
     {
         this.verifier.actual(this.setup.enclosedMultiLayerNavigableRoad(),
-                new MalformedRoundaboutCheck(ConfigurationResolver.emptyConfiguration()));
+                new MalformedRoundaboutCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"MalformedRoundaboutCheck\":{\"angle.threshold.maximum_degree\":" + 179.0
+                                + ",\"min.nodes\":" + 0.0 + "}}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/MalformedRoundaboutCheckTestRule.java
@@ -28,6 +28,30 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
     private static final String COUNTER_CLOCKWISE_4 = "38.90588716371307,-77.03230261802673";
     private static final String COUNTER_CLOCKWISE_5 = "38.90551980892527,-77.03236699104309";
 
+    private static final String MIN_NODE_1 = "-27.4514156, 153.0121326";
+    private static final String MIN_NODE_2 = "-27.4514168, 153.0120745";
+    private static final String MIN_NODE_3 = "-27.4513729, 153.0120172";
+    private static final String MIN_NODE_4 = "-27.4512972, 153.0120204";
+    private static final String MIN_NODE_5 = "-27.4512764, 153.0121637";
+    private static final String MIN_NODE_6 = "-27.4513581, 153.0121916";
+    private static final String MIN_NODE_7 = "-27.4512564, 153.0120857";
+
+    // Contain angle greater than threshold
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = MIN_NODE_1)),
+            @Node(coordinates = @Loc(value = MIN_NODE_2)),
+            @Node(coordinates = @Loc(value = MIN_NODE_3)),
+            @Node(coordinates = @Loc(value = MIN_NODE_4)),
+            @Node(coordinates = @Loc(value = MIN_NODE_5)),
+            @Node(coordinates = @Loc(value = MIN_NODE_6)),
+            @Node(coordinates = @Loc(value = MIN_NODE_7)), }, edges = {
+                    @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
+                            @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
+                            @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
+                            @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
+                            @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
+                                    "highway=primary", "iso_country_code=USA" }) })
+    private Atlas angleGreaterThanThresholdAtlas;
+
     // Clockwise roundabout, left driving country
     @TestAtlas(
             // nodes
@@ -135,6 +159,22 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
                             @Loc(value = COUNTER_CLOCKWISE_1) }, tags = { "junction=roundabout",
                                     "iso_country_code=USA", "highway=primary" }) })
     private Atlas counterClockwiseRoundaboutRightDrivingAtlas;
+
+    // Fewer than 9 nodes
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = MIN_NODE_1)),
+            @Node(coordinates = @Loc(value = MIN_NODE_2)),
+            @Node(coordinates = @Loc(value = MIN_NODE_3)),
+            @Node(coordinates = @Loc(value = MIN_NODE_4)),
+            @Node(coordinates = @Loc(value = MIN_NODE_5)),
+            @Node(coordinates = @Loc(value = MIN_NODE_6)),
+            @Node(coordinates = @Loc(value = MIN_NODE_7)), }, edges = {
+                    @Edge(id = "1234", coordinates = { @Loc(value = MIN_NODE_1),
+                            @Loc(value = MIN_NODE_2), @Loc(value = MIN_NODE_3),
+                            @Loc(value = MIN_NODE_4), @Loc(value = MIN_NODE_5),
+                            @Loc(value = MIN_NODE_6), @Loc(value = MIN_NODE_7),
+                            @Loc(value = MIN_NODE_1), }, tags = { "junction=roundabout",
+                                    "highway=primary", "iso_country_code=USA" }) })
+    private Atlas fewerThanMinOSMNodesRoundaboutAtlas;
 
     // Multi-directional Atlas
     @TestAtlas(
@@ -642,6 +682,11 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
                                     "iso_country_code=SGP", "highway=primary" }) })
     private Atlas syntheticNode;
 
+    public Atlas angleGreaterThanThreshold()
+    {
+        return this.angleGreaterThanThresholdAtlas;
+    }
+
     public Atlas clockwiseRoundaboutLeftDrivingAtlas()
     {
         return this.clockwiseRoundaboutLeftDrivingAtlas;
@@ -730,6 +775,11 @@ public class MalformedRoundaboutCheckTestRule extends CoreTestRule
     public Atlas enclosedNavigableRoadArea()
     {
         return this.enclosedNavigableRoadArea;
+    }
+
+    public Atlas fewerThanMinOSMNodesRoundaboutAtlas()
+    {
+        return this.fewerThanMinOSMNodesRoundaboutAtlas;
     }
 
     public Atlas multiDirectionalRoundaboutAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameGapCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameGapCheckTest.java
@@ -5,6 +5,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.tags.names.AlternativeNameTag;
+import org.openstreetmap.atlas.tags.names.BridgeNameTag;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
@@ -24,11 +26,47 @@ public class RoadNameGapCheckTest
             "{\"RoadNameGapCheck\":{\"valid.highway.tag\":[\"primary\",\"tertiary\",\"trunk\",\"motorway\",\"secondary\"]}}");
 
     @Test
+    public void testForBridgeEdgeWithDifferentNameTag()
+    {
+        this.verifier.actual(this.setup.getBridgeEdge(),
+                new RoadNameGapCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags ->
+        {
+            Assert.assertEquals(1, flags.size());
+            Assert.assertEquals(1, flags.get(0).getFixSuggestions().size());
+            flags.get(0).getFixSuggestions()
+                    .forEach(s -> Assert.assertTrue(s.getTag(BridgeNameTag.KEY).isPresent()));
+        });
+    }
+
+    @Test
+    public void testForEdgeWithAltName()
+    {
+        this.verifier.actual(this.setup.getEdgeWithAltName(),
+                new RoadNameGapCheck(this.inlineConfiguration));
+        this.verifier.globallyVerify(flags ->
+        {
+            Assert.assertEquals(1, flags.size());
+            Assert.assertEquals(1, flags.get(0).getFixSuggestions().size());
+            flags.get(0).getFixSuggestions()
+                    .forEach(s -> Assert.assertTrue(s.getTag(AlternativeNameTag.KEY).isPresent()));
+            flags.get(0).getFixSuggestions().forEach(
+                    s -> Assert.assertTrue(s.getTag(AlternativeNameTag.KEY + "_1").isPresent()));
+        });
+    }
+
+    @Test
     public void testForEdgeWithDifferentNameTag()
     {
         this.verifier.actual(this.setup.getEdgeWithDifferentNameTag(),
                 new RoadNameGapCheck(this.inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags ->
+        {
+            Assert.assertEquals(1, flags.size());
+            Assert.assertEquals(1, flags.get(0).getFixSuggestions().size());
+            flags.get(0).getFixSuggestions()
+                    .forEach(s -> Assert.assertTrue(s.getTag(AlternativeNameTag.KEY).isPresent()));
+        });
     }
 
     @Test
@@ -44,7 +82,11 @@ public class RoadNameGapCheckTest
     {
         this.verifier.actual(this.setup.getEdgeWithNoNameTag(),
                 new RoadNameGapCheck(this.inlineConfiguration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.globallyVerify(flags ->
+        {
+            Assert.assertEquals(1, flags.size());
+            Assert.assertEquals(1, flags.get(0).getFixSuggestions().size());
+        });
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameGapCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/RoadNameGapCheckTestRule.java
@@ -25,6 +25,52 @@ public class RoadNameGapCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1), id = "0"),
+                    @Node(coordinates = @Loc(value = TEST_2), id = "1"),
+                    @Node(coordinates = @Loc(value = TEST_3), id = "2"),
+                    @Node(coordinates = @Loc(value = TEST_4), id = "3"),
+                    @Node(coordinates = @Loc(value = TEST_5), id = "4"),
+                    @Node(coordinates = @Loc(value = TEST_6), id = "5"),
+                    @Node(coordinates = @Loc(value = TEST_7), id = "6"),
+                    @Node(coordinates = @Loc(value = TEST_8), id = "7") },
+            // edges
+            edges = {
+                    @Edge(id = "1001000000", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6) }, tags = { "highway=primary",
+                                    "name=Tsing Long Highway" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_6),
+                            @Loc(value = TEST_7) }, tags = { "highway=primary", "name=failingName",
+                                    "bridge=yes" }),
+                    @Edge(id = "1003000002", coordinates = { @Loc(value = TEST_7),
+                            @Loc(value = TEST_8) }, tags = { "highway=primary",
+                                    "name=Tsing Long Highway" }) })
+    private Atlas bridgeEdge;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1), id = "0"),
+                    @Node(coordinates = @Loc(value = TEST_2), id = "1"),
+                    @Node(coordinates = @Loc(value = TEST_3), id = "2"),
+                    @Node(coordinates = @Loc(value = TEST_4), id = "3"),
+                    @Node(coordinates = @Loc(value = TEST_5), id = "4"),
+                    @Node(coordinates = @Loc(value = TEST_6), id = "5"),
+                    @Node(coordinates = @Loc(value = TEST_7), id = "6"),
+                    @Node(coordinates = @Loc(value = TEST_8), id = "7") },
+            // edges
+            edges = {
+                    @Edge(id = "1001000000", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6) }, tags = { "highway=primary",
+                                    "name=Tsing Long Highway" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_6),
+                            @Loc(value = TEST_7) }, tags = { "highway=primary", "name=failingName",
+                                    "alt_name=firstFailure" }),
+                    @Edge(id = "1003000002", coordinates = { @Loc(value = TEST_7),
+                            @Loc(value = TEST_8) }, tags = { "highway=primary",
+                                    "name=Tsing Long Highway" }) })
+    private Atlas edgeWithAltName;
+
+    @TestAtlas(
+            // nodes
             nodes = { @Node(coordinates = @TestAtlas.Loc(value = TEST_3), id = "2"),
                     @Node(coordinates = @TestAtlas.Loc(value = TEST_4), id = "3") },
             // edges
@@ -115,6 +161,16 @@ public class RoadNameGapCheckTestRule extends CoreTestRule
                             @Loc(value = TEST_8) }, tags = { "highway=primary",
                                     "name=Tsing Long Highway" }) })
     private Atlas edgeWithNoNameTag;
+
+    public Atlas getBridgeEdge()
+    {
+        return this.bridgeEdge;
+    }
+
+    public Atlas getEdgeWithAltName()
+    {
+        return this.edgeWithAltName;
+    }
 
     public Atlas getEdgeWithDifferentNameTag()
     {


### PR DESCRIPTION
### Description:

Handling reversed edges in CommonMethods.buildOriginalOsmWayGeometry. Please refer: https://github.com/osmlab/atlas-checks/issues/483

### Potential Impact:

Supporting Reversed Edges. 

### Unit Test Approach:

Create unit test for Reversed edge. 

### Test Results:

Passed