### PR TITLE
[New Check] SimilarTagValueCheck

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -960,6 +960,22 @@
     }
   },
   "SimilarTagValueCheck": {
+    "filter": {
+      "commonSimilars": [
+        ["american", "mexican"], ["cafe", "cake"], ["male", "female"], ["woman", "man"],
+        ["women", "men"], ["male_toilet", "female_toilet"], ["radiology", "cardiology"],
+        ["baseball", "basketball"], ["bowls", "boules"], ["padel", "paddel"], ["formal", "informal"],
+        ["hotel", "hostel"], ["hump", "bump"], ["seed", "feed"]
+      ],
+      "tags": [
+        "asset_ref", "collection_times", "except", "is_in", "junction:ref", "maxspeed:conditional",
+        "old_name", "old_ref", "opening_hours", "ref", "restriction_hours", "route_ref", "supervised",
+        "source_ref", "target", "telescope"
+      ],
+      "tagsWithSubCategories": [
+        "addr", "alt_name", "destination", "name", "seamark", "turn"
+      ]
+    },
     "similarity.threshold": {
       "min": 0.0,
       "max": 1.0

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -959,6 +959,19 @@
       "tags":"highway"
     }
   },
+  "SimilarTagValueCheck": {
+    "similarity.threshold": {
+      "min": 0.0,
+      "max": 1.0
+    },
+    "value.length.min": 4.0,
+    "challenge": {
+      "description": "Tasks identify duplicate/similar values in tags.",
+      "blurb": "Duplicate/Similar tag values.",
+      "instruction": "Determine if the duplicate/similar value is necessary or can be removed.",
+      "difficulty": "EASY"
+    }
+  },
   "SingleSegmentMotorwayCheck": {
     "challenge": {
       "description": "Tasks that identify ways tagged with highway=motorway that are not connected to any ways tagged the same.",

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -86,6 +86,7 @@ This document is a list of tables with a description and link to documentation f
 | [MixedCaseNameCheck](checks/mixedCaseNameCheck.md) | The purpose of this check is to identify names that contain invalid mixed cases so that they can be edited to be the standard format. |
 | [RoadNameGapCheck](checks/RoadNameGapCheck.md) | The purpose of this check is to identify edge connected between two edges whose name tag is same. Flag the edge if the edge has a name tag different to name tag of edges connected to it or if there is no name tag itself.
 | [RoadNameSpellingConsistencyCheck](checks/RoadNameSpellingConsistencyCheck.md) | The purpose of this check is to identify road segments that have a name Tag with a different spelling from that of other segments of the same road. This check is primarily meant to catch small errors in spelling, such as a missing letter, letter accent mixups, or capitalization errors. |
+| [SimilarTagValueCheck](checks/SimilarTagValueCheck.md) | The purpose of this check is to identify tags whose values are either duplicates or similar enough to warrant someone to look at them. |
 | ShortNameCheck | The short name check will validate that any and all names contain at least 2 letters in the name. |
 | [StreetNameIntegersOnlyCheck](checks/streetNameIntegersOnlyCheck.md) | The purpose of this check is to identify streets whose names contain integers only. |
 | [TollValidationCheck](checks/tollValidationCheck) | The purpose of this check is to identify ways that need to have their toll tags investigated/added/removed.

--- a/docs/checks/similarTagValueCheck.md
+++ b/docs/checks/similarTagValueCheck.md
@@ -6,7 +6,11 @@ The purpose of this check is to identify tags whose values are either duplicates
 enough to warrant someone to look at them.
 
 #### Live Examples
+Similar tag values
+1. The node [5142510561](https://www.openstreetmap.org/way/5142510561) has the similar values: "crayfish" and "Crayfish"
 
+Duplicate tag values
+1. The way [173171120](https://www.openstreetmap.org/way/173171120) has multiple duplicate values in the "source" tag
 
 #### Code Review
 

--- a/docs/checks/similarTagValueCheck.md
+++ b/docs/checks/similarTagValueCheck.md
@@ -5,6 +5,17 @@
 The purpose of this check is to identify tags whose values are either duplicates or similar
 enough to warrant someone to look at them.
 
+Configurables: 
+* "value.length.min": Minimum length an individual value must be to be considered for inspection, value.length >= min. 
+* "similarity.threshold.min": Minimum edit distance between two values to be added to the flag where a value of 0 is 
+   used to include duplicates, value >= min.
+* "similarity.threshold.max": Maximum edit distance between two values to be added to the flag, value <= max.
+* "filter.commonSimilars": values that can commonly be found together validly on a tag that are similar but with no 
+   action needed to be taken.
+* "filter.tags": tags that commonly have values that are duplicates/similars that are valid.
+* "filter.tagsWithSubCategories": tags that contain one or many sub-categories that commonly have valid 
+   duplicate/similar values.
+
 #### Live Examples
 Similar tag values
 1. The node [5142510561](https://www.openstreetmap.org/way/5142510561) has the similar values: "crayfish" and "Crayfish"

--- a/docs/checks/similarTagValueCheck.md
+++ b/docs/checks/similarTagValueCheck.md
@@ -35,3 +35,7 @@ similarity threshold.
 From there we split the gathered pairs between those that are duplicate values, and those that are similar.
 The duplicates are added to the instructions and used to create a fix suggestion.
 The similars are just added to the instructions.
+
+#### Fix Suggestion
+We create fix suggestions only on duplicate values, as similar values are difficult to determine which one (if not both)
+should be kept. The fix, for duplicates, is to remove all but one occurrence of the duplicate value from the tag.

--- a/docs/checks/similarTagValueCheck.md
+++ b/docs/checks/similarTagValueCheck.md
@@ -1,0 +1,33 @@
+# SimilarTagValueCheck
+
+#### Description
+
+The purpose of this check is to identify tags whose values are either duplicates or similar
+enough to warrant someone to look at them.
+
+#### Live Examples
+
+
+#### Code Review
+
+This check evaluates all atlas objects that can hold OSM tags.
+Any duplicate tags are removed in a feature change, while similars are flagged for user review.
+
+#### Validating the object
+The incoming object must:
+* have at least one tag with multiple values (contains a ";")
+
+#### Flagging the object
+We filter out all tags that:
+* are tags that commonly contain valid duplicate/similar values
+* values that are similar to others that commonly occur on the same tag
+* values that either contain: length shorter than the defined min length, a number, non-latin characters
+* the last filtering step we remove any tags that do not contain multiple values
+
+We then take the valid tags and compare each value computing similarity between each, using the
+Levenshtein Edit Distance algorithm. We keep value pairs with a similarity that falls within our 
+similarity threshold.
+
+From there we split the gathered pairs between those that are duplicate values, and those that are similar.
+The duplicates are added to the instructions and used to create a fix suggestion.
+The similars are just added to the instructions.

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
@@ -1,5 +1,17 @@
 package org.openstreetmap.atlas.checks.validation.tag;
 
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
@@ -9,53 +21,35 @@ import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 /**
- * This check looks for tags with multiple values that are duplicates or
- * values are similar that contain a typo.
+ * This check looks for tags with multiple values that are duplicates or values are similar that
+ * contain a typo.
+ * 
  * @author brianjor
  */
 public class SimilarTagValueCheck extends BaseCheck<Long>
 {
     private static final long serialVersionUID = 6115389966264680867L;
-    private static final Predicate<String> HAS_NON_LATIN = Pattern.compile("[^\\d\\s\\p{Punct}\\p{IsLatin}]").asPredicate();
+    private static final Predicate<String> HAS_NON_LATIN = Pattern
+            .compile("[^\\d\\s\\p{Punct}\\p{IsLatin}]").asPredicate();
     private static final Predicate<String> HAS_NUMBER = Pattern.compile("\\d").asPredicate();
     private static final String SEMICOLON = ";";
     private static final String DUPLICATE_TAG_VALUE_INSTRUCTION = "The tag \"%s\" contains duplicate values: %s";
     private static final int DUPLICATE_INSTRUCTION_INDEX = 0;
     private static final String SIMILAR_TAG_VALUE_INSTRUCTION = "The tag \"%s\" contains similar values: %s";
     private static final int SIMILAR_INSTRUCTION_INDEX = 1;
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
-            DUPLICATE_TAG_VALUE_INSTRUCTION, SIMILAR_TAG_VALUE_INSTRUCTION);
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(DUPLICATE_TAG_VALUE_INSTRUCTION, SIMILAR_TAG_VALUE_INSTRUCTION);
     private static final Double MIN_VALUE_LENGTH = 4.0;
     private static final Double MIN_SIMILARITY_THRESHOLD_DEFAULT = 0.0;
     private static final Double MAX_SIMILARITY_THRESHOLD_DEFAULT = 1.0;
-    private static final Set<String> TAGS_TO_IGNORE = Set.of(
-            "asset_ref",
-            "collection_times",
-            "except",
-            "is_in",
-            "junction:ref",
-            "maxspeed:conditional",
-            "old_name", "old_ref", "opening_hours",
-            "ref", "restriction_hours", "route_ref",
-            "supervised", "source_ref",
-            "target", "telescope"
-    );
+    private static final Set<String> TAGS_TO_IGNORE = Set.of("asset_ref", "collection_times",
+            "except", "is_in", "junction:ref", "maxspeed:conditional", "old_name", "old_ref",
+            "opening_hours", "ref", "restriction_hours", "route_ref", "supervised", "source_ref",
+            "target", "telescope");
     // Set of tags with many sub-categories that create a lot of False positives
-    private static final Set<String> TAGS_TO_IGNORE_WITH_SUB_CATEGORIES = Set.of(
-            "addr", "alt_name",
-            "destination",
-            "name",
-            "seamark",
-            "turn"
-    );
+    private static final Set<String> TAGS_TO_IGNORE_WITH_SUB_CATEGORIES = Set.of("addr", "alt_name",
+            "destination", "name", "seamark", "turn");
     // Common value sets that are similar but can be on the same tag
     private static final List<Set<String>> COMMON_SIMILAR_VALUES = Arrays.asList(
             // Ethnonyms
@@ -68,14 +62,10 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
             // Medical
             Set.of("radiology", "cardiology"),
             // Sports
-            Set.of("baseball", "basketball"), Set.of("bowls", "boules"),
-            Set.of("padel", "paddel"),
+            Set.of("baseball", "basketball"), Set.of("bowls", "boules"), Set.of("padel", "paddel"),
             // Other
-            Set.of("formal", "informal"),
-            Set.of("hotel", "hostel"),
-            Set.of("hump", "bump"),
-            Set.of("seed", "feed")
-    );
+            Set.of("formal", "informal"), Set.of("hotel", "hostel"), Set.of("hump", "bump"),
+            Set.of("seed", "feed"));
 
     private final Double minValueLength;
     private final Double minSimilarityThreshold;
@@ -90,10 +80,10 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
         super(configuration);
         this.minValueLength = this.configurationValue(configuration, "value.length.min",
                 MIN_VALUE_LENGTH, Double::doubleValue);
-        this.minSimilarityThreshold = this.configurationValue(configuration, "similarity.threshold.min",
-                MIN_SIMILARITY_THRESHOLD_DEFAULT, Double::doubleValue);
-        this.maxSimilarityThreshold = this.configurationValue(configuration, "similarity.threshold.max",
-                MAX_SIMILARITY_THRESHOLD_DEFAULT, Double::doubleValue);
+        this.minSimilarityThreshold = this.configurationValue(configuration,
+                "similarity.threshold.min", MIN_SIMILARITY_THRESHOLD_DEFAULT, Double::doubleValue);
+        this.maxSimilarityThreshold = this.configurationValue(configuration,
+                "similarity.threshold.max", MAX_SIMILARITY_THRESHOLD_DEFAULT, Double::doubleValue);
     }
 
     /**
@@ -107,10 +97,7 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
     public boolean validCheckForObject(final AtlasObject object)
     {
         // Only want objects with tags that contain multiple values.
-        return object.getOsmTags()
-                .values()
-                .stream()
-                .anyMatch(value -> value.contains(SEMICOLON));
+        return object.getOsmTags().values().stream().anyMatch(value -> value.contains(SEMICOLON));
     }
 
     /**
@@ -123,10 +110,7 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        final Map<String, String> tagsWithMultipleValues = object
-                .getOsmTags()
-                .entrySet()
-                .stream()
+        final Map<String, String> tagsWithMultipleValues = object.getOsmTags().entrySet().stream()
                 .filter(entry -> !TAGS_TO_IGNORE.contains(entry.getKey()))
                 .filter(Predicate.not(this::isTagWithSubCategoriesToIgnore))
                 .map(this::removeCommonFalsePositiveValues)
@@ -135,59 +119,58 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
         // Gather all tags with a list of their similars
-        final Map<String, List<Similar>> tagsWithSimilars = tagsWithMultipleValues
-                .entrySet()
-                .stream()
-                .map(this::findSimilars)
-                .filter(entry -> !entry.getValue().isEmpty())
+        final Map<String, List<Similar>> tagsWithSimilars = tagsWithMultipleValues.entrySet()
+                .stream().map(this::findSimilars).filter(entry -> !entry.getValue().isEmpty())
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
         // Pull out tags + values to only contain similars that are duplicates
-        final Map<String, List<Similar>> duplicates =
-                this.filterSimilars(tagsWithSimilars, similar -> similar.getSimilarity() == 0);
+        final Map<String, List<Similar>> duplicates = this.filterSimilars(tagsWithSimilars,
+                similar -> similar.getSimilarity() == 0);
 
         // Pull out tags + values to only contain similars that are not duplicates
-        final Map<String, List<Similar>> similars =
-                this.filterSimilars(tagsWithSimilars, similar -> similar.getSimilarity() != 0);
+        final Map<String, List<Similar>> similars = this.filterSimilars(tagsWithSimilars,
+                similar -> similar.getSimilarity() != 0);
 
-        List<String> instructions = new ArrayList<>();
+        final List<String> instructions = new ArrayList<>();
         FeatureChange removeDuplicatesFixSuggestion = null;
         if (!duplicates.isEmpty())
         {
-            instructions.addAll(duplicates
-                    .entrySet()
-                    .stream()
-                    .map(entry -> String.format(getFallbackInstructions().get(DUPLICATE_INSTRUCTION_INDEX), entry.getKey(), entry.getValue())
-                    ).collect(Collectors.toList()));
+            instructions.addAll(duplicates.entrySet().stream()
+                    .map(entry -> String.format(
+                            this.getFallbackInstructions().get(DUPLICATE_INSTRUCTION_INDEX),
+                            entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList()));
 
-            final CompleteEntity completeEntity = ((CompleteEntity) CompleteEntity.from((AtlasEntity) object));
-            object.getOsmTags()
-                    .entrySet()
-                    .stream()
+            final CompleteEntity completeEntity = (CompleteEntity) CompleteEntity
+                    .from((AtlasEntity) object);
+            object.getOsmTags().entrySet().stream()
                     // only want to create a feature change on tags that contain duplicates
-                    .filter(entry -> duplicates.containsKey(entry.getKey()))
-                    .forEach(entry -> {
-                        String valueWithDuplicatesRemoved = Arrays.stream(entry.getValue().split(SEMICOLON))
-                                .distinct()
+                    .filter(entry -> duplicates.containsKey(entry.getKey())).forEach(entry ->
+                    {
+                        final String valueWithDuplicatesRemoved = Arrays
+                                .stream(entry.getValue().split(SEMICOLON)).distinct()
                                 .collect(Collectors.joining(SEMICOLON));
-                        completeEntity.withReplacedTag(entry.getKey(), entry.getKey(), valueWithDuplicatesRemoved);
+                        completeEntity.withReplacedTag(entry.getKey(), entry.getKey(),
+                                valueWithDuplicatesRemoved);
                     });
-            removeDuplicatesFixSuggestion = FeatureChange.add((AtlasEntity) completeEntity, object.getAtlas());
+            removeDuplicatesFixSuggestion = FeatureChange.add((AtlasEntity) completeEntity,
+                    object.getAtlas());
         }
 
         if (!similars.isEmpty())
         {
-            instructions.addAll(similars
-                    .entrySet()
-                    .stream()
-                    .map(entry -> String.format(getFallbackInstructions().get(SIMILAR_INSTRUCTION_INDEX), entry.getKey(), entry.getValue())
-                    ).collect(Collectors.toList()));
+            instructions.addAll(similars.entrySet().stream()
+                    .map(entry -> String.format(
+                            this.getFallbackInstructions().get(SIMILAR_INSTRUCTION_INDEX),
+                            entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList()));
         }
 
         if (!instructions.isEmpty())
         {
-            final String instruction =  String.join(". ", instructions);
-            return Optional.of(this.createFlag(object, instruction).addFixSuggestion(removeDuplicatesFixSuggestion));
+            final String instruction = String.join(". ", instructions);
+            return Optional.of(this.createFlag(object, instruction)
+                    .addFixSuggestion(removeDuplicatesFixSuggestion));
         }
         return Optional.empty();
     }
@@ -200,31 +183,30 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
 
     /**
      * Filters out similars from tags according to the filterBy predicate.
-     * @param tagsWithSimilars tags with similars.
-     * @param filterBy predicate to apply to the tags similars.
+     * 
+     * @param tagsWithSimilars
+     *            tags with similars.
+     * @param filterBy
+     *            predicate to apply to the tags similars.
      * @return the tag with the similars filtered out.
      */
-    private Map<String, List<Similar>> filterSimilars(Map<String, List<Similar>> tagsWithSimilars, Predicate<Similar> filterBy)
+    private Map<String, List<Similar>> filterSimilars(
+            final Map<String, List<Similar>> tagsWithSimilars, final Predicate<Similar> filterBy)
     {
-        return tagsWithSimilars
-                .entrySet()
-                .stream()
-                .map(entry -> {
-                    final Entry<String, List<Similar>> newEntry = new SimpleEntry<>(entry);
-                    final List<Similar> newValue = newEntry
-                            .getValue()
-                            .stream()
-                            .filter(filterBy)
-                            .collect(Collectors.toList());
-                    newEntry.setValue(newValue);
-                    return newEntry;
-                })
-                .filter(entry -> !entry.getValue().isEmpty())
+        return tagsWithSimilars.entrySet().stream().map(entry ->
+        {
+            final Entry<String, List<Similar>> newEntry = new SimpleEntry<>(entry);
+            final List<Similar> newValue = newEntry.getValue().stream().filter(filterBy)
+                    .collect(Collectors.toList());
+            newEntry.setValue(newValue);
+            return newEntry;
+        }).filter(entry -> !entry.getValue().isEmpty())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**
      * Finds the Levenshtein edit distance for the strings.
+     * 
      * @return edit distance between the two strings, or -1 if either string is null.
      */
     private int findEditDistance(final String left, final String right)
@@ -233,32 +215,34 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
         {
             return LevenshteinDistance.getDefaultInstance().apply(left, right);
         }
-        catch (IllegalArgumentException exception)
+        catch (final IllegalArgumentException exception)
         {
             return -1;
         }
     }
 
     /**
-     * Map a tag entry to an entry where their value is a list of tuples containing the two
-     * similar tags and their edit distance.
+     * Map a tag entry to an entry where their value is a list of tuples containing the two similar
+     * tags and their edit distance.
      */
-    private Entry<String, List<Similar>> findSimilars(final Entry<String, String> entry) {
+    private Entry<String, List<Similar>> findSimilars(final Entry<String, String> entry)
+    {
         final List<String> values = Arrays.asList(entry.getValue().split(SEMICOLON));
-        List<Similar> similars = new ArrayList<>();
+        final List<Similar> similars = new ArrayList<>();
         for (int i = 0; i < values.size() - 1; i++)
         {
             for (int j = i + 1; j < values.size(); j++)
             {
                 final String left = values.get(i);
                 final String right = values.get(j);
-                boolean isCommonSimilars = this.isCommonSimilars(left, right);
-                boolean duplicates = left.equals(right);
+                final boolean isCommonSimilars = this.isCommonSimilars(left, right);
+                final boolean duplicates = left.equals(right);
                 // Keep duplicates even if they are common similars
                 if (!isCommonSimilars || duplicates)
                 {
                     final int editDistance = this.findEditDistance(left, right);
-                    if (minSimilarityThreshold <= editDistance && editDistance <= maxSimilarityThreshold)
+                    if (this.minSimilarityThreshold <= editDistance
+                            && editDistance <= this.maxSimilarityThreshold)
                     {
                         similars.add(new Similar(left, right, editDistance));
                     }
@@ -273,8 +257,8 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
      */
     private boolean isCommonSimilars(final String left, final String right)
     {
-        return COMMON_SIMILAR_VALUES.stream().anyMatch(setOfSimilars ->
-                setOfSimilars.contains(left) && setOfSimilars.contains(right));
+        return COMMON_SIMILAR_VALUES.stream().anyMatch(
+                setOfSimilars -> setOfSimilars.contains(left) && setOfSimilars.contains(right));
     }
 
     /**
@@ -282,66 +266,66 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
      */
     private boolean isTagWithSubCategoriesToIgnore(final Map.Entry<String, String> entry)
     {
-        return TAGS_TO_IGNORE_WITH_SUB_CATEGORIES
-                .stream()
-                .anyMatch(entry.getKey()::startsWith);
+        return TAGS_TO_IGNORE_WITH_SUB_CATEGORIES.stream().anyMatch(entry.getKey()::startsWith);
     }
 
     /**
-     * Remove values that are susceptible to being false positives.
-     * <br>
+     * Remove values that are susceptible to being false positives. <br>
      * Removes:
      * <ul>
-     *     <li>Values whose length < {@value MIN_VALUE_LENGTH}</li>
-     *     <li>Numbers</li>
-     *     <li>Values with characters that match the HAS_NON_LATIN regex</li>
+     * <li>Values whose length < {@value MIN_VALUE_LENGTH}</li>
+     * <li>Numbers</li>
+     * <li>Values with characters that match the HAS_NON_LATIN regex</li>
      * </ul>
      */
     private Entry<String, String> removeCommonFalsePositiveValues(final Entry<String, String> tag)
     {
         final Entry<String, String> newTag = new SimpleEntry<>(tag);
-        List<String> splitValues = Arrays.stream(newTag.getValue().split(SEMICOLON))
+        final List<String> splitValues = Arrays.stream(newTag.getValue().split(SEMICOLON))
                 // Values must be greater than or equal to the specified minimum length.
                 .filter(value -> value.length() >= this.minValueLength)
                 // Remove values that contain numbers.
                 .filter(Predicate.not(HAS_NUMBER))
                 // Remove values that contain non-Latin characters, and others (see regex).
-                .filter(Predicate.not(HAS_NON_LATIN))
-                .collect(Collectors.toList());
+                .filter(Predicate.not(HAS_NON_LATIN)).collect(Collectors.toList());
         newTag.setValue(String.join(SEMICOLON, splitValues));
         return newTag;
     }
 
     /**
-     * Contains the two similar strings and their similarity.
-     * Convenience class for readability.
+     * Contains the two similar strings and their similarity. Convenience class for readability.
      */
-    private static class Similar {
+    private static class Similar
+    {
         private final String similar1;
         private final String similar2;
         private final Integer similarity;
 
-        public Similar(final String similar1, final String similar2, final Integer similarity)
+        Similar(final String similar1, final String similar2, final Integer similarity)
         {
             this.similar1 = similar1;
             this.similar2 = similar2;
             this.similarity = similarity;
         }
 
-        public String getSimilar1() {
-            return similar1;
+        public String getSimilar1()
+        {
+            return this.similar1;
         }
 
-        public String getSimilar2() {
-            return similar2;
+        public String getSimilar2()
+        {
+            return this.similar2;
         }
 
-        public Integer getSimilarity() {
-            return similarity;
+        public Integer getSimilarity()
+        {
+            return this.similarity;
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return String.format("(%s,%s,%d)", this.similar1, this.similar2, this.similarity);
         }
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
@@ -24,7 +24,12 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 /**
  * This check looks for tags with multiple values that are duplicates or values are similar that
  * contain a typo.
- * 
+ *
+ * Configurables:
+ * "value.length.min": Minimum length an individual value must be to be considered for inspection, value.length >= min.
+ * "similarity.threshold.min": Minimum edit distance between two values to be add to the flag where a value of 0 is used to include duplicates, value >= min.
+ * "similarity.threshold.max": Maximum edit distance between two values to be add to the flag, value <= max.
+ *
  * @author brianjor
  */
 public class SimilarTagValueCheck extends BaseCheck<Long>

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
@@ -1,0 +1,258 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import scala.Tuple3;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * This check looks for tags with multiple values that are duplicates or
+ * values are similar that contain a typo.
+ * @author brianjor
+ */
+public class SimilarTagValueCheck extends BaseCheck<Long>
+{
+    private static final long serialVersionUID = 6115389966264680867L;
+    private static final Predicate<String> HAS_NON_LATIN = Pattern.compile("[^\\d\\s\\p{Punct}\\p{IsLatin}]").asPredicate();
+    private static final Predicate<String> HAS_NUMBER = Pattern.compile("\\d").asPredicate();
+    private static final String SEMICOLON = ";";
+    private static final String DUPLICATE_TAG_VALUE_INSTRUCTION = "The tag {0} contains duplicate values: {0}";
+    private static final int DUPLICATE_INSTRUCTION_INDEX = 0;
+    private static final String SIMILAR_TAG_VALUE_INSTRUCTION = "The tag {0} contains similar values: {0}";
+    private static final int SIMILAR_INSTRUCTION_INDEX = 1;
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(
+            DUPLICATE_TAG_VALUE_INSTRUCTION, SIMILAR_TAG_VALUE_INSTRUCTION);
+    private static final Double MIN_VALUE_LENGTH = 4.0;
+    private static final Double MIN_SIMILARITY_THRESHOLD_DEFAULT = 0.0;
+    private static final Double MAX_SIMILARITY_THRESHOLD_DEFAULT = 1.0;
+    private static final Set<String> TAGS_TO_IGNORE = Set.of(
+            "asset_ref",
+            "collection_times",
+            "except",
+            "is_in",
+            "junction:ref",
+            "maxspeed:conditional",
+            "old_name", "old_ref", "opening_hours",
+            "ref", "restriction_hours", "route_ref",
+            "supervised", "source_ref",
+            "target", "telescope"
+    );
+    // Set of tags with many sub-categories that create a lot of False positives
+    private static final Set<String> TAGS_TO_IGNORE_WITH_SUB_CATEGORIES = Set.of(
+            "addr", "alt_name",
+            "destination",
+            "name",
+            "seamark",
+            "turn"
+    );
+    // Common value sets that are similar but can be on the same tag
+    private static final List<Set<String>> COMMON_SIMILAR_VALUES = Arrays.asList(
+            // Ethnonyms
+            Set.of("american", "mexican"),
+            // Food
+            Set.of("cafe", "cake"),
+            // Gender
+            Set.of("male", "female"), Set.of("woman", "man"), Set.of("women", "men"),
+            Set.of("male_toilet", "female_toilet"),
+            // Medical
+            Set.of("radiology", "cardiology"),
+            // Sports
+            Set.of("baseball", "basketball"), Set.of("bowls", "boules"),
+            Set.of("padel", "paddel"),
+            // Other
+            Set.of("formal", "informal"),
+            Set.of("hotel", "hostel"),
+            Set.of("hump", "bump"),
+            Set.of("seed", "feed")
+    );
+
+    private final Double minValueLength;
+    private final Double minSimilarityThreshold;
+    private final Double maxSimilarityThreshold;
+
+    /**
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public SimilarTagValueCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.minValueLength = this.configurationValue(configuration, "value.length.min",
+                MIN_VALUE_LENGTH, Double::doubleValue);
+        this.minSimilarityThreshold = this.configurationValue(configuration, "similarity.threshold.min",
+                MIN_SIMILARITY_THRESHOLD_DEFAULT, Double::doubleValue);
+        this.maxSimilarityThreshold = this.configurationValue(configuration, "similarity.threshold.max",
+                MAX_SIMILARITY_THRESHOLD_DEFAULT, Double::doubleValue);
+    }
+
+    /**
+     * Valid objects for this check objects with tags that contain multiple values.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        // Only want objects with tags that contain multiple values.
+        return object.getOsmTags()
+                .values()
+                .stream()
+                .anyMatch(value -> value.contains(SEMICOLON));
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Map<String, String> tagsWithMultipleValues = object
+                .getOsmTags()
+                .entrySet()
+                .stream()
+                .filter(entry -> !TAGS_TO_IGNORE.contains(entry.getKey()))
+                .filter(Predicate.not(this::isTagWithSubCategoriesToIgnore))
+                .map(this::removeCommonFalsePositiveValues)
+                // Only keep tags that still have multiple values
+                .filter(entry -> entry.getValue().contains(SEMICOLON))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        // Map of tags with a list of similar values with their similarity score
+        final Map<String, List<Tuple3<String, String, Integer>>> tagsWithSimilars = tagsWithMultipleValues
+                .entrySet()
+                .stream()
+                .map(this::findSimilars)
+                .filter(entry -> !entry.getValue().isEmpty())
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        if (!tagsWithSimilars.isEmpty())
+        {
+            final String ogTags = object.getOsmTags()
+                    .entrySet()
+                    .stream()
+                    .filter(t -> tagsWithSimilars.entrySet().stream().anyMatch(tw -> tw.getKey().equals(t.getKey())))
+                    .map(t -> "Tag: " + t.getKey() + ", Value: " + t.getValue())
+                    .collect(Collectors.joining(", "));
+            System.out.println("Osmid: " + object.getOsmIdentifier());
+            System.out.println("    OG Tags: " + ogTags);
+            String in = tagsWithSimilars
+                    .entrySet()
+                    .stream()
+                    .map(entry -> "    Tag: " + entry.getKey() + ", Similars: " + entry.getValue())
+                    .collect(Collectors.joining(",\n"));
+            System.out.println(in);
+            return Optional.of(this.createFlag(object, in));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * Finds the Levenshtein edit distance for the strings.
+     * @return edit distance between the two strings, or -1 if either string is null.
+     */
+    private int findEditDistance(final String left, final String right)
+    {
+        try
+        {
+            return LevenshteinDistance.getDefaultInstance().apply(left, right);
+        }
+        catch (IllegalArgumentException exception)
+        {
+            return -1;
+        }
+    }
+
+    /**
+     * Map a tag entry to an entry where their value is a list of tuples containing the two
+     * similar tags and their edit distance.
+     */
+    private Entry<String, List<Tuple3<String, String, Integer>>> findSimilars(final Entry<String, String> entry) {
+        final List<String> values = Arrays.asList(entry.getValue().split(SEMICOLON));
+        List<Tuple3<String, String, Integer>> similars = new ArrayList<>();
+        for (int i = 0; i < values.size() - 1; i++)
+        {
+            for (int j = i + 1; j < values.size(); j++)
+            {
+                final String left = values.get(i);
+                final String right = values.get(j);
+                boolean isCommonSimilars = this.isCommonSimilars(left, right);
+                boolean duplicates = left.equals(right);
+                // Keep duplicates even if they are common similars
+                if (!isCommonSimilars || duplicates)
+                {
+                    final int editDistance = this.findEditDistance(left, right);
+                    if (minSimilarityThreshold <= editDistance && editDistance <= maxSimilarityThreshold)
+                    {
+                        similars.add(new Tuple3<>(left, right, editDistance));
+                    }
+                }
+            }
+        }
+        return new SimpleEntry<>(entry.getKey(), similars);
+    }
+
+    /**
+     * Checks if the strings are contained in the same set of common similars.
+     */
+    private boolean isCommonSimilars(final String left, final String right)
+    {
+        return COMMON_SIMILAR_VALUES.stream().anyMatch(setOfSimilars ->
+                setOfSimilars.contains(left) && setOfSimilars.contains(right));
+    }
+
+    /**
+     * Checks if the tag for the entry starts with any of the tags with sub-categories to ignore.
+     */
+    private boolean isTagWithSubCategoriesToIgnore(final Map.Entry<String, String> entry)
+    {
+        return TAGS_TO_IGNORE_WITH_SUB_CATEGORIES
+                .stream()
+                .anyMatch(entry.getKey()::startsWith);
+    }
+
+    /**
+     * Remove values that are susceptible to being false positives.
+     * <br>
+     * Removes:
+     * <ul>
+     *     <li>Values whose length < {@value MIN_VALUE_LENGTH}</li>
+     *     <li>Numbers</li>
+     *     <li>Common similar values</li>
+     * </ul>
+     */
+    private Entry<String, String> removeCommonFalsePositiveValues(final Entry<String, String> tag)
+    {
+        final Entry<String, String> newTag = new SimpleEntry<>(tag);
+        List<String> splitValues = Arrays.stream(newTag.getValue().split(SEMICOLON))
+                // Values must be greater than or equal to the specified minimum length.
+                .filter(value -> value.length() >= this.minValueLength)
+                // Remove values that contain numbers.
+                .filter(Predicate.not(HAS_NUMBER))
+                // Remove values that contain non-Latin characters, and others (see regex).
+                .filter(Predicate.not(HAS_NON_LATIN))
+                .collect(Collectors.toList());
+        newTag.setValue(String.join(SEMICOLON, splitValues));
+        return newTag;
+    }
+}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
@@ -229,12 +229,12 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
     {
         final List<String> values = Arrays.asList(entry.getValue().split(SEMICOLON));
         final List<Similar> similars = new ArrayList<>();
-        for (int i = 0; i < values.size() - 1; i++)
+        for (int leftIndex = 0; leftIndex < values.size() - 1; leftIndex++)
         {
-            for (int j = i + 1; j < values.size(); j++)
+            for (int rightIndex = leftIndex + 1; rightIndex < values.size(); rightIndex++)
             {
-                final String left = values.get(i);
-                final String right = values.get(j);
+                final String left = values.get(leftIndex);
+                final String right = values.get(rightIndex);
                 final boolean isCommonSimilars = this.isCommonSimilars(left, right);
                 final boolean duplicates = left.equals(right);
                 // Keep duplicates even if they are common similars

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
@@ -23,12 +23,12 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 /**
  * This check looks for tags with multiple values that are duplicates or values are similar that
  * contain a typo. Configurables: "value.length.min": Minimum length an individual value must be to
- * be considered for inspection, value.length >= min. "similarity.threshold.min": Minimum edit
- * distance between two values to be add to the flag where a value of 0 is used to include
- * duplicates, value >= min. "similarity.threshold.max": Maximum edit distance between two values to
- * be add to the flag, value <= max. "filter.commonSimilars": values that can commonly be found
- * together validly on a tag that are similar but with no action needed to be taken. "filter.tags":
- * tags that commonly have values that are duplicates/similars that are valid.
+ * be considered for inspection, {@literal value.length >= min}. "similarity.threshold.min": Minimum
+ * edit distance between two values to be add to the flag where a value of 0 is used to include
+ * duplicates, {@literal value >= min}. "similarity.threshold.max": Maximum edit distance between
+ * two values to be add to the flag, {@literal value <= max}. "filter.commonSimilars": values that
+ * can commonly be found together validly on a tag that are similar but with no action needed to be
+ * taken. "filter.tags": tags that commonly have values that are duplicates/similars that are valid.
  * "filter.tagsWithSubCategories": tags that contain one or many sub-categories that commonly have
  * valid duplicate/similar values.
  *

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheck.java
@@ -22,15 +22,15 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
  * This check looks for tags with multiple values that are duplicates or values are similar that
- * contain a typo.
- *
- * Configurables:
- * "value.length.min": Minimum length an individual value must be to be considered for inspection, value.length >= min.
- * "similarity.threshold.min": Minimum edit distance between two values to be add to the flag where a value of 0 is used to include duplicates, value >= min.
- * "similarity.threshold.max": Maximum edit distance between two values to be add to the flag, value <= max.
- * "filter.commonSimilars": values that can commonly be found together validly on a tag that are similar but with no action needed to be taken.
- * "filter.tags": tags that commonly have values that are duplicates/similars that are valid.
- * "filter.tagsWithSubCategories": tags that contain one or many sub-categories that commonly have valid duplicate/similar values.
+ * contain a typo. Configurables: "value.length.min": Minimum length an individual value must be to
+ * be considered for inspection, value.length >= min. "similarity.threshold.min": Minimum edit
+ * distance between two values to be add to the flag where a value of 0 is used to include
+ * duplicates, value >= min. "similarity.threshold.max": Maximum edit distance between two values to
+ * be add to the flag, value <= max. "filter.commonSimilars": values that can commonly be found
+ * together validly on a tag that are similar but with no action needed to be taken. "filter.tags":
+ * tags that commonly have values that are duplicates/similars that are valid.
+ * "filter.tagsWithSubCategories": tags that contain one or many sub-categories that commonly have
+ * valid duplicate/similar values.
  *
  * @author brianjor
  */
@@ -50,13 +50,13 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
     private static final Double MIN_VALUE_LENGTH = 4.0;
     private static final Double MIN_SIMILARITY_THRESHOLD_DEFAULT = 0.0;
     private static final Double MAX_SIMILARITY_THRESHOLD_DEFAULT = 1.0;
-    private static final List<String> TAGS_TO_IGNORE_DEFAULT = List.of("asset_ref", "collection_times",
-            "except", "is_in", "junction:ref", "maxspeed:conditional", "old_name", "old_ref",
-            "opening_hours", "ref", "restriction_hours", "route_ref", "supervised", "source_ref",
-            "target", "telescope");
+    private static final List<String> TAGS_TO_IGNORE_DEFAULT = List.of("asset_ref",
+            "collection_times", "except", "is_in", "junction:ref", "maxspeed:conditional",
+            "old_name", "old_ref", "opening_hours", "ref", "restriction_hours", "route_ref",
+            "supervised", "source_ref", "target", "telescope");
     // Set of tags with many sub-categories that create a lot of False positives
-    private static final List<String> TAGS_WITH_SUB_CATEGORIES_TO_IGNORE_DEFAULT = List.of("addr", "alt_name",
-            "destination", "name", "seamark", "turn");
+    private static final List<String> TAGS_WITH_SUB_CATEGORIES_TO_IGNORE_DEFAULT = List.of("addr",
+            "alt_name", "destination", "name", "seamark", "turn");
     // Common value sets that are similar but can be on the same tag
     private static final List<List<String>> COMMON_SIMILARS_DEFAULT = List.of(
             // Ethnonyms
@@ -69,7 +69,8 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
             // Medical
             List.of("radiology", "cardiology"),
             // Sports
-            List.of("baseball", "basketball"), List.of("bowls", "boules"), List.of("padel", "paddel"),
+            List.of("baseball", "basketball"), List.of("bowls", "boules"),
+            List.of("padel", "paddel"),
             // Other
             List.of("formal", "informal"), List.of("hotel", "hostel"), List.of("hump", "bump"),
             List.of("seed", "feed"));
@@ -92,8 +93,8 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
                 COMMON_SIMILARS_DEFAULT);
         this.tagsToIgnore = this.configurationValue(configuration, "filter.tags",
                 TAGS_TO_IGNORE_DEFAULT);
-        this.tagsWithSubCategoriesToIgnore = this.configurationValue(configuration, "filter.tagsWithSubCategories",
-                TAGS_WITH_SUB_CATEGORIES_TO_IGNORE_DEFAULT);
+        this.tagsWithSubCategoriesToIgnore = this.configurationValue(configuration,
+                "filter.tagsWithSubCategories", TAGS_WITH_SUB_CATEGORIES_TO_IGNORE_DEFAULT);
         this.minValueLength = this.configurationValue(configuration, "value.length.min",
                 MIN_VALUE_LENGTH, Double::doubleValue);
         this.minSimilarityThreshold = this.configurationValue(configuration,
@@ -168,25 +169,22 @@ public class SimilarTagValueCheck extends BaseCheck<Long>
 
         if (!instructions.isEmpty())
         {
-            final Map<String, String> newTags = object.getOsmTags().entrySet().stream()
-                    .map(entry ->
-                    {
-                        final Entry<String, String> newEntry = new SimpleEntry<>(entry);
-                        if (duplicates.containsKey(entry.getKey()))
-                        {
-                            final String valueWithDuplicatesRemoved = Arrays
-                                    .stream(entry.getValue().split(SEMICOLON)).distinct()
-                                    .collect(Collectors.joining(SEMICOLON));
-                            newEntry.setValue(valueWithDuplicatesRemoved);
-                        }
-                        return newEntry;
-                    }).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+            final Map<String, String> newTags = object.getOsmTags().entrySet().stream().map(entry ->
+            {
+                final Entry<String, String> newEntry = new SimpleEntry<>(entry);
+                if (duplicates.containsKey(entry.getKey()))
+                {
+                    final String valueWithDuplicatesRemoved = Arrays
+                            .stream(entry.getValue().split(SEMICOLON)).distinct()
+                            .collect(Collectors.joining(SEMICOLON));
+                    newEntry.setValue(valueWithDuplicatesRemoved);
+                }
+                return newEntry;
+            }).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
             final String instruction = String.join(". ", instructions);
-            return Optional.of(this.createFlag(object, instruction)
-                    .addFixSuggestion(
-                            FeatureChange.add(
-                                    (AtlasEntity) ((CompleteEntity) CompleteEntity
-                                            .from((AtlasEntity) object)).withTags(newTags), object.getAtlas())));
+            return Optional.of(this.createFlag(object, instruction).addFixSuggestion(FeatureChange
+                    .add((AtlasEntity) ((CompleteEntity) CompleteEntity.from((AtlasEntity) object))
+                            .withTags(newTags), object.getAtlas())));
         }
         return Optional.empty();
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
@@ -1,0 +1,47 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link SimilarTagValueCheck}
+ *
+ * @author v-brjor
+ */
+public class SimilarTagValueCheckTest
+{
+    @Rule
+    public SimilarTagValueCheckTestRule setup = new SimilarTagValueCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final SimilarTagValueCheck check = new SimilarTagValueCheck(ConfigurationResolver
+            .inlineConfiguration(
+                "{" +
+                    "\"SimilarTagValueCheck\": {" +
+                        "\"similarity.threshold\": {" +
+                            "\"min\": " + 0.0 + "," +
+                            "\"max\": " + 1.0 +
+                        "}," +
+                        "\"value.length.min\": " + 4.0 +
+                    "}" +
+                "}"));
+
+    @Test
+    public void testHasDuplicateTagValue()
+    {
+        this.verifier.actual(this.setup.getHasDuplicateTagTest(), this.check);
+        this.verifier.verify(flag -> Assert.assertEquals("1. The tag \"hasDupe\" contains duplicate values: [(dupe,dupe,0)]", flag.getInstructions()));
+    }
+
+    @Test
+    public void testHasSimilarTagValue()
+    {
+        this.verifier.actual(this.setup.getHasSimilarTagTest(), this.check);
+        this.verifier.verify(flag -> Assert.assertEquals("1. The tag \"hasSimilar\" contains similar values: [(similar,similer,1)]", flag.getInstructions()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
@@ -25,6 +25,15 @@ public class SimilarTagValueCheckTest
                             + "\"max\":" + 1.0 + "},\"value.length.min\":" + 4.0 + "}}"));
 
     @Test
+    public void testDuplicateCommonSimilars()
+    {
+        this.verifier.actual(this.setup.getDuplicateCommonSimilarsTest(), this.check);
+        this.verifier.verify(flag -> Assert.assertEquals(
+                "1. The tag \"cuisine\" contains duplicate values: [(cake,cake,0)]",
+                flag.getInstructions()));
+    }
+
+    @Test
     public void testHasDuplicateTagValue()
     {
         this.verifier.actual(this.setup.getHasDuplicateTagTest(), this.check);
@@ -40,5 +49,26 @@ public class SimilarTagValueCheckTest
         this.verifier.verify(flag -> Assert.assertEquals(
                 "1. The tag \"hasSimilar\" contains similar values: [(similar,similer,1)]",
                 flag.getInstructions()));
+    }
+
+    @Test
+    public void testCommonSimilars()
+    {
+        this.verifier.actual(this.setup.getIgnoreCommonSimilarsTest(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testIgnoreTag()
+    {
+        this.verifier.actual(this.setup.getIgnoreTagTest(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testIgnoreTagSubclass()
+    {
+        this.verifier.actual(this.setup.getIgnoreTagSubclassTest(), this.check);
+        this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
@@ -19,29 +19,26 @@ public class SimilarTagValueCheckTest
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
-    private final SimilarTagValueCheck check = new SimilarTagValueCheck(ConfigurationResolver
-            .inlineConfiguration(
-                "{" +
-                    "\"SimilarTagValueCheck\": {" +
-                        "\"similarity.threshold\": {" +
-                            "\"min\": " + 0.0 + "," +
-                            "\"max\": " + 1.0 +
-                        "}," +
-                        "\"value.length.min\": " + 4.0 +
-                    "}" +
-                "}"));
+    private final SimilarTagValueCheck check = new SimilarTagValueCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"SimilarTagValueCheck\":{" + "\"similarity.threshold\":{\"min\":" + 0.0 + ","
+                            + "\"max\":" + 1.0 + "},\"value.length.min\":" + 4.0 + "}}"));
 
     @Test
     public void testHasDuplicateTagValue()
     {
         this.verifier.actual(this.setup.getHasDuplicateTagTest(), this.check);
-        this.verifier.verify(flag -> Assert.assertEquals("1. The tag \"hasDupe\" contains duplicate values: [(dupe,dupe,0)]", flag.getInstructions()));
+        this.verifier.verify(flag -> Assert.assertEquals(
+                "1. The tag \"hasDupe\" contains duplicate values: [(dupe,dupe,0)]",
+                flag.getInstructions()));
     }
 
     @Test
     public void testHasSimilarTagValue()
     {
         this.verifier.actual(this.setup.getHasSimilarTagTest(), this.check);
-        this.verifier.verify(flag -> Assert.assertEquals("1. The tag \"hasSimilar\" contains similar values: [(similar,similer,1)]", flag.getInstructions()));
+        this.verifier.verify(flag -> Assert.assertEquals(
+                "1. The tag \"hasSimilar\" contains similar values: [(similar,similer,1)]",
+                flag.getInstructions()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTest.java
@@ -25,6 +25,13 @@ public class SimilarTagValueCheckTest
                             + "\"max\":" + 1.0 + "},\"value.length.min\":" + 4.0 + "}}"));
 
     @Test
+    public void testCommonSimilars()
+    {
+        this.verifier.actual(this.setup.getIgnoreCommonSimilarsTest(), this.check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testDuplicateCommonSimilars()
     {
         this.verifier.actual(this.setup.getDuplicateCommonSimilarsTest(), this.check);
@@ -49,13 +56,6 @@ public class SimilarTagValueCheckTest
         this.verifier.verify(flag -> Assert.assertEquals(
                 "1. The tag \"hasSimilar\" contains similar values: [(similar,similer,1)]",
                 flag.getInstructions()));
-    }
-
-    @Test
-    public void testCommonSimilars()
-    {
-        this.verifier.actual(this.setup.getIgnoreCommonSimilarsTest(), this.check);
-        this.verifier.verifyEmpty();
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
@@ -1,0 +1,40 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Tests for {@link SimilarTagValueCheck}
+ *
+ * @author v-brjor
+ */
+public class SimilarTagValueCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "0, 0";
+
+    @TestAtlas(
+            nodes = {
+                    @Node(coordinates = @Loc(value = TEST_1), tags = { "hasDupe=dupe;dupe"})
+            }
+    )
+    private Atlas hasDuplicateTagTest;
+
+    @TestAtlas(
+            nodes = {
+                    @Node(coordinates = @Loc(value = TEST_1), tags = { "hasSimilar=similar;similer"})
+            }
+    )
+    private Atlas hasSimilarTagTest;
+
+    public Atlas getHasDuplicateTagTest()
+    {
+        return this.hasDuplicateTagTest;
+    }
+
+    public Atlas getHasSimilarTagTest() {
+        return this.hasSimilarTagTest;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
@@ -35,11 +35,11 @@ public class SimilarTagValueCheckTestRule extends CoreTestRule
             @Node(coordinates = @Loc(value = TEST_1), tags = { "turn:lanes:forward=dupe;dupe" }) })
     private Atlas ignoreTagSubclassTest;
 
-    @TestAtlas(nodes = {
-            @Node(coordinates = @Loc(value = TEST_1), tags = { "ref=dupe;dupe" }) })
+    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = TEST_1), tags = { "ref=dupe;dupe" }) })
     private Atlas ignoreTagTest;
 
-    public Atlas getDuplicateCommonSimilarsTest() {
+    public Atlas getDuplicateCommonSimilarsTest()
+    {
         return this.duplicateCommonSimilarsTest;
     }
 
@@ -53,15 +53,18 @@ public class SimilarTagValueCheckTestRule extends CoreTestRule
         return this.hasSimilarTagTest;
     }
 
-    public Atlas getIgnoreCommonSimilarsTest() {
+    public Atlas getIgnoreCommonSimilarsTest()
+    {
         return this.ignoreCommonSimilarsTest;
     }
 
-    public Atlas getIgnoreTagSubclassTest() {
+    public Atlas getIgnoreTagSubclassTest()
+    {
         return this.ignoreTagSubclassTest;
     }
 
-    public Atlas getIgnoreTagTest() {
+    public Atlas getIgnoreTagTest()
+    {
         return this.ignoreTagTest;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
@@ -16,12 +16,32 @@ public class SimilarTagValueCheckTestRule extends CoreTestRule
     private static final String TEST_1 = "0, 0";
 
     @TestAtlas(nodes = {
+            @Node(coordinates = @Loc(value = TEST_1), tags = { "cuisine=cake;cake" }) })
+    private Atlas duplicateCommonSimilarsTest;
+
+    @TestAtlas(nodes = {
             @Node(coordinates = @Loc(value = TEST_1), tags = { "hasDupe=dupe;dupe" }) })
     private Atlas hasDuplicateTagTest;
 
     @TestAtlas(nodes = {
             @Node(coordinates = @Loc(value = TEST_1), tags = { "hasSimilar=similar;similer" }) })
     private Atlas hasSimilarTagTest;
+
+    @TestAtlas(nodes = {
+            @Node(coordinates = @Loc(value = TEST_1), tags = { "cuisine=cafe;cake" }) })
+    private Atlas ignoreCommonSimilarsTest;
+
+    @TestAtlas(nodes = {
+            @Node(coordinates = @Loc(value = TEST_1), tags = { "turn:lanes:forward=dupe;dupe" }) })
+    private Atlas ignoreTagSubclassTest;
+
+    @TestAtlas(nodes = {
+            @Node(coordinates = @Loc(value = TEST_1), tags = { "ref=dupe;dupe" }) })
+    private Atlas ignoreTagTest;
+
+    public Atlas getDuplicateCommonSimilarsTest() {
+        return this.duplicateCommonSimilarsTest;
+    }
 
     public Atlas getHasDuplicateTagTest()
     {
@@ -31,5 +51,17 @@ public class SimilarTagValueCheckTestRule extends CoreTestRule
     public Atlas getHasSimilarTagTest()
     {
         return this.hasSimilarTagTest;
+    }
+
+    public Atlas getIgnoreCommonSimilarsTest() {
+        return this.ignoreCommonSimilarsTest;
+    }
+
+    public Atlas getIgnoreTagSubclassTest() {
+        return this.ignoreTagSubclassTest;
+    }
+
+    public Atlas getIgnoreTagTest() {
+        return this.ignoreTagTest;
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/SimilarTagValueCheckTestRule.java
@@ -15,18 +15,12 @@ public class SimilarTagValueCheckTestRule extends CoreTestRule
 {
     private static final String TEST_1 = "0, 0";
 
-    @TestAtlas(
-            nodes = {
-                    @Node(coordinates = @Loc(value = TEST_1), tags = { "hasDupe=dupe;dupe"})
-            }
-    )
+    @TestAtlas(nodes = {
+            @Node(coordinates = @Loc(value = TEST_1), tags = { "hasDupe=dupe;dupe" }) })
     private Atlas hasDuplicateTagTest;
 
-    @TestAtlas(
-            nodes = {
-                    @Node(coordinates = @Loc(value = TEST_1), tags = { "hasSimilar=similar;similer"})
-            }
-    )
+    @TestAtlas(nodes = {
+            @Node(coordinates = @Loc(value = TEST_1), tags = { "hasSimilar=similar;similer" }) })
     private Atlas hasSimilarTagTest;
 
     public Atlas getHasDuplicateTagTest()
@@ -34,7 +28,8 @@ public class SimilarTagValueCheckTestRule extends CoreTestRule
         return this.hasDuplicateTagTest;
     }
 
-    public Atlas getHasSimilarTagTest() {
+    public Atlas getHasSimilarTagTest()
+    {
         return this.hasSimilarTagTest;
     }
 }


### PR DESCRIPTION
### Description:

This check looks for similar values in a tag that are separated by a ‘;’.  

### Potential Impact:

No impact

### Unit Test Approach:

Added tests for duplicate tags and similar tags

### Test Results:

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|------------|--------------|----|----| -------------------- |
|AUS|      491        |      491     |    100%        | 489 | 2  |         0.004%          |
|ARG|      24         |        24      |    100%        |  24 | 0   |             0%            |
|NZL|      28         |        28      |    100%        |  28 | 0   |             0%            |
|SWE|      44         |        44      |    100%        | 44 | 0   |             0%            |
|TUR|      79         |        79      |    100%        |  79 | 0   |             0%            |


The two FPs (both on guide_text tag):
https://www.openstreetmap.org/node/8965935
https://www.openstreetmap.org/node/4092708898

Resolves: #485 