### PR TITLE
Fix template parameter in checks AWS script

### DIFF
--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -823,7 +823,7 @@ def evaluate(args, cloudctl):
     if args.name is not None:
         cloudctl.instanceName = args.name
     if args.template is not None:
-        cloudctl.templateName = args.templateName
+        cloudctl.templateName = args.template
     if args.minutes is not None:
         cloudctl.timeoutMinutes = args.minutes
     if hasattr(args, "input") and args.input is not None:


### PR DESCRIPTION
### Description:

Quick fix to make the "template" parameter in the AWS checks script to work properly.

### Potential Impact:

This will make the parameter work. No impact to other code or functionality.

### Unit Test Approach:

Executed script with the --template parameter

### Test Results:
NA