### PR TITLE
OverlappingEdgeCheck: One task per way

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheck.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
@@ -89,19 +88,22 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
             for (final Edge wayEdge : edges)
             {
                 Location start = null;
-                for (final Location end : wayEdge.asPolyLine()) {
-                    if (start != null) {
+                for (final Location end : wayEdge.asPolyLine())
+                {
+                    if (start != null)
+                    {
                         // we only have to check one end for intersecting edges
                         final Rectangle box = start.boxAround(Distance.meters(0));
                         // add all overlapping edges not yet flagged and not pedestrian areas
-                        overlappingItems.addAll(Iterables
-                                .stream(atlas.edgesIntersecting(box, Edge::isMainEdge))
-                                .filter(notEqual(wayEdge).and(this.notIn(wayEdge))
-                                        .and(this.overlapsSegment(start, end))
-                                        .and(this.filterPedestrianAreas ? edge -> !this.edgeIsArea(edge)
-                                                : this.notPedestrianAreas(wayEdge))
-                                        .and(this.haveSameLevels(wayEdge)))
-                                .collectToSet());
+                        overlappingItems.addAll(
+                                Iterables.stream(atlas.edgesIntersecting(box, Edge::isMainEdge))
+                                        .filter(notEqual(wayEdge).and(this.notIn(wayEdge))
+                                                .and(this.overlapsSegment(start, end))
+                                                .and(this.filterPedestrianAreas
+                                                        ? edge -> !this.edgeIsArea(edge)
+                                                        : this.notPedestrianAreas(wayEdge))
+                                                .and(this.haveSameLevels(wayEdge)))
+                                        .collectToSet());
                     }
                     start = end;
                 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheck.java
@@ -84,7 +84,8 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
 
         if (!this.isFlagged(object.getIdentifier()))
         {
-            final Set<AtlasObject> overlappingItems = this.getOverlappingItems(object.getAtlas(), edges);
+            final Set<AtlasObject> overlappingItems = this.getOverlappingItems(object.getAtlas(),
+                    edges);
 
             if (!overlappingItems.isEmpty())
             {
@@ -135,12 +136,13 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
 
     /**
      * Finds all overlapping {@link AtlasObject}s.
+     * 
      * @param atlas
-     *              The {@link Atlas} the object is associated with.
+     *            The {@link Atlas} the object is associated with.
      * @param edges
-     *              {@link Set} of {@link Edge}s of the way the original object is a part of.
+     *            {@link Set} of {@link Edge}s of the way the original object is a part of.
      */
-    private Set<AtlasObject> getOverlappingItems(Atlas atlas, Set<Edge> edges)
+    private Set<AtlasObject> getOverlappingItems(final Atlas atlas, final Set<Edge> edges)
     {
         final Set<AtlasObject> overlappingItems = new HashSet<>();
         for (final Edge wayEdge : edges)
@@ -153,15 +155,14 @@ public class OverlappingEdgeCheck extends BaseCheck<Long>
                     // we only have to check one end for intersecting edges
                     final Rectangle box = start.boxAround(Distance.meters(0));
                     // add all overlapping edges not yet flagged and not pedestrian areas
-                    overlappingItems.addAll(
-                            Iterables.stream(atlas.edgesIntersecting(box, Edge::isMainEdge))
-                                    .filter(notEqual(wayEdge).and(this.notIn(wayEdge))
-                                            .and(this.overlapsSegment(start, end))
-                                            .and(this.filterPedestrianAreas
-                                                    ? edge -> !this.edgeIsArea(edge)
-                                                    : this.notPedestrianAreas(wayEdge))
-                                            .and(this.haveSameLevels(wayEdge)))
-                                    .collectToSet());
+                    overlappingItems.addAll(Iterables
+                            .stream(atlas.edgesIntersecting(box, Edge::isMainEdge))
+                            .filter(notEqual(wayEdge).and(this.notIn(wayEdge))
+                                    .and(this.overlapsSegment(start, end))
+                                    .and(this.filterPedestrianAreas ? edge -> !this.edgeIsArea(edge)
+                                            : this.notPedestrianAreas(wayEdge))
+                                    .and(this.haveSameLevels(wayEdge)))
+                            .collectToSet());
                 }
                 start = end;
             }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/OverlappingEdgeCheckTest.java
@@ -62,7 +62,8 @@ public class OverlappingEdgeCheckTest
         final Atlas atlas = this.setup.getOverlappingHeadAtlas();
         this.verifier.actual(atlas, check);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(check -> verifyFlaggedGeometry(check, atlas));
+        this.verifier.verify(
+                check -> Assert.assertEquals(atlas.numberOfEdges(), check.getPolyLines().size()));
     }
 
     @Test
@@ -80,7 +81,8 @@ public class OverlappingEdgeCheckTest
         final Atlas atlas = this.setup.getOverlappingTailAtlas();
         this.verifier.actual(atlas, check);
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(check -> verifyFlaggedGeometry(check, atlas));
+        this.verifier.verify(
+                check -> Assert.assertEquals(atlas.numberOfEdges(), check.getPolyLines().size()));
     }
 
     @Test


### PR DESCRIPTION
### Description:

Resolves #501. For each edge we walk the way and gather all other edges. Looping over those edges we mark them as flagged and group all overlaps into one instruction.

### Potential Impact:

Reduces the number of tasks for this check by grouping up flagged edges that are part of the same OSM way into the same task.

### Unit Test Approach:

None added.

