### PR TITLE
[Check Improvement] EdgeCrossingEdgeCheck improvement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
       env:
         MERGE_TAG_GITHUB_SECRET_TOKEN: ${{ secrets.MERGE_TAG_GITHUB_SECRET_TOKEN }}
       run: .github/workflow_scripts/merge-dev-to-main.sh
-      if: ${{ secrets.MERGE_TAG_GITHUB_SECRET_TOKEN != "" }}
 
 # Sign and Publish
     - name: Decrypt GPG key (To sign artifacts)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       env:
         MERGE_TAG_GITHUB_SECRET_TOKEN: ${{ secrets.MERGE_TAG_GITHUB_SECRET_TOKEN }}
       run: .github/workflow_scripts/merge-dev-to-main.sh
+      if: ${{ secrets.MERGE_TAG_GITHUB_SECRET_TOKEN != "" }}
 
 # Sign and Publish
     - name: Decrypt GPG key (To sign artifacts)

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {
@@ -270,13 +270,7 @@
     }
   },
   "EdgeCrossingEdgeCheck": {
-    "enabled": true,
     "minimum.highway.type": "no",
-    "maximum.highway.type": "trunk",
-    "car.navigable": false,
-    "pedestrian.navigable": true,
-    "crossing.car.navigable": true,
-    "crossing.pedestrian.navigable": true,
     "challenge": {
       "description": "Tasks contain ways that do not have shared nodes but cross each other.",
       "blurb": "Crossing Ways",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -276,6 +276,7 @@
     "pedestrian.navigable": false,
     "crossing.car.navigable": true,
     "crossing.pedestrian.navigable": false,
+    "indoor.mapping": "indoor->*|highway->corridor,steps|level->*",
     "challenge": {
       "description": "Tasks contain ways that do not have shared nodes but cross each other.",
       "blurb": "Crossing Ways",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -271,11 +271,11 @@
   },
   "EdgeCrossingEdgeCheck": {
     "minimum.highway.type": "no",
-    "maximum.highway.type": "trunk",
+    "maximum.highway.type": "motorway",
     "car.navigable": true,
     "pedestrian.navigable": false,
     "crossing.car.navigable": true,
-    "crossing.pedestrian.navigable": true,
+    "crossing.pedestrian.navigable": false,
     "challenge": {
       "description": "Tasks contain ways that do not have shared nodes but cross each other.",
       "blurb": "Crossing Ways",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {
@@ -270,11 +270,10 @@
     }
   },
   "EdgeCrossingEdgeCheck": {
-    "enabled": true,
     "minimum.highway.type": "no",
     "maximum.highway.type": "trunk",
-    "car.navigable": false,
-    "pedestrian.navigable": true,
+    "car.navigable": true,
+    "pedestrian.navigable": false,
     "crossing.car.navigable": true,
     "crossing.pedestrian.navigable": true,
     "challenge": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
+    "enabled.value.default": false
   },
   "PoolSizeCheck": {
     "surface": {
@@ -270,7 +270,13 @@
     }
   },
   "EdgeCrossingEdgeCheck": {
+    "enabled": true,
     "minimum.highway.type": "no",
+    "maximum.highway.type": "trunk",
+    "car.navigable": false,
+    "pedestrian.navigable": true,
+    "crossing.car.navigable": true,
+    "crossing.pedestrian.navigable": true,
     "challenge": {
       "description": "Tasks contain ways that do not have shared nodes but cross each other.",
       "blurb": "Crossing Ways",

--- a/docs/checks/edgeCrossingEdgeCheck.md
+++ b/docs/checks/edgeCrossingEdgeCheck.md
@@ -16,7 +16,7 @@ Layer tag range defined in Atlas (min = -5, max = 5, exclude = 0) [TagInfo](http
 4. Line [id:486493202](https://www.openstreetmap.org/way/486493202) and [id:172811290](https://www.openstreetmap.org/way/172811290) are duplicates that intersect at [id:172811276](https://www.openstreetmap.org/way/172811276).
 
 #### Check configuration.
-1) "minimum.highway.type" and "maximum.highway.type" - specifying corridor of OSM ways that will be checks.
+1) "minimum.highway.type" and "maximum.highway.type" - specifying corridor of OSM ways to check.
 ##### Example 
 Check OSM ways that fall into following corridor highway=trunk to highway=primary.
 "minimum.highway.type": "primary",

--- a/docs/checks/edgeCrossingEdgeCheck.md
+++ b/docs/checks/edgeCrossingEdgeCheck.md
@@ -41,6 +41,7 @@ Check Pedestrian-Navigable ways crossing with Car-Navigable and Pedestrian Navig
 * Must be a `MainEdge`
 * Must not be an `Area`
 * Must have not contain `level` tag. `level` tag primary usage for indoor mapping. [Level Tag](https://wiki.openstreetmap.org/wiki/Key:level)
+* Must have not contain `indoor` tag. `indoor` tag primary usage for indoor mapping. [Indoor Mapping](https://wiki.openstreetmap.org/wiki/Indoor_Mapping#Proposed_Tags)  
 * The check flags Edges that cross each other if they do not share the same node of intersection, or if none of the Edges have a _layer_ Tag. In addition, this check flags all Edges that cross the "candidate edge" Edge that is currently inspected by the check. The check inspects every Edge, creating duplicated flags when there are multiple Edges invalidly crossing each other.
 
 To learn more about the code, please look at the comments in the source code for the check.

--- a/docs/checks/edgeCrossingEdgeCheck.md
+++ b/docs/checks/edgeCrossingEdgeCheck.md
@@ -11,6 +11,27 @@ The purpose of this check is to identify Edges intersecting another Edge(s) that
 3. Line [id:313458620](https://www.openstreetmap.org/way/313458620) and [id:554507231](https://www.openstreetmap.org/way/554507231) are overlapping duplicates.
 4. Line [id:486493202](https://www.openstreetmap.org/way/486493202) and [id:172811290](https://www.openstreetmap.org/way/172811290) are duplicates that intersect at [id:172811276](https://www.openstreetmap.org/way/172811276).
 
+#### Check configuration.
+1) "minimum.highway.type" and "maximum.highway.type" - specifying corridor of OSM ways that will be checks.
+##### Example 
+Check OSM ways that fall into following corridor highway=trunk to highway=primary.
+"minimum.highway.type": "primary",
+"maximum.highway.type": "trunk",
+2) "car.navigable", "pedestrian.navigable", "crossing.car.navigable", "crossing.pedestrian.navigable" - grouping highway types for Atlas object and crossing Atlas object. 
+Please refer to [Highway Tag](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/tags/HighwayTag.java) for highway grouping.
+##### Example 
+Check Car-Navigable ways crossing with Car-Navigable ways only (default).
+"car.navigable": true,
+"pedestrian.navigable": false,
+"crossing.car.navigable": true,
+"crossing.pedestrian.navigable": false
+##### Example
+Check Pedestrian-Navigable ways crossing with Car-Navigable and Pedestrian Navigable.
+"car.navigable": false,
+"pedestrian.navigable": true,
+"crossing.car.navigable": true,
+"crossing.pedestrian.navigable": true.
+
 #### Code Review
 
 The check ensures that the Atlas object being evaluated is a car-navigable Edge. The check flags Edges that cross each other if they do not share the same node of intersection, or if none of the Edges have a _layer_ Tag. In addition, this check flags all Edges that cross the "candidate edge" Edge that is currently inspected by the check). The check inspects every Edge, creating duplicated flags when there are multiple Edges invalidly crossing each other.

--- a/docs/checks/edgeCrossingEdgeCheck.md
+++ b/docs/checks/edgeCrossingEdgeCheck.md
@@ -4,8 +4,12 @@
 
 The purpose of this check is to identify Edges intersecting another Edge(s) that do not share the same Node (meaning they are not well-connected) nor have proper layer tagging on one of these Edge(s) (meaning there should be a _layer_ Tag for one of the Edges).
 
-#### Live Examples
+#### Layer Tag Default Assignment in Atlas.
+Layer tag range defined in Atlas (min = -5, max = 5, exclude = 0) [TagInfo](http://taginfo.openstreetmap.org/keys/layer#values), [OSM](http://wiki.openstreetmap.org/wiki/Layer")
+1. Tag Combination (Layer=0 and Bridge=yes) returns Layer=1 [reference](https://github.com/osmlab/atlas/blob/f6fd9d008ac6383b833f8cdf8d91827a79f60648/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java#L52).
+2. Tag Combination (Layer=0 and Tunnel=yes) returns Layer=-1 [reference](https://github.com/osmlab/atlas/blob/f6fd9d008ac6383b833f8cdf8d91827a79f60648/src/main/java/org/openstreetmap/atlas/tags/LayerTag.java#L52).
 
+#### Live Examples
 1. Line [id:245574716](https://www.openstreetmap.org/way/245574716) and [id:245574709](https://www.openstreetmap.org/way/245574709) do not share a node of intersection.
 2. Line [id:400798431](https://www.openstreetmap.org/way/400798431) and [id:386147030](https://www.openstreetmap.org/way/386147030) cross invalidly.
 3. Line [id:313458620](https://www.openstreetmap.org/way/313458620) and [id:554507231](https://www.openstreetmap.org/way/554507231) are overlapping duplicates.
@@ -33,8 +37,11 @@ Check Pedestrian-Navigable ways crossing with Car-Navigable and Pedestrian Navig
 "crossing.pedestrian.navigable": true.
 
 #### Code Review
-
-The check ensures that the Atlas object being evaluated is a car-navigable Edge. The check flags Edges that cross each other if they do not share the same node of intersection, or if none of the Edges have a _layer_ Tag. In addition, this check flags all Edges that cross the "candidate edge" Edge that is currently inspected by the check). The check inspects every Edge, creating duplicated flags when there are multiple Edges invalidly crossing each other.
+* The check ensures that the Atlas object being evaluated is a car-navigable or pedestrian-navigable Edge.
+* Must be a `MainEdge`
+* Must not be an `Area`
+* Must have not contain `level` tag. `level` tag primary usage for indoor mapping. [Level Tag](https://wiki.openstreetmap.org/wiki/Key:level)
+* The check flags Edges that cross each other if they do not share the same node of intersection, or if none of the Edges have a _layer_ Tag. In addition, this check flags all Edges that cross the "candidate edge" Edge that is currently inspected by the check. The check inspects every Edge, creating duplicated flags when there are multiple Edges invalidly crossing each other.
 
 To learn more about the code, please look at the comments in the source code for the check.
 [EdgeCrossingEdgeCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,7 +22,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.walker.EdgeWalker;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
-import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -32,7 +32,7 @@ import scala.Tuple2;
  * they should have an intersection location shared in both edges. Otherwise, their layer tag should
  * tell the difference.
  *
- * @author mkalender, gpogulsky, bbreithaupt
+ * @author mkalender, gpogulsky, bbreithaupt, vlemberg
  */
 public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
 {
@@ -42,7 +42,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private class EdgeCrossingEdgeWalker extends EdgeWalker
     {
         EdgeCrossingEdgeWalker(final Edge startingEdge,
-                final Function<Edge, Stream<Edge>> nextCandidates)
+                               final Function<Edge, Stream<Edge>> nextCandidates)
         {
             super(startingEdge, nextCandidates);
         }
@@ -55,10 +55,20 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private static final String INVALID_EDGE_FORMAT = "Edge {0,number,#} is crossing invalidly with {1}.";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_FORMAT,
             INVALID_EDGE_FORMAT);
+    private static final boolean CAR_NAVIGABLE_DEFAULT = true;
+    private static final boolean PEDESTRIAN_NAVIGABLE_DEFAULT = false;
+    private static final boolean CROSSING_CAR_NAVIGABLE_DEFAULT = true;
+    private static final boolean CROSSING_PEDESTRIAN_NAVIGABLE_DEFAULT = false;
     private static final String MINIMUM_HIGHWAY_DEFAULT = HighwayTag.NO.toString();
+    private static final String MAXIMUM_HIGHWAY_DEFAULT = HighwayTag.MOTORWAY.toString();
     private static final Long OSM_LAYER_DEFAULT = 0L;
     private static final long serialVersionUID = 2146863485833228593L;
+    private final boolean carNavigable;
+    private final boolean pedestrianNavigable;
+    private final boolean crossingCarNavigable;
+    private final boolean crossingPedestrianNavigable;
     private final HighwayTag minimumHighwayType;
+    private final HighwayTag maximumHighwayType;
 
     /**
      * Checks whether given {@link PolyLine}s can cross each other.
@@ -75,17 +85,16 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      *            Intersection {@link Location}
      * @return {@code true} if given {@link PolyLine}s can cross each other
      */
-    private static boolean canCross(final PolyLine edgeAsPolyLine, final Optional<Long> edgeLayer,
-            final PolyLine crossingEdgeAsPolyLine, final Optional<Long> crossingEdgeLayer,
-            final Location intersection)
+    private static boolean canCross(final PolyLine edgeAsPolyLine, final Long edgeLayer,
+                                    final PolyLine crossingEdgeAsPolyLine, final Long crossingEdgeLayer,
+                                    final Location intersection)
     {
         // If crossing edges have nodes at intersections points, then crossing is valid
         return edgeAsPolyLine.contains(intersection)
                 && crossingEdgeAsPolyLine.contains(intersection)
                 // Otherwise, if crossing edges has valid, but different tag values
                 // Then that is still a valid crossing
-                || edgeLayer.isPresent() && crossingEdgeLayer.isPresent()
-                        && !edgeLayer.get().equals(crossingEdgeLayer.get());
+                || !edgeLayer.equals(crossingEdgeLayer);
     }
 
     public EdgeCrossingEdgeCheck(final Configuration configuration)
@@ -93,12 +102,23 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
         super(configuration);
         this.minimumHighwayType = this.configurationValue(configuration, "minimum.highway.type",
                 MINIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
+        this.maximumHighwayType = this.configurationValue(configuration, "maximum.highway.type",
+                MAXIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
+        this.carNavigable = this.configurationValue(configuration, "car.navigable",
+                CAR_NAVIGABLE_DEFAULT);
+        this.pedestrianNavigable = this.configurationValue(configuration, "pedestrian.navigable",
+                PEDESTRIAN_NAVIGABLE_DEFAULT);
+        this.crossingCarNavigable = this.configurationValue(configuration, "crossing.car.navigable",
+                CROSSING_CAR_NAVIGABLE_DEFAULT);
+        this.crossingPedestrianNavigable = this.configurationValue(configuration,
+                "crossing.pedestrian.navigable", CROSSING_PEDESTRIAN_NAVIGABLE_DEFAULT);
     }
 
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TypePredicates.IS_EDGE.test(object) && this.isValidCrossingEdge(object);
+        return TypePredicates.IS_EDGE.test(object)
+                && this.isValidCrossingEdge(object, this.carNavigable, this.pedestrianNavigable);
     }
 
     @Override
@@ -118,8 +138,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                                     .collectEdges()))
                     .collect(Collectors.toList());
             edgeCrossPairs.add(new Tuple2<>((Edge) object, collectedEdges));
-            final Optional<Tuple2<Edge, Set<Edge>>> maxPair = edgeCrossPairs.stream().max(
-                    (entry1, entry2) -> Integer.compare(entry1._2().size(), entry2._2().size()));
+            final Optional<Tuple2<Edge, Set<Edge>>> maxPair = edgeCrossPairs.stream()
+                    .max(Comparator.comparingInt(entry -> entry._2().size()));
             if (maxPair.isPresent())
             {
                 final int maxSize = (maxPair.get()._2()).size();
@@ -130,9 +150,9 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                         .collect(Collectors.toList());
                 final Optional<Tuple2<Edge, Set<Edge>>> minIdentifierPair = maxEdgePairs.stream()
                         .reduce((edge1, edge2) ->
-                        // reduce to get the minimum osm identifier edge pair.
-                        edge1._1().getOsmIdentifier() <= edge2._1().getOsmIdentifier() ? edge1
-                                : edge2);
+                                // reduce to get the minimum osm identifier edge pair.
+                                edge1._1().getOsmIdentifier() <= edge2._1().getOsmIdentifier() ? edge1
+                                        : edge2);
                 if (minIdentifierPair.isPresent())
                 {
                     final Tuple2<Edge, Set<Edge>> minPair = minIdentifierPair.get();
@@ -162,7 +182,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      * @return newly created edge cross check glag including crossing edges locations.
      */
     private Optional<CheckFlag> createEdgeCrossCheckFlag(final Edge edge,
-            final Set<Edge> collectedEdges)
+                                                         final Set<Edge> collectedEdges)
     {
         final CheckFlag newFlag = new CheckFlag(this.getTaskIdentifier(edge));
         this.markAsFlagged(edge.getIdentifier());
@@ -176,6 +196,40 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
         newFlag.addPoints(points);
         newFlag.addObject(edge);
         return Optional.of(newFlag);
+    }
+
+    /**
+     * Check if {@link Edge} highway tag is vehicle or pedestrian navigable.
+     *
+     * @param edge
+     *            Atlas object.
+     * @param carNav
+     *            Car Navigable Highway Type.
+     * @param pedestrianNav
+     *            Pedestrian Navigable Highway Type.
+     * @return {@code true} if {@link Edge} is vehicle or pedestrian navigable.
+     */
+    private boolean getCrossingHighwayType(final Edge edge, final boolean carNav,
+                                           final boolean pedestrianNav)
+    {
+        if (carNav && pedestrianNav)
+        {
+            return HighwayTag.isCarNavigableHighway(edge)
+                    || HighwayTag.isPedestrianNavigableHighway(edge);
+        }
+        else if (carNav)
+        {
+            return HighwayTag.isCarNavigableHighway(edge);
+        }
+        else if (pedestrianNav)
+        {
+            return HighwayTag.isPedestrianNavigableHighway(edge);
+        }
+        else
+        {
+            return !HighwayTag.isCarNavigableHighway(edge)
+                    && !HighwayTag.isPedestrianNavigableHighway(edge);
+        }
     }
 
     /**
@@ -207,16 +261,15 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             final PolyLine edgeAsPolyLine = edge.asPolyLine();
             final Rectangle edgeBounds = edge.bounds();
             // If layer tag is present use its value, else use the OSM default
-            final Optional<Long> edgeLayer = Validators.hasValuesFor(edge, LayerTag.class)
-                    ? LayerTag.getTaggedValue(edge)
-                    : Optional.of(OSM_LAYER_DEFAULT);
+            final Long edgeLayer = LayerTag.getTaggedOrImpliedValue(edge, OSM_LAYER_DEFAULT);
 
             // Retrieve crossing edges
             final Atlas atlas = edge.getAtlas();
             return Iterables.asList(atlas.edgesIntersecting(edgeBounds,
                     // filter out the same edge and non-valid crossing edges
                     crossingEdge -> edge.getIdentifier() != crossingEdge.getIdentifier()
-                            && this.isValidCrossingEdge(crossingEdge)))
+                            && this.isValidCrossingEdge(crossingEdge, this.crossingCarNavigable,
+                            this.crossingPedestrianNavigable)))
                     .stream()
                     .filter(crossingEdge -> crossingEdge.getOsmIdentifier() != edge
                             .getOsmIdentifier())
@@ -231,10 +284,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                     .filter(crossingEdge ->
                     {
                         final PolyLine crossingEdgeAsPolyLine = crossingEdge.asPolyLine();
-                        final Optional<Long> crossingEdgeLayer = Validators
-                                .hasValuesFor(crossingEdge, LayerTag.class)
-                                        ? LayerTag.getTaggedValue(crossingEdge)
-                                        : Optional.of(OSM_LAYER_DEFAULT);
+                        final Long crossingEdgeLayer = LayerTag
+                                .getTaggedOrImpliedValue(crossingEdge, OSM_LAYER_DEFAULT);
                         return edgeAsPolyLine.intersections(crossingEdgeAsPolyLine).stream()
                                 .anyMatch(intersection -> !canCross(edgeAsPolyLine, edgeLayer,
                                         crossingEdgeAsPolyLine, crossingEdgeLayer, intersection));
@@ -250,7 +301,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      *            {@link AtlasObject} to test
      * @return {@code true} if given {@link AtlasObject} object is a valid crossing edge
      */
-    private boolean isValidCrossingEdge(final AtlasObject object)
+    private boolean isValidCrossingEdge(final AtlasObject object, final boolean carNav,
+                                        final boolean pedNav)
     {
         if (Edge.isMainEdgeIdentifier(object.getIdentifier())
                 && !TagPredicates.IS_AREA.test(object))
@@ -259,9 +311,11 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             if (highway.isPresent())
             {
                 final HighwayTag highwayTag = highway.get();
-                return HighwayTag.isCarNavigableHighway(highwayTag)
+                return this.getCrossingHighwayType((Edge) object, carNav, pedNav)
                         && !HighwayTag.CROSSING.equals(highwayTag)
-                        && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType);
+                        && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType)
+                        && highwayTag.isLessImportantThanOrEqualTo(this.maximumHighwayType);
+
             }
         }
         return false;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -1,7 +1,6 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +21,7 @@ import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.walker.EdgeWalker;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -32,7 +32,7 @@ import scala.Tuple2;
  * they should have an intersection location shared in both edges. Otherwise, their layer tag should
  * tell the difference.
  *
- * @author mkalender, gpogulsky, bbreithaupt, vlemberg
+ * @author mkalender, gpogulsky, bbreithaupt
  */
 public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
 {
@@ -42,7 +42,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private class EdgeCrossingEdgeWalker extends EdgeWalker
     {
         EdgeCrossingEdgeWalker(final Edge startingEdge,
-                               final Function<Edge, Stream<Edge>> nextCandidates)
+                final Function<Edge, Stream<Edge>> nextCandidates)
         {
             super(startingEdge, nextCandidates);
         }
@@ -55,20 +55,10 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private static final String INVALID_EDGE_FORMAT = "Edge {0,number,#} is crossing invalidly with {1}.";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_FORMAT,
             INVALID_EDGE_FORMAT);
-    private static final boolean CAR_NAVIGABLE_DEFAULT = true;
-    private static final boolean PEDESTRIAN_NAVIGABLE_DEFAULT = false;
-    private static final boolean CROSSING_CAR_NAVIGABLE_DEFAULT = true;
-    private static final boolean CROSSING_PEDESTRIAN_NAVIGABLE_DEFAULT = false;
     private static final String MINIMUM_HIGHWAY_DEFAULT = HighwayTag.NO.toString();
-    private static final String MAXIMUM_HIGHWAY_DEFAULT = HighwayTag.MOTORWAY.toString();
     private static final Long OSM_LAYER_DEFAULT = 0L;
     private static final long serialVersionUID = 2146863485833228593L;
-    private final boolean carNavigable;
-    private final boolean pedestrianNavigable;
-    private final boolean crossingCarNavigable;
-    private final boolean crossingPedestrianNavigable;
     private final HighwayTag minimumHighwayType;
-    private final HighwayTag maximumHighwayType;
 
     /**
      * Checks whether given {@link PolyLine}s can cross each other.
@@ -85,16 +75,17 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      *            Intersection {@link Location}
      * @return {@code true} if given {@link PolyLine}s can cross each other
      */
-    private static boolean canCross(final PolyLine edgeAsPolyLine, final Long edgeLayer,
-                                    final PolyLine crossingEdgeAsPolyLine, final Long crossingEdgeLayer,
-                                    final Location intersection)
+    private static boolean canCross(final PolyLine edgeAsPolyLine, final Optional<Long> edgeLayer,
+            final PolyLine crossingEdgeAsPolyLine, final Optional<Long> crossingEdgeLayer,
+            final Location intersection)
     {
         // If crossing edges have nodes at intersections points, then crossing is valid
         return edgeAsPolyLine.contains(intersection)
                 && crossingEdgeAsPolyLine.contains(intersection)
                 // Otherwise, if crossing edges has valid, but different tag values
                 // Then that is still a valid crossing
-                || !edgeLayer.equals(crossingEdgeLayer);
+                || edgeLayer.isPresent() && crossingEdgeLayer.isPresent()
+                        && !edgeLayer.get().equals(crossingEdgeLayer.get());
     }
 
     public EdgeCrossingEdgeCheck(final Configuration configuration)
@@ -102,23 +93,12 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
         super(configuration);
         this.minimumHighwayType = this.configurationValue(configuration, "minimum.highway.type",
                 MINIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
-        this.maximumHighwayType = this.configurationValue(configuration, "maximum.highway.type",
-                MAXIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
-        this.carNavigable = this.configurationValue(configuration, "car.navigable",
-                CAR_NAVIGABLE_DEFAULT);
-        this.pedestrianNavigable = this.configurationValue(configuration, "pedestrian.navigable",
-                PEDESTRIAN_NAVIGABLE_DEFAULT);
-        this.crossingCarNavigable = this.configurationValue(configuration, "crossing.car.navigable",
-                CROSSING_CAR_NAVIGABLE_DEFAULT);
-        this.crossingPedestrianNavigable = this.configurationValue(configuration,
-                "crossing.pedestrian.navigable", CROSSING_PEDESTRIAN_NAVIGABLE_DEFAULT);
     }
 
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TypePredicates.IS_EDGE.test(object)
-                && this.isValidCrossingEdge(object, this.carNavigable, this.pedestrianNavigable);
+        return TypePredicates.IS_EDGE.test(object) && this.isValidCrossingEdge(object);
     }
 
     @Override
@@ -138,8 +118,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                                     .collectEdges()))
                     .collect(Collectors.toList());
             edgeCrossPairs.add(new Tuple2<>((Edge) object, collectedEdges));
-            final Optional<Tuple2<Edge, Set<Edge>>> maxPair = edgeCrossPairs.stream()
-                    .max(Comparator.comparingInt(entry -> entry._2().size()));
+            final Optional<Tuple2<Edge, Set<Edge>>> maxPair = edgeCrossPairs.stream().max(
+                    (entry1, entry2) -> Integer.compare(entry1._2().size(), entry2._2().size()));
             if (maxPair.isPresent())
             {
                 final int maxSize = (maxPair.get()._2()).size();
@@ -150,9 +130,9 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                         .collect(Collectors.toList());
                 final Optional<Tuple2<Edge, Set<Edge>>> minIdentifierPair = maxEdgePairs.stream()
                         .reduce((edge1, edge2) ->
-                                // reduce to get the minimum osm identifier edge pair.
-                                edge1._1().getOsmIdentifier() <= edge2._1().getOsmIdentifier() ? edge1
-                                        : edge2);
+                        // reduce to get the minimum osm identifier edge pair.
+                        edge1._1().getOsmIdentifier() <= edge2._1().getOsmIdentifier() ? edge1
+                                : edge2);
                 if (minIdentifierPair.isPresent())
                 {
                     final Tuple2<Edge, Set<Edge>> minPair = minIdentifierPair.get();
@@ -182,7 +162,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      * @return newly created edge cross check glag including crossing edges locations.
      */
     private Optional<CheckFlag> createEdgeCrossCheckFlag(final Edge edge,
-                                                         final Set<Edge> collectedEdges)
+            final Set<Edge> collectedEdges)
     {
         final CheckFlag newFlag = new CheckFlag(this.getTaskIdentifier(edge));
         this.markAsFlagged(edge.getIdentifier());
@@ -196,40 +176,6 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
         newFlag.addPoints(points);
         newFlag.addObject(edge);
         return Optional.of(newFlag);
-    }
-
-    /**
-     * Check if {@link Edge} highway tag is vehicle or pedestrian navigable.
-     *
-     * @param edge
-     *            Atlas object.
-     * @param carNav
-     *            Car Navigable Highway Type.
-     * @param pedestrianNav
-     *            Pedestrian Navigable Highway Type.
-     * @return {@code true} if {@link Edge} is vehicle or pedestrian navigable.
-     */
-    private boolean getCrossingHighwayType(final Edge edge, final boolean carNav,
-                                           final boolean pedestrianNav)
-    {
-        if (carNav && pedestrianNav)
-        {
-            return HighwayTag.isCarNavigableHighway(edge)
-                    || HighwayTag.isPedestrianNavigableHighway(edge);
-        }
-        else if (carNav)
-        {
-            return HighwayTag.isCarNavigableHighway(edge);
-        }
-        else if (pedestrianNav)
-        {
-            return HighwayTag.isPedestrianNavigableHighway(edge);
-        }
-        else
-        {
-            return !HighwayTag.isCarNavigableHighway(edge)
-                    && !HighwayTag.isPedestrianNavigableHighway(edge);
-        }
     }
 
     /**
@@ -261,15 +207,16 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             final PolyLine edgeAsPolyLine = edge.asPolyLine();
             final Rectangle edgeBounds = edge.bounds();
             // If layer tag is present use its value, else use the OSM default
-            final Long edgeLayer = LayerTag.getTaggedOrImpliedValue(edge, OSM_LAYER_DEFAULT);
+            final Optional<Long> edgeLayer = Validators.hasValuesFor(edge, LayerTag.class)
+                    ? LayerTag.getTaggedValue(edge)
+                    : Optional.of(OSM_LAYER_DEFAULT);
 
             // Retrieve crossing edges
             final Atlas atlas = edge.getAtlas();
             return Iterables.asList(atlas.edgesIntersecting(edgeBounds,
                     // filter out the same edge and non-valid crossing edges
                     crossingEdge -> edge.getIdentifier() != crossingEdge.getIdentifier()
-                            && this.isValidCrossingEdge(crossingEdge, this.crossingCarNavigable,
-                            this.crossingPedestrianNavigable)))
+                            && this.isValidCrossingEdge(crossingEdge)))
                     .stream()
                     .filter(crossingEdge -> crossingEdge.getOsmIdentifier() != edge
                             .getOsmIdentifier())
@@ -284,8 +231,10 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                     .filter(crossingEdge ->
                     {
                         final PolyLine crossingEdgeAsPolyLine = crossingEdge.asPolyLine();
-                        final Long crossingEdgeLayer = LayerTag
-                                .getTaggedOrImpliedValue(crossingEdge, OSM_LAYER_DEFAULT);
+                        final Optional<Long> crossingEdgeLayer = Validators
+                                .hasValuesFor(crossingEdge, LayerTag.class)
+                                        ? LayerTag.getTaggedValue(crossingEdge)
+                                        : Optional.of(OSM_LAYER_DEFAULT);
                         return edgeAsPolyLine.intersections(crossingEdgeAsPolyLine).stream()
                                 .anyMatch(intersection -> !canCross(edgeAsPolyLine, edgeLayer,
                                         crossingEdgeAsPolyLine, crossingEdgeLayer, intersection));
@@ -301,8 +250,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      *            {@link AtlasObject} to test
      * @return {@code true} if given {@link AtlasObject} object is a valid crossing edge
      */
-    private boolean isValidCrossingEdge(final AtlasObject object, final boolean carNav,
-                                        final boolean pedNav)
+    private boolean isValidCrossingEdge(final AtlasObject object)
     {
         if (Edge.isMainEdgeIdentifier(object.getIdentifier())
                 && !TagPredicates.IS_AREA.test(object))
@@ -311,11 +259,9 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             if (highway.isPresent())
             {
                 final HighwayTag highwayTag = highway.get();
-                return this.getCrossingHighwayType((Edge) object, carNav, pedNav)
+                return HighwayTag.isCarNavigableHighway(highwayTag)
                         && !HighwayTag.CROSSING.equals(highwayTag)
-                        && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType)
-                        && highwayTag.isLessImportantThanOrEqualTo(this.maximumHighwayType);
-
+                        && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType);
             }
         }
         return false;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -200,40 +200,6 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     }
 
     /**
-     * Check if {@link Edge} highway tag is vehicle or pedestrian navigable.
-     *
-     * @param edge
-     *            Atlas object.
-     * @param carNav
-     *            Car Navigable Highway Type.
-     * @param pedestrianNav
-     *            Pedestrian Navigable Highway Type.
-     * @return {@code true} if {@link Edge} is vehicle or pedestrian navigable.
-     */
-    private boolean getCrossingHighwayType(final Edge edge, final boolean carNav,
-            final boolean pedestrianNav)
-    {
-        if (carNav && pedestrianNav)
-        {
-            return HighwayTag.isCarNavigableHighway(edge)
-                    || HighwayTag.isPedestrianNavigableHighway(edge);
-        }
-        else if (carNav)
-        {
-            return HighwayTag.isCarNavigableHighway(edge);
-        }
-        else if (pedestrianNav)
-        {
-            return HighwayTag.isPedestrianNavigableHighway(edge);
-        }
-        else
-        {
-            return !HighwayTag.isCarNavigableHighway(edge)
-                    && !HighwayTag.isPedestrianNavigableHighway(edge);
-        }
-    }
-
-    /**
      * This function returns set of intersections locations for given params.
      *
      * @param edge1
@@ -295,6 +261,30 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     }
 
     /**
+     * Check if {@link Edge} highway tag is vehicle or pedestrian navigable.
+     *
+     * @param edge
+     *            Atlas object.
+     * @param carNavigable
+     *            Car Navigable Highway Type.
+     * @param pedestrianNavigable
+     *            Pedestrian Navigable Highway Type.
+     * @return {@code true} if {@link Edge} is vehicle or pedestrian navigable.
+     */
+    private boolean isCrossingHighwayType(final Edge edge, final boolean carNavigable,
+            final boolean pedestrianNavigable)
+    {
+        return (carNavigable && pedestrianNavigable
+                && (HighwayTag.isCarNavigableHighway(edge)
+                        || HighwayTag.isPedestrianNavigableHighway(edge)))
+                || (carNavigable && HighwayTag.isCarNavigableHighway(edge)
+                        || (pedestrianNavigable && HighwayTag.isPedestrianNavigableHighway(edge)))
+                || (!carNavigable && !pedestrianNavigable
+                        && (!HighwayTag.isCarNavigableHighway(edge)
+                                || !HighwayTag.isPedestrianNavigableHighway(edge)));
+    }
+
+    /**
      * Validates given {@link AtlasObject} (assumed to be an {@link Edge}) whether it is a valid
      * crossing edge or not
      *
@@ -302,8 +292,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      *            {@link AtlasObject} to test
      * @return {@code true} if given {@link AtlasObject} object is a valid crossing edge
      */
-    private boolean isValidCrossingEdge(final AtlasObject object, final boolean carNav,
-            final boolean pedNav)
+    private boolean isValidCrossingEdge(final AtlasObject object, final boolean carNavigable,
+            final boolean pedNavigable)
     {
         if (((Edge) object).isMainEdge() && object.getTag(AreaTag.KEY).isEmpty()
                 && object.getTag(LevelTag.KEY).isEmpty())
@@ -312,7 +302,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             if (highway.isPresent())
             {
                 final HighwayTag highwayTag = highway.get();
-                return this.getCrossingHighwayType((Edge) object, carNav, pedNav)
+                return this.isCrossingHighwayType((Edge) object, carNavigable, pedNavigable)
                         && !HighwayTag.CROSSING.equals(highwayTag)
                         && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType)
                         && highwayTag.isLessImportantThanOrEqualTo(this.maximumHighwayType);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -1,6 +1,7 @@
 package org.openstreetmap.atlas.checks.validation.intersections;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -21,7 +22,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.walker.EdgeWalker;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
-import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -32,7 +32,7 @@ import scala.Tuple2;
  * they should have an intersection location shared in both edges. Otherwise, their layer tag should
  * tell the difference.
  *
- * @author mkalender, gpogulsky, bbreithaupt
+ * @author mkalender, gpogulsky, bbreithaupt, vlemberg
  */
 public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
 {
@@ -55,10 +55,20 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private static final String INVALID_EDGE_FORMAT = "Edge {0,number,#} is crossing invalidly with {1}.";
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_FORMAT,
             INVALID_EDGE_FORMAT);
+    private static final boolean CAR_NAVIGABLE_DEFAULT = true;
+    private static final boolean PEDESTRIAN_NAVIGABLE_DEFAULT = false;
+    private static final boolean CROSSING_CAR_NAVIGABLE_DEFAULT = true;
+    private static final boolean CROSSING_PEDESTRIAN_NAVIGABLE_DEFAULT = false;
     private static final String MINIMUM_HIGHWAY_DEFAULT = HighwayTag.NO.toString();
+    private static final String MAXIMUM_HIGHWAY_DEFAULT = HighwayTag.MOTORWAY.toString();
     private static final Long OSM_LAYER_DEFAULT = 0L;
     private static final long serialVersionUID = 2146863485833228593L;
+    private final boolean carNavigable;
+    private final boolean pedestrianNavigable;
+    private final boolean crossingCarNavigable;
+    private final boolean crossingPedestrianNavigable;
     private final HighwayTag minimumHighwayType;
+    private final HighwayTag maximumHighwayType;
 
     /**
      * Checks whether given {@link PolyLine}s can cross each other.
@@ -75,8 +85,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      *            Intersection {@link Location}
      * @return {@code true} if given {@link PolyLine}s can cross each other
      */
-    private static boolean canCross(final PolyLine edgeAsPolyLine, final Optional<Long> edgeLayer,
-            final PolyLine crossingEdgeAsPolyLine, final Optional<Long> crossingEdgeLayer,
+    private static boolean canCross(final PolyLine edgeAsPolyLine, final Long edgeLayer,
+            final PolyLine crossingEdgeAsPolyLine, final Long crossingEdgeLayer,
             final Location intersection)
     {
         // If crossing edges have nodes at intersections points, then crossing is valid
@@ -84,8 +94,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                 && crossingEdgeAsPolyLine.contains(intersection)
                 // Otherwise, if crossing edges has valid, but different tag values
                 // Then that is still a valid crossing
-                || edgeLayer.isPresent() && crossingEdgeLayer.isPresent()
-                        && !edgeLayer.get().equals(crossingEdgeLayer.get());
+                || !edgeLayer.equals(crossingEdgeLayer);
     }
 
     public EdgeCrossingEdgeCheck(final Configuration configuration)
@@ -93,12 +102,23 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
         super(configuration);
         this.minimumHighwayType = this.configurationValue(configuration, "minimum.highway.type",
                 MINIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
+        this.maximumHighwayType = this.configurationValue(configuration, "maximum.highway.type",
+                MAXIMUM_HIGHWAY_DEFAULT, str -> Enum.valueOf(HighwayTag.class, str.toUpperCase()));
+        this.carNavigable = this.configurationValue(configuration, "car.navigable",
+                CAR_NAVIGABLE_DEFAULT);
+        this.pedestrianNavigable = this.configurationValue(configuration, "pedestrian.navigable",
+                PEDESTRIAN_NAVIGABLE_DEFAULT);
+        this.crossingCarNavigable = this.configurationValue(configuration, "crossing.car.navigable",
+                CROSSING_CAR_NAVIGABLE_DEFAULT);
+        this.crossingPedestrianNavigable = this.configurationValue(configuration,
+                "crossing.pedestrian.navigable", CROSSING_PEDESTRIAN_NAVIGABLE_DEFAULT);
     }
 
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TypePredicates.IS_EDGE.test(object) && this.isValidCrossingEdge(object);
+        return TypePredicates.IS_EDGE.test(object)
+                && this.isValidCrossingEdge(object, this.carNavigable, this.pedestrianNavigable);
     }
 
     @Override
@@ -118,8 +138,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                                     .collectEdges()))
                     .collect(Collectors.toList());
             edgeCrossPairs.add(new Tuple2<>((Edge) object, collectedEdges));
-            final Optional<Tuple2<Edge, Set<Edge>>> maxPair = edgeCrossPairs.stream().max(
-                    (entry1, entry2) -> Integer.compare(entry1._2().size(), entry2._2().size()));
+            final Optional<Tuple2<Edge, Set<Edge>>> maxPair = edgeCrossPairs.stream()
+                    .max(Comparator.comparingInt(entry -> entry._2().size()));
             if (maxPair.isPresent())
             {
                 final int maxSize = (maxPair.get()._2()).size();
@@ -179,6 +199,40 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     }
 
     /**
+     * Check if {@link Edge} highway tag is vehicle or pedestrian navigable.
+     *
+     * @param edge
+     *            Atlas object.
+     * @param carNav
+     *            Car Navigable Highway Type.
+     * @param pedestrianNav
+     *            Pedestrian Navigable Highway Type.
+     * @return {@code true} if {@link Edge} is vehicle or pedestrian navigable.
+     */
+    private boolean getCrossingHighwayType(final Edge edge, final boolean carNav,
+            final boolean pedestrianNav)
+    {
+        if (carNav && pedestrianNav)
+        {
+            return HighwayTag.isCarNavigableHighway(edge)
+                    || HighwayTag.isPedestrianNavigableHighway(edge);
+        }
+        else if (carNav)
+        {
+            return HighwayTag.isCarNavigableHighway(edge);
+        }
+        else if (pedestrianNav)
+        {
+            return HighwayTag.isPedestrianNavigableHighway(edge);
+        }
+        else
+        {
+            return !HighwayTag.isCarNavigableHighway(edge)
+                    && !HighwayTag.isPedestrianNavigableHighway(edge);
+        }
+    }
+
+    /**
      * This function returns set of intersections locations for given params.
      *
      * @param edge1
@@ -207,16 +261,15 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             final PolyLine edgeAsPolyLine = edge.asPolyLine();
             final Rectangle edgeBounds = edge.bounds();
             // If layer tag is present use its value, else use the OSM default
-            final Optional<Long> edgeLayer = Validators.hasValuesFor(edge, LayerTag.class)
-                    ? LayerTag.getTaggedValue(edge)
-                    : Optional.of(OSM_LAYER_DEFAULT);
+            final Long edgeLayer = LayerTag.getTaggedOrImpliedValue(edge, OSM_LAYER_DEFAULT);
 
             // Retrieve crossing edges
             final Atlas atlas = edge.getAtlas();
             return Iterables.asList(atlas.edgesIntersecting(edgeBounds,
                     // filter out the same edge and non-valid crossing edges
                     crossingEdge -> edge.getIdentifier() != crossingEdge.getIdentifier()
-                            && this.isValidCrossingEdge(crossingEdge)))
+                            && this.isValidCrossingEdge(crossingEdge, this.crossingCarNavigable,
+                                    this.crossingPedestrianNavigable)))
                     .stream()
                     .filter(crossingEdge -> crossingEdge.getOsmIdentifier() != edge
                             .getOsmIdentifier())
@@ -231,10 +284,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
                     .filter(crossingEdge ->
                     {
                         final PolyLine crossingEdgeAsPolyLine = crossingEdge.asPolyLine();
-                        final Optional<Long> crossingEdgeLayer = Validators
-                                .hasValuesFor(crossingEdge, LayerTag.class)
-                                        ? LayerTag.getTaggedValue(crossingEdge)
-                                        : Optional.of(OSM_LAYER_DEFAULT);
+                        final Long crossingEdgeLayer = LayerTag
+                                .getTaggedOrImpliedValue(crossingEdge, OSM_LAYER_DEFAULT);
                         return edgeAsPolyLine.intersections(crossingEdgeAsPolyLine).stream()
                                 .anyMatch(intersection -> !canCross(edgeAsPolyLine, edgeLayer,
                                         crossingEdgeAsPolyLine, crossingEdgeLayer, intersection));
@@ -250,7 +301,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      *            {@link AtlasObject} to test
      * @return {@code true} if given {@link AtlasObject} object is a valid crossing edge
      */
-    private boolean isValidCrossingEdge(final AtlasObject object)
+    private boolean isValidCrossingEdge(final AtlasObject object, final boolean carNav,
+            final boolean pedNav)
     {
         if (Edge.isMainEdgeIdentifier(object.getIdentifier())
                 && !TagPredicates.IS_AREA.test(object))
@@ -259,9 +311,11 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             if (highway.isPresent())
             {
                 final HighwayTag highwayTag = highway.get();
-                return HighwayTag.isCarNavigableHighway(highwayTag)
+                return this.getCrossingHighwayType((Edge) object, carNav, pedNav)
                         && !HighwayTag.CROSSING.equals(highwayTag)
-                        && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType);
+                        && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType)
+                        && highwayTag.isLessImportantThanOrEqualTo(this.maximumHighwayType);
+
             }
         }
         return false;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -9,7 +9,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
 import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
@@ -20,8 +19,10 @@ import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
 import org.openstreetmap.atlas.geography.atlas.walker.EdgeWalker;
+import org.openstreetmap.atlas.tags.AreaTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.LayerTag;
+import org.openstreetmap.atlas.tags.LevelTag;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
@@ -304,8 +305,8 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
     private boolean isValidCrossingEdge(final AtlasObject object, final boolean carNav,
             final boolean pedNav)
     {
-        if (Edge.isMainEdgeIdentifier(object.getIdentifier())
-                && !TagPredicates.IS_AREA.test(object))
+        if (((Edge) object).isMainEdge() && object.getTag(AreaTag.KEY).isEmpty()
+                && object.getTag(LevelTag.KEY).isEmpty())
         {
             final Optional<HighwayTag> highway = HighwayTag.highwayTag(object);
             if (highway.isPresent())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheck.java
@@ -293,7 +293,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
      * @return {@code true} if given {@link AtlasObject} object is a valid crossing edge
      */
     private boolean isValidCrossingEdge(final AtlasObject object, final boolean carNavigable,
-            final boolean pedNavigable)
+            final boolean pedestrianNavigable)
     {
         if (((Edge) object).isMainEdge() && object.getTag(AreaTag.KEY).isEmpty()
                 && object.getTag(LevelTag.KEY).isEmpty())
@@ -302,7 +302,7 @@ public class EdgeCrossingEdgeCheck extends BaseCheck<Long>
             if (highway.isPresent())
             {
                 final HighwayTag highwayTag = highway.get();
-                return this.isCrossingHighwayType((Edge) object, carNavigable, pedNavigable)
+                return this.isCrossingHighwayType((Edge) object, carNavigable, pedestrianNavigable)
                         && !HighwayTag.CROSSING.equals(highwayTag)
                         && highwayTag.isMoreImportantThanOrEqualTo(this.minimumHighwayType)
                         && highwayTag.isLessImportantThanOrEqualTo(this.maximumHighwayType);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -8,7 +8,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * @author mkalender, bbreithaupt
+ * @author mkalender, bbreithaupt, vlemberg
  */
 public class EdgeCrossingEdgeCheckTest
 {
@@ -22,9 +22,30 @@ public class EdgeCrossingEdgeCheckTest
     public void testInvalidCrossingItemsAtlas()
     {
         this.verifier.actual(this.setup.invalidCrossingItemsAtlas(),
-                new EdgeCrossingEdgeCheck(this.configuration));
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":true}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingItemsAtlasCarNavigationOnly()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPed(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingItemsAtlasPedestrianNavigationOnly()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPed(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":true,\"crossing.car.navigable\":false,\"crossing.pedestrian.navigable\":true}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -42,7 +63,7 @@ public class EdgeCrossingEdgeCheckTest
                 new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.verifyNotEmpty();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -8,7 +8,7 @@ import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedC
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
- * @author mkalender, bbreithaupt, vlemberg
+ * @author mkalender, bbreithaupt
  */
 public class EdgeCrossingEdgeCheckTest
 {
@@ -22,30 +22,9 @@ public class EdgeCrossingEdgeCheckTest
     public void testInvalidCrossingItemsAtlas()
     {
         this.verifier.actual(this.setup.invalidCrossingItemsAtlas(),
-                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":true}}")));
+                new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
-    }
-
-    @Test
-    public void testInvalidCrossingItemsAtlasCarNavigationOnly()
-    {
-        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPed(),
-                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false}}")));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
-    }
-
-    @Test
-    public void testInvalidCrossingItemsAtlasPedestrianNavigationOnly()
-    {
-        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPed(),
-                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":true,\"crossing.car.navigable\":false,\"crossing.pedestrian.navigable\":true}}")));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -63,7 +42,7 @@ public class EdgeCrossingEdgeCheckTest
                 new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.verifyNotEmpty();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -19,6 +19,18 @@ public class EdgeCrossingEdgeCheckTest
     private final Configuration configuration = ConfigurationResolver.emptyConfiguration();
 
     @Test
+    public void testInvalidCrossingCarNavigation()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
     public void testInvalidCrossingItemsAtlas()
     {
         this.verifier.actual(this.setup.invalidCrossingItemsAtlas(),
@@ -77,18 +89,6 @@ public class EdgeCrossingEdgeCheckTest
     }
 
     @Test
-    public void testInvalidCrossingItemsAtlasCarNavigationOnly()
-    {
-        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
-                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false,"
-                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
-
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
-    }
-
-    @Test
     public void testInvalidCrossingItemsAtlasIndoorMapping()
     {
         this.verifier.actual(this.setup.invalidCrossingItemsAtlasIndoorMapping(),
@@ -96,17 +96,6 @@ public class EdgeCrossingEdgeCheckTest
                         "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":true,"
                                 + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
         this.verifier.verifyEmpty();
-    }
-
-    @Test
-    public void testInvalidCrossingItemsAtlasPedestrianNavigationOnly()
-    {
-        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
-                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":true,\"crossing.car.navigable\":false,\"crossing.pedestrian.navigable\":true,"
-                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -145,6 +134,17 @@ public class EdgeCrossingEdgeCheckTest
         this.verifier.verifyNotEmpty();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingPedestrianNavigation()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":true,\"crossing.car.navigable\":false,\"crossing.pedestrian.navigable\":true,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -23,27 +23,88 @@ public class EdgeCrossingEdgeCheckTest
     {
         this.verifier.actual(this.setup.invalidCrossingItemsAtlas(),
                 new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":true}}")));
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
     }
 
     @Test
-    public void testInvalidCrossingItemsAtlasCarNavigationOnly()
+    public void testInvalidCrossingItemsAtlasArea()
     {
-        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPed(),
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasArea(),
                 new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false}}")));
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test
+    public void testInvalidCrossingItemsAtlasCarAndPedestrian()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":true,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingItemsAtlasCarAndPedestrianCase2()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
+    }
+
+    @Test
+    public void testInvalidCrossingItemsAtlasCarAndPedestrianCase3()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":true,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testInvalidCrossingItemsAtlasCarNavigationOnly()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":false,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingItemsAtlasIndoorMapping()
+    {
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasIndoorMapping(),
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":true,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testInvalidCrossingItemsAtlasPedestrianNavigationOnly()
     {
-        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPed(),
+        this.verifier.actual(this.setup.invalidCrossingItemsAtlasCarPedestrian(),
                 new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
-                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":true,\"crossing.car.navigable\":false,\"crossing.pedestrian.navigable\":true}}")));
+                        "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":true,\"crossing.car.navigable\":false,\"crossing.pedestrian.navigable\":true,"
+                                + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -81,6 +81,25 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     private Atlas invalidCrossingItemsAtlas;
 
     @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOCATION_1)),
+                    @Node(coordinates = @Loc(value = LOCATION_2)),
+                    @Node(coordinates = @Loc(value = LOCATION_3)),
+                    @Node(coordinates = @Loc(value = LOCATION_4)),
+                    @Node(coordinates = @Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway", "area=yes" }),
+                    @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=motorway" }),
+                    @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }) })
+    private Atlas invalidCrossingItemsAtlasArea;
+
+    @TestAtlas(
             /*
              * This Atlas contains Car and Pedestrian Navigable edges
              */
@@ -100,7 +119,30 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_5) }, tags = { "highway=pedestrian" }),
                     @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_4) }, tags = { "highway=footway" }) })
-    private Atlas invalidCrossingItemsAtlasCarPed;
+    private Atlas invalidCrossingItemsAtlasCarPedestrian;
+
+    @TestAtlas(
+            /*
+             * This Atlas contains Car and Pedestrian Navigable edges
+             */
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOCATION_1)),
+                    @Node(coordinates = @Loc(value = LOCATION_2)),
+                    @Node(coordinates = @Loc(value = LOCATION_3)),
+                    @Node(coordinates = @Loc(value = LOCATION_4)),
+                    @Node(coordinates = @Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=steps" }),
+                    @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=corridor" }),
+                    @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=pedestrian",
+                                    "indoor=yes" }),
+                    @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=footway", "level=1" }) })
+    private Atlas invalidCrossingItemsAtlasIndoorMapping;
 
     @TestAtlas(
             // nodes
@@ -211,9 +253,19 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
         return this.invalidCrossingItemsAtlas;
     }
 
-    public Atlas invalidCrossingItemsAtlasCarPed()
+    public Atlas invalidCrossingItemsAtlasArea()
     {
-        return this.invalidCrossingItemsAtlasCarPed;
+        return this.invalidCrossingItemsAtlasArea;
+    }
+
+    public Atlas invalidCrossingItemsAtlasCarPedestrian()
+    {
+        return this.invalidCrossingItemsAtlasCarPedestrian;
+    }
+
+    public Atlas invalidCrossingItemsAtlasIndoorMapping()
+    {
+        return this.invalidCrossingItemsAtlasIndoorMapping;
     }
 
     public Atlas invalidCrossingItemsWithDifferentLayerTagAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -81,6 +81,28 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     private Atlas invalidCrossingItemsAtlas;
 
     @TestAtlas(
+            /*
+             * This Atlas contains Car and Pedestrian Navigable edges
+             */
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOCATION_1)),
+                    @Node(coordinates = @Loc(value = LOCATION_2)),
+                    @Node(coordinates = @Loc(value = LOCATION_3)),
+                    @Node(coordinates = @Loc(value = LOCATION_4)),
+                    @Node(coordinates = @Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=primary" }),
+                    @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=pedestrian" }),
+                    @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=footway" }) })
+    private Atlas invalidCrossingItemsAtlasCarPed;
+
+    @TestAtlas(
             // nodes
             nodes = { @Node(coordinates = @Loc(value = LOCATION_1)),
                     @Node(coordinates = @Loc(value = LOCATION_2)),
@@ -187,6 +209,11 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     public Atlas invalidCrossingItemsAtlas()
     {
         return this.invalidCrossingItemsAtlas;
+    }
+
+    public Atlas invalidCrossingItemsAtlasCarPed()
+    {
+        return this.invalidCrossingItemsAtlasCarPed;
     }
 
     public Atlas invalidCrossingItemsWithDifferentLayerTagAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -54,7 +54,7 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_5) }, tags = { "highway=path" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_4) }, tags = { "highway=pedestrian",
-                                    "area=yes" }),
+                            "area=yes" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_5),
                             @Loc(value = LOCATION_2) }, tags = { "railway=crossing" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_5),
@@ -79,6 +79,28 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                     @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }) })
     private Atlas invalidCrossingItemsAtlas;
+
+    @TestAtlas(
+            /*
+             * This Atlas contains Car and Pedestrian Navigable edges
+             */
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOCATION_1)),
+                    @Node(coordinates = @Loc(value = LOCATION_2)),
+                    @Node(coordinates = @Loc(value = LOCATION_3)),
+                    @Node(coordinates = @Loc(value = LOCATION_4)),
+                    @Node(coordinates = @Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=primary" }),
+                    @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
+                            @Loc(value = LOCATION_5) }, tags = { "highway=pedestrian" }),
+                    @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=footway" }) })
+    private Atlas invalidCrossingItemsAtlasCarPed;
 
     @TestAtlas(
             // nodes
@@ -122,7 +144,7 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_4) }, tags = { "highway=road", "layer=1" }),
                     @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
                             @Loc(value = LOCATION_5) }, tags = { "highway=residential",
-                                    "layer=-1" }),
+                            "layer=-1" }),
                     @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_4) }, tags = { "highway=track", "layer=-1" }) })
     private Atlas invalidCrossingItemsWithSameLayerTagAtlas;
@@ -187,6 +209,11 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     public Atlas invalidCrossingItemsAtlas()
     {
         return this.invalidCrossingItemsAtlas;
+    }
+
+    public Atlas invalidCrossingItemsAtlasCarPed()
+    {
+        return this.invalidCrossingItemsAtlasCarPed;
     }
 
     public Atlas invalidCrossingItemsWithDifferentLayerTagAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -54,7 +54,7 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_5) }, tags = { "highway=path" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_4) }, tags = { "highway=pedestrian",
-                            "area=yes" }),
+                                    "area=yes" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_5),
                             @Loc(value = LOCATION_2) }, tags = { "railway=crossing" }),
                     @Edge(coordinates = { @Loc(value = LOCATION_5),
@@ -79,28 +79,6 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                     @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }) })
     private Atlas invalidCrossingItemsAtlas;
-
-    @TestAtlas(
-            /*
-             * This Atlas contains Car and Pedestrian Navigable edges
-             */
-            // nodes
-            nodes = { @Node(coordinates = @Loc(value = LOCATION_1)),
-                    @Node(coordinates = @Loc(value = LOCATION_2)),
-                    @Node(coordinates = @Loc(value = LOCATION_3)),
-                    @Node(coordinates = @Loc(value = LOCATION_4)),
-                    @Node(coordinates = @Loc(value = LOCATION_5)) },
-            // edges
-            edges = {
-                    @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_1),
-                            @Loc(value = LOCATION_3) }, tags = { "highway=motorway" }),
-                    @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_2),
-                            @Loc(value = LOCATION_4) }, tags = { "highway=primary" }),
-                    @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
-                            @Loc(value = LOCATION_5) }, tags = { "highway=pedestrian" }),
-                    @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
-                            @Loc(value = LOCATION_4) }, tags = { "highway=footway" }) })
-    private Atlas invalidCrossingItemsAtlasCarPed;
 
     @TestAtlas(
             // nodes
@@ -144,7 +122,7 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_4) }, tags = { "highway=road", "layer=1" }),
                     @Edge(id = "323456789000000", coordinates = { @Loc(value = LOCATION_3),
                             @Loc(value = LOCATION_5) }, tags = { "highway=residential",
-                            "layer=-1" }),
+                                    "layer=-1" }),
                     @Edge(id = "423456789000000", coordinates = { @Loc(value = LOCATION_1),
                             @Loc(value = LOCATION_4) }, tags = { "highway=track", "layer=-1" }) })
     private Atlas invalidCrossingItemsWithSameLayerTagAtlas;
@@ -209,11 +187,6 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     public Atlas invalidCrossingItemsAtlas()
     {
         return this.invalidCrossingItemsAtlas;
-    }
-
-    public Atlas invalidCrossingItemsAtlasCarPed()
-    {
-        return this.invalidCrossingItemsAtlasCarPed;
     }
 
     public Atlas invalidCrossingItemsWithDifferentLayerTagAtlas()


### PR DESCRIPTION
**Description:**
Please refer to:
check improvement: #466
bug fix: #473

**Potential Impact:**
Adding more options for crossing without intersections.

Can flag car navigable with car navigable (original, default)
Will flag car navigable with pedestrian (optional)
Will flag pedestrian with car navigable (optional)
Will flag pedestrian to pedestrian only (optional)
Will flag both car navigable, pedestrian with navigable, pedestrian (optional)
Unit Test Approach:
N/A still in draft

**Test Results:**

ISO | Sampled | TP | FP | False Positive Rate
-- | -- | -- | -- | --
USA | 1050 | 521 | 18 | 3.45%
BRA | 90| 90 | 9 | 8.89%
IND | 41 | 41 | 0 | 0%
IDN | 1| 1| 0 | 0%
GBR | 420 | 420 | 22 | 5.24%

**False Positives:**
(all below cases are handled with unit tests)
1. Combination of Layer=0 with Bridge/Tunnel=yes set Layer=1. This tag combination is potentially a data issue. 
2. Level Tag. [Level Tag](https://wiki.openstreetmap.org/wiki/Key:level) primary usage is for the indoor mapping. Therefore its removed from the Check logic
3. [Indoor Mapping](https://wiki.openstreetmap.org/wiki/Indoor_Mapping#Proposed_Tags) handling with the Tag filter: `"indoor->*|highway->corridor,steps|level->*" `
