### PR TITLE
Clear output folder before sync in AWS script

### DIFF
--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -287,7 +287,7 @@ class CloudAtlasChecksControl:
                 )
             )
             if self.ssh_cmd(
-                "aws s3 sync --only-show-errors {0}/flag/{1} {2}flag/{1}".format(
+                "rm -rf {2}flag/*; aws s3 sync --only-show-errors {0}/flag/{1} {2}flag/{1}".format(
                     self.s3InFolder, c, self.atlasOutDir
                 )
             ):


### PR DESCRIPTION
### Description:

When executing Challenge command in AWS script this will clear the output folder before syncing with S3

### Potential Impact:

This speeds up map roulette upload command

### Unit Test Approach:

Executed manually on three countries and it cleared the old data and synced the new folders correctly.

### Test Results:

NA