### PR TITLE
ShardedIntegrityChecksSparkJob Deduplication Revamp

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -2,8 +2,15 @@ package org.openstreetmap.atlas.checks.distributed;
 
 import static org.openstreetmap.atlas.checks.distributed.IntegrityCheckSparkJob.METRICS_FILENAME;
 
+import java.io.BufferedWriter;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -14,9 +21,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.FlatMapFunction2;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
 import org.apache.spark.api.java.function.PairFunction;
 import org.apache.spark.api.java.function.VoidFunction;
 import org.apache.spark.broadcast.Broadcast;
@@ -31,13 +45,17 @@ import org.openstreetmap.atlas.checks.event.CheckFlagFileProcessor;
 import org.openstreetmap.atlas.checks.event.CheckFlagGeoJsonProcessor;
 import org.openstreetmap.atlas.checks.event.CheckFlagTippecanoeProcessor;
 import org.openstreetmap.atlas.checks.event.MetricFileGenerator;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
 import org.openstreetmap.atlas.checks.utility.UniqueCheckFlagContainer;
+import org.openstreetmap.atlas.checks.vectortiles.TippecanoeCheckSettings;
 import org.openstreetmap.atlas.event.EventService;
 import org.openstreetmap.atlas.event.Processor;
 import org.openstreetmap.atlas.event.ShutdownEvent;
 import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.generator.sharding.AtlasSharding;
 import org.openstreetmap.atlas.generator.tools.caching.HadoopAtlasFileCache;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemCreator;
+import org.openstreetmap.atlas.generator.tools.filesystem.FileSystemHelper;
 import org.openstreetmap.atlas.generator.tools.spark.SparkJob;
 import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
@@ -47,6 +65,9 @@ import org.openstreetmap.atlas.geography.atlas.dynamic.policy.DynamicAtlasPolicy
 import org.openstreetmap.atlas.geography.atlas.multi.MultiAtlas;
 import org.openstreetmap.atlas.geography.sharding.Shard;
 import org.openstreetmap.atlas.geography.sharding.Sharding;
+import org.openstreetmap.atlas.streaming.compression.Compressor;
+import org.openstreetmap.atlas.streaming.resource.OutputStreamWritableResource;
+import org.openstreetmap.atlas.streaming.resource.WritableResource;
 import org.openstreetmap.atlas.utilities.collections.StringList;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.configuration.MergedConfiguration;
@@ -55,6 +76,7 @@ import org.openstreetmap.atlas.utilities.conversion.StringConverter;
 import org.openstreetmap.atlas.utilities.filters.AtlasEntityPolygonsFilter;
 import org.openstreetmap.atlas.utilities.maps.MultiMap;
 import org.openstreetmap.atlas.utilities.runtime.CommandMap;
+import org.openstreetmap.atlas.utilities.runtime.Retry;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
 import org.openstreetmap.atlas.utilities.scalars.Duration;
 import org.openstreetmap.atlas.utilities.threads.Pool;
@@ -226,17 +248,12 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
                     this.getContext().setLocalProperty("callSite.short", String
                             .format("Running checks on %s", tasksForCountry.get(0).getCountry()));
 
-                    final JavaRDD<UniqueCheckFlagContainer> flagContainers = this.getContext()
+                    this.getContext()
                             .parallelize(tasksForCountry, tasksForCountry.size())
                             .flatMap(this.produceFlags(input, output, this.configurationMap(),
                                     fileHelper, shardingBroadcast, distanceToLoadShards,
                                     (Boolean) commandMap.get(MULTI_ATLAS)))
-                            .distinct();
-                    flagContainers.persist(StorageLevel.MEMORY_AND_DISK());
-                    final long count = flagContainers.count();
-                    flagContainers.foreachPartition(i -> logger
-                            .error(String.format("Distinct flags in %s: %s", country, count)));
-                    flagContainers.map(UniqueCheckFlagContainer::getEvent).foreachPartition(
+                            .distinct().map(UniqueCheckFlagContainer::getEvent).foreachPartition(
                             this.processFlags(output, fileHelper, outputFormats, country));
                 });
             }
@@ -319,6 +336,9 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
             eventService.complete();
         };
     }
+
+    private static final String LOG_EXTENSION = new LogFilePathFilter(true).getExtension();
+    private static final String GEOJSON_EXTENSION = new GeoJsonPathFilter(true).getExtension();
 
     /**
      * {@link PairFunction} to run each {@link ShardedCheckFlagsTask} through to produce

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -65,7 +65,6 @@ import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.Subscribe;
 
 import scala.Serializable;
-import scala.Tuple2;
 
 /**
  * A spark job for generating integrity checks in a sharded fashion. This allows for a lower local
@@ -276,8 +275,9 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
      * @param outputFormats
      *            {@link Set} of
      *            {@link org.openstreetmap.atlas.checks.distributed.IntegrityChecksCommandArguments.OutputFormats}
-     * @return {@link VoidFunction} that takes a {@link Tuple2} of a {@link String} country code and
-     *         a {@link UniqueCheckFlagContainer}
+     * @param country
+     *            {@link String} ISO code for the country being processed
+     * @return {@link VoidFunction} that takes an {@link Iterator} of {@link CheckFlagEvent}s
      */
     @SuppressWarnings("unchecked")
     private VoidFunction<Iterator<CheckFlagEvent>> processFlags(final String output,
@@ -331,8 +331,8 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
      *            {@link Distance} to expand the shard group
      * @param multiAtlas
      *            boolean whether to use a multi or dynamic Atlas
-     * @return {@link PairFunction} that takes {@link ShardedCheckFlagsTask} and returns a
-     *         {@link Tuple2} of a {@link String} country code and {@link UniqueCheckFlagContainer}
+     * @return {@link FlatMapFunction} that takes {@link ShardedCheckFlagsTask} and returns a
+     *         {@link Iterator} of {@link UniqueCheckFlagContainer}s
      */
     @SuppressWarnings("unchecked")
     private FlatMapFunction<ShardedCheckFlagsTask, UniqueCheckFlagContainer> produceFlags(

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -233,7 +233,7 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
                                     (Boolean) commandMap.get(MULTI_ATLAS)))
                             .distinct();
                     flagContainers.persist(StorageLevel.MEMORY_AND_DISK());
-                    logger.info(String.format("Distinct flags in %s: %s", country,
+                    logger.error(String.format("Distinct flags in %s: %s", country,
                             flagContainers.count()));
                     flagContainers.map(UniqueCheckFlagContainer::getEvent).foreachPartition(
                             this.processFlags(output, fileHelper, outputFormats, country));

--- a/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/distributed/ShardedIntegrityChecksSparkJob.java
@@ -233,8 +233,9 @@ public class ShardedIntegrityChecksSparkJob extends IntegrityChecksCommandArgume
                                     (Boolean) commandMap.get(MULTI_ATLAS)))
                             .distinct();
                     flagContainers.persist(StorageLevel.MEMORY_AND_DISK());
-                    logger.error(String.format("Distinct flags in %s: %s", country,
-                            flagContainers.count()));
+                    final long count = flagContainers.count();
+                    flagContainers.foreachPartition(i -> logger
+                            .error(String.format("Distinct flags in %s: %s", country, count)));
                     flagContainers.map(UniqueCheckFlagContainer::getEvent).foreachPartition(
                             this.processFlags(output, fileHelper, outputFormats, country));
                 });

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagGeoJsonProcessor.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.spark.TaskContext;
 import org.openstreetmap.atlas.checks.constants.CommonConstants;
 import org.openstreetmap.atlas.checks.distributed.GeoJsonPathFilter;
 import org.openstreetmap.atlas.event.Processor;
@@ -178,7 +179,8 @@ public final class CheckFlagGeoJsonProcessor implements Processor<CheckFlagEvent
 
     protected String getFilename(final String challenge, final int size)
     {
-        return String.format("%s-%s-%s%s", challenge, new Date().getTime(), size,
+        return String.format("%s-%sP%s-%s%s", challenge, new Date().getTime(),
+                TaskContext.getPartitionId(), size,
                 new GeoJsonPathFilter(this.compressOutput).getExtension());
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagTippecanoeProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagTippecanoeProcessor.java
@@ -2,6 +2,7 @@ package org.openstreetmap.atlas.checks.event;
 
 import java.util.Date;
 
+import org.apache.spark.TaskContext;
 import org.openstreetmap.atlas.checks.distributed.GeoJsonPathFilter;
 import org.openstreetmap.atlas.checks.vectortiles.TippecanoeCheckSettings;
 import org.openstreetmap.atlas.generator.tools.spark.utilities.SparkFileHelper;
@@ -64,7 +65,7 @@ public class CheckFlagTippecanoeProcessor extends FileProcessor<CheckFlagEvent>
     @Override
     protected String getFilename()
     {
-        return String.format("%s-%s%s", new Date().getTime(), getCount(),
+        return String.format("%sP%s-%s%s", new Date().getTime(), TaskContext.getPartitionId(), getCount(),
                 new GeoJsonPathFilter(doesCompressOutput()).getExtension());
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagTippecanoeProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/CheckFlagTippecanoeProcessor.java
@@ -65,7 +65,7 @@ public class CheckFlagTippecanoeProcessor extends FileProcessor<CheckFlagEvent>
     @Override
     protected String getFilename()
     {
-        return String.format("%sP%s-%s%s", new Date().getTime(), TaskContext.getPartitionId(), getCount(),
-                new GeoJsonPathFilter(doesCompressOutput()).getExtension());
+        return String.format("%sP%s-%s%s", new Date().getTime(), TaskContext.getPartitionId(),
+                getCount(), new GeoJsonPathFilter(doesCompressOutput()).getExtension());
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/event/FileProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/FileProcessor.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.spark.TaskContext;
 import org.openstreetmap.atlas.checks.distributed.LogFilePathFilter;
 import org.openstreetmap.atlas.event.Event;
 import org.openstreetmap.atlas.event.Processor;
@@ -159,7 +160,7 @@ public abstract class FileProcessor<T extends Event> implements Processor<T>
      */
     protected String getFilename()
     {
-        return String.format("%s-%s%s", new Date().getTime(), this.getCount(),
+        return String.format("%sP%s-%s%s", new Date().getTime(), TaskContext.getPartitionId(), this.getCount(),
                 new LogFilePathFilter(this.compressOutput).getExtension());
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/event/FileProcessor.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/event/FileProcessor.java
@@ -160,8 +160,8 @@ public abstract class FileProcessor<T extends Event> implements Processor<T>
      */
     protected String getFilename()
     {
-        return String.format("%sP%s-%s%s", new Date().getTime(), TaskContext.getPartitionId(), this.getCount(),
-                new LogFilePathFilter(this.compressOutput).getExtension());
+        return String.format("%sP%s-%s%s", new Date().getTime(), TaskContext.getPartitionId(),
+                this.getCount(), new LogFilePathFilter(this.compressOutput).getExtension());
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/utility/UniqueCheckFlagContainer.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/utility/UniqueCheckFlagContainer.java
@@ -1,17 +1,14 @@
 package org.openstreetmap.atlas.checks.utility;
 
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 import org.openstreetmap.atlas.checks.event.CheckFlagEvent;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
 
 /**
- * A container that will deduplicate check flags based on source and unique IDs
+ * A container used to deduplicate check flags based on checkName and unique IDs
  *
  * @author jklamer
  * @author bbreithaupt
@@ -19,91 +16,75 @@ import org.openstreetmap.atlas.checks.flag.CheckFlag;
 public class UniqueCheckFlagContainer implements Serializable
 {
 
-    private final ConcurrentHashMap<String, ConcurrentHashMap<Set<String>, CheckFlag>> uniqueFlags;
+    private String checkName;
+    private Set<String> uniqueIdentifiers;
+    private CheckFlag checkFlag;
 
     /**
-     * Combines to containers. This deduplicates {@link CheckFlag}s by overwiting ones with matching
-     * sources and IDs.
-     *
-     * @param container1
-     *            {@link UniqueCheckFlagContainer}
-     * @param container2
-     *            {@link UniqueCheckFlagContainer}
-     * @return merged {@link UniqueCheckFlagContainer}
+     * @param checkFlagEvent
+     *            {@link CheckFlagEvent}
      */
-    public static UniqueCheckFlagContainer combine(final UniqueCheckFlagContainer container1,
-            final UniqueCheckFlagContainer container2)
+    public UniqueCheckFlagContainer(final CheckFlagEvent checkFlagEvent)
     {
-        container2.uniqueFlags.entrySet()
-                .forEach(entry -> container1.addAll(entry.getKey(), entry.getValue().values()));
-        return container1;
-    }
-
-    public UniqueCheckFlagContainer()
-    {
-        this.uniqueFlags = new ConcurrentHashMap<>();
-    }
-
-    @SuppressWarnings("s1144")
-    // Ignore unused constructor warning, this is used for deserialization
-    private UniqueCheckFlagContainer(
-            final ConcurrentHashMap<String, ConcurrentHashMap<Set<String>, CheckFlag>> flags)
-    {
-        this.uniqueFlags = flags;
+        this(checkFlagEvent.getCheckName(), checkFlagEvent.getCheckFlag().getUniqueIdentifiers(),
+                checkFlagEvent.getCheckFlag().makeComplete());
     }
 
     /**
-     * Add a {@link CheckFlag} to the container based on its source.
-     *
-     * @param flagSource
-     *            {@link String} source (check that generated the flag)
-     * @param flag
+     * @param checkName
+     *            {@link String} check name
+     * @param uniqueIdentifiers
+     *            {@link Set} of {@link String}s from {@link CheckFlag#getUniqueIdentifiers()}
+     * @param checkFlag
      *            {@link CheckFlag}
      */
-    public void add(final String flagSource, final CheckFlag flag)
+    public UniqueCheckFlagContainer(final String checkName, final Set<String> uniqueIdentifiers,
+            final CheckFlag checkFlag)
     {
-        this.uniqueFlags.putIfAbsent(flagSource, new ConcurrentHashMap<>());
-        final Set<String> uniqueObjectIdentifiers = flag.getUniqueIdentifiers();
-        this.uniqueFlags.get(flagSource)
-                .putIfAbsent(uniqueObjectIdentifiers.isEmpty()
-                        ? Collections.singleton(flag.getIdentifier())
-                        : uniqueObjectIdentifiers, flag);
+        this.checkName = checkName;
+        this.uniqueIdentifiers = uniqueIdentifiers;
+        this.checkFlag = checkFlag.makeComplete();
     }
 
-    /**
-     * Batch add {@link CheckFlag} from a single source.
-     *
-     * @param flagSource
-     *            {@link String} source (check that generated the flags)
-     * @param flags
-     *            {@link Iterable} of {@link CheckFlag}s
-     */
-    public void addAll(final String flagSource, final Iterable<CheckFlag> flags)
+    @Override
+    public boolean equals(final Object other)
     {
-        flags.forEach(flag -> this.add(flagSource, flag));
-
+        if (this == other)
+        {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass())
+        {
+            return false;
+        }
+        final UniqueCheckFlagContainer that = (UniqueCheckFlagContainer) other;
+        return Objects.equals(this.checkName, that.checkName)
+                && Objects.equals(this.uniqueIdentifiers, that.uniqueIdentifiers);
     }
 
-    /**
-     * Convert the {@link CheckFlag}s into a {@link Stream} of {@link CheckFlagEvent}s.
-     *
-     * @return a {@link Stream} of {@link CheckFlagEvent}s
-     */
-    public Stream<CheckFlagEvent> reconstructEvents()
+    public CheckFlag getCheckFlag()
     {
-        return this.uniqueFlags.keySet().stream()
-                .flatMap(checkName -> this.uniqueFlags.get(checkName).values().stream()
-                        .map(checkFlag -> new CheckFlagEvent(checkName, checkFlag)));
+        return this.checkFlag;
     }
 
-    /**
-     * Get the contents of the container as a stream.
-     *
-     * @return a {@link Stream} of {@link CheckFlag}s
-     */
-    public Stream<CheckFlag> stream()
+    public String getCheckName()
     {
-        return this.uniqueFlags.values().stream().map(ConcurrentHashMap::values)
-                .flatMap(Collection::stream);
+        return this.checkName;
+    }
+
+    public CheckFlagEvent getEvent()
+    {
+        return new CheckFlagEvent(this.checkName, this.checkFlag);
+    }
+
+    public Set<String> getUniqueIdentifiers()
+    {
+        return this.uniqueIdentifiers;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(this.checkName, this.uniqueIdentifiers);
     }
 }


### PR DESCRIPTION
### Description:

This changes the way flag deduplication is done in the ShardedIntegrityChecksSparkJob to make it more distributable. 

Currently deduplicaiton is done using a reduce function to combine UniqueCheckFlagContainers. This results in all the flags for a country ending up on a single executor and thread.

This new system rework the UniqueCheckFlagContainer to contain only a single CheckFlag instead of many, and gives it a custom equals method that only compares the check name and unique identifiers of the flag. This allows for the use of sparks built in distinct method to remove duplicate containers in a distributed manor. By distributing this, and the following output step, each executor can be assigned less memory, as the maximum amount of data that any executor may need to store is drastically lowered. 

In making the deduplication step more distributed the final output step had to become more distributed as well, in order to maintain the distribution. This has resulted in minor changes to the naming of the output files to allow for multiple simultaneous writes to occur. Appended to the end of each time stamp in the flag, geojson, and tippecanoe outputs there is a `P` followed by a partition number. The one other result of the output distribution is that slightly more output files are created. This is due to each spark partition creating outputs independently, so the 2500 flag per file cap is reached less often. 

### Potential Impact:

There is no known impact. However anything that uses the UniqueCheckFlagContainer or the timestamp in the output file names will be impacted.

### Unit Test Approach:

Rewrote the UniqueCheckFlagContainer unit tests to reflect the new function.

### Test Results:

Local test runs were performed on CYP, and all output types were verified to be identical in content to runs with the old deduplication system. 
2 Large scale tests were performed. One with most countries, but excluding high data density countries like GRB, FRA, DEU, USA, and CAN. The other was a full world run. Flags from these runs were verified to be identical to the old system, excluding a few differences in checks with known nondeterministic behavior. The smaller run required only 8gb or memory per executor to run, down from 48gb (200 executors with 8 threads each). The world run required 24gb to run effectively, down from 64gb+ to run at all. 

