### PR TITLE
Change sharpAngle instructions

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheck.java
@@ -27,8 +27,8 @@ import org.openstreetmap.atlas.utilities.tuples.Tuple;
 public class SharpAngleCheck extends BaseCheck<Long>
 {
     private static final double THRESHOLD_DEGREES_DEFAULT = 97.0;
-    private static final String TOO_SHARP_INSTRUCTION_1 = "Highway {0,number,#} has too sharp an angle at {1}";
-    private static final String TOO_SHARP_INSTRUCTION_2 = "Highway {0,number,#} has {1} angles that are too sharp";
+    private static final String TOO_SHARP_INSTRUCTION_1 = "Way {0,number,#} has {1} node(s) with angle(s) that are too sharp.";
+    private static final String TOO_SHARP_INSTRUCTION_2 = "The node at {0} is too sharp.";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(TOO_SHARP_INSTRUCTION_1,
             TOO_SHARP_INSTRUCTION_2);
     private static final long serialVersionUID = 285618700794811828L;
@@ -69,25 +69,17 @@ public class SharpAngleCheck extends BaseCheck<Long>
         if (!offendingAngles.isEmpty() && !this.hasBeenFlagged(edge))
         {
             this.flagEdge(edge);
-            final String checkMessage;
-
-            if (offendingAngles.size() == 1)
-            {
-                // Single offending angle - output the location.
-                checkMessage = this.getLocalizedInstruction(0, object.getOsmIdentifier(),
-                        offendingAngles.get(0).getSecond());
-            }
-            else
-            {
-                // Multiple such angles - output the total count.
-                checkMessage = this.getLocalizedInstruction(1, object.getOsmIdentifier(),
-                        offendingAngles.size());
-            }
 
             final List<Location> offendingLocations = this.buildLocationList(offendingAngles);
-            return Optional.of(this.createFlag(object, checkMessage, offendingLocations));
-        }
+            final CheckFlag newFlag = this.createFlag(object, this.getLocalizedInstruction(0,
+                    object.getOsmIdentifier(), offendingAngles.size()), offendingLocations);
 
+            for (final Location sharpAngle : offendingLocations)
+            {
+                newFlag.addInstruction(this.getLocalizedInstruction(1, sharpAngle.toString()));
+            }
+            return Optional.of(newFlag);
+        }
         return Optional.empty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SharpAngleCheckTest.java
@@ -45,7 +45,7 @@ public class SharpAngleCheckTest
         this.verifier.actual(this.setup.sharpeAnglesAtlas(),
                 new SharpAngleCheck(this.inlineConfiguration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert
-                .assertTrue(flag.getInstructions().contains("2 angles that are too sharp")));
+        this.verifier
+                .verify(flag -> Assert.assertTrue(flag.getInstructions().contains("The node at ")));
     }
 }


### PR DESCRIPTION
### Description:
Address issue https://github.com/osmlab/atlas-checks/issues/502
Change SharpAngelCheck so that the instructions list all points at which a sharp angle exist.

### Potential Impact:
This will change the instructions only for SharpAngleCheck. Examples are below

### Unit Test Approach:
Unit test was altered to test the new instructions.

### Test Results:
Before the change this is what a single sharp angle issue looked like
https://maproulette.org/challenge/15097/task/69659510
![Screen Shot 2021-02-12 at 5 31 32 PM](https://user-images.githubusercontent.com/5851115/107829640-27f74c00-6d58-11eb-8589-0dc29961016d.png)

After the patch is applied this is what that same task looks like
https://maproulette.org/challenge/16923/task/83503556
![Screen Shot 2021-02-12 at 5 31 09 PM](https://user-images.githubusercontent.com/5851115/107829614-1a41c680-6d58-11eb-9a4e-120ac23d01ed.png)

Before the patch this is what a multiple sharp angle task looks like
https://maproulette.org/challenge/15097/task/69659519
![Screen Shot 2021-02-12 at 5 33 42 PM](https://user-images.githubusercontent.com/5851115/107829781-7573b900-6d58-11eb-9f8e-19f11957b5e6.png)

After the patch this is what a multiple sharp angle task looks like
https://maproulette.org/challenge/16923/task/83503558
![Screen Shot 2021-02-12 at 5 34 03 PM](https://user-images.githubusercontent.com/5851115/107829814-8290a800-6d58-11eb-81bf-eb8ec3a12a8a.png)
(Note that in this example the two sharp angles are VERY close to each other so it look on the map like only one anchor.