### PR TITLE
Add support for extra info input files in AWS script.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,22 +135,12 @@ task shaded(type: Jar) {
     zip64 = true
 }
 
-/*
 shadowJar {
     baseName = project.name
     mergeServiceFiles()
     transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer) {
         resource = 'reference.conf'
     }
-    zip64 = true
-}
-*/
-shadowJar {
-    archiveBaseName = project.name
-    classifier = 'shadow'
-    configurations = [project.configurations.compile]
-    relocate 'com.google.protobuf', 'shadow.com.google.protobuf'
-    relocate 'com.google.common', 'shadow.com.google.common'
     zip64 = true
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -135,12 +135,22 @@ task shaded(type: Jar) {
     zip64 = true
 }
 
+/*
 shadowJar {
     baseName = project.name
     mergeServiceFiles()
     transform(com.github.jengelman.gradle.plugins.shadow.transformers.AppendingTransformer) {
         resource = 'reference.conf'
     }
+    zip64 = true
+}
+*/
+shadowJar {
+    archiveBaseName = project.name
+    classifier = 'shadow'
+    configurations = [project.configurations.compile]
+    relocate 'com.google.protobuf', 'shadow.com.google.protobuf'
+    relocate 'com.google.common', 'shadow.com.google.common'
     zip64 = true
 }
 

--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -55,9 +55,12 @@ class CloudAtlasChecksControl:
         mrkey="",
         mrProject="",
         mrURL="https://maproulette.org:443",
-        jar="atlas-checks/build/libs/atlas-checks-*-SNAPSHOT-shadow.jar",
+        jar="atlas-checks/build/libs/atlas-checks-latest-SNAPSHOT-shadow.jar",
+        s3dbFolder=None,
         awsRegion=AWS_REGION,
+        info=None,
     ):
+        self.info = info
         self.timeoutMinutes = timeoutMinutes
         self.key = key
         self.instanceId = instanceId
@@ -75,6 +78,7 @@ class CloudAtlasChecksControl:
         self.atlasCheckDir = os.path.join(self.homeDir, "atlas-checks/")
         self.atlasOutDir = os.path.join(self.homeDir, "output/")
         self.atlasInDir = os.path.join(self.homeDir, "input/")
+        self.atlasDBDir = os.path.join(self.atlasInDir, "extra/")
         self.atlasLogDir = os.path.join(self.homeDir, "log/")
         self.atlasCheckLogName = "atlasCheck.log"
         self.atlasCheckLog = os.path.join(self.atlasLogDir, self.atlasCheckLogName)
@@ -88,6 +92,7 @@ class CloudAtlasChecksControl:
         self.mrProject = mrProject
         self.mrURL = mrURL
         self.jar = jar
+        self.s3dbFolder = s3dbFolder
 
         self.instanceName = "AtlasChecks"
         self.localJar = '/tmp/atlas-checks.jar'
@@ -194,8 +199,13 @@ class CloudAtlasChecksControl:
                 )
             ):
                 self.finish("Failed to copy sharding.txt", -1)
+            if self.s3dbFolder is not None:
+                logger.info(f"syncing {self.s3dbFolder}")
+                if self.ssh_cmd(f"aws s3 sync --only-show-errors {self.s3dbFolder} {self.atlasDBDir}"):
+                    self.finish(f"Failed to sync {self.s3dbFolder}", -1)
 
             if self.info is not None:
+                logger.info(f"creating INFO: {self.info}")
                 cmd = ("echo '{{\n{},\n\"cmd\":\"{}\"\n}}' > {}INFO "
                 .format(self.info, " ".join(sys.argv), self.atlasOutDir))
             else:
@@ -210,6 +220,7 @@ class CloudAtlasChecksControl:
             cmd = (
                 "/opt/spark/bin/spark-submit"
                 + " --class=org.openstreetmap.atlas.checks.distributed.ShardedIntegrityChecksSparkJob"
+                + " --jars ~/sqlite-jdbc-latest.jar"
                 + " --master=local[{}]".format(self.processes)
                 + " --conf='spark.driver.memory={}g'".format(self.memory)
                 + " --conf='spark.rdd.compress=true'"
@@ -701,9 +712,13 @@ def parse_args():
         help="JAR - s3://path/to/atlas_checks.jar or /local/path/to/atlas_checks.jar to execute",
     )
     parser_check.add_argument(
+        "--db",
+        help="db - The full path to the db folder used for external db checks.",
+    )
+    parser_check.add_argument(
         "--info",
         help="INFO - Json string to add to the 'INFO' file in the output folder "
-        "(e.g. --tag='{\"version\":\"1.6.3\"}')",
+        "(e.g. --info='{\"version\":\"1.6.3\"}')",
     )
     parser_check.set_defaults(func=CloudAtlasChecksControl.atlasCheck)
 
@@ -852,7 +867,9 @@ def evaluate(args, cloudctl):
         cloudctl.mrProject = args.project
     if hasattr(args, "jar") and args.jar is not None:
         cloudctl.jar = args.jar
-    if hasattr(args, "info") and args.jar is not None:
+    if hasattr(args, "db") and args.db is not None:
+        cloudctl.s3dbFolder = args.db
+    if hasattr(args, "info") and args.info is not None:
         cloudctl.info = args.info
     if hasattr(args, "id") and args.id != "" and args.id is not None:
         cloudctl.instanceId = args.id

--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -56,7 +56,7 @@ class CloudAtlasChecksControl:
         mrProject="",
         mrURL="https://maproulette.org:443",
         jar="atlas-checks/build/libs/atlas-checks-latest-SNAPSHOT-shadow.jar",
-        s3dbFolder=None,
+        s3ExtraFolder=None,
         awsRegion=AWS_REGION,
         info=None,
     ):
@@ -78,7 +78,7 @@ class CloudAtlasChecksControl:
         self.atlasCheckDir = os.path.join(self.homeDir, "atlas-checks/")
         self.atlasOutDir = os.path.join(self.homeDir, "output/")
         self.atlasInDir = os.path.join(self.homeDir, "input/")
-        self.atlasDBDir = os.path.join(self.atlasInDir, "extra/")
+        self.atlasExtraDir = os.path.join(self.atlasInDir, "extra/")
         self.atlasLogDir = os.path.join(self.homeDir, "log/")
         self.atlasCheckLogName = "atlasCheck.log"
         self.atlasCheckLog = os.path.join(self.atlasLogDir, self.atlasCheckLogName)
@@ -92,7 +92,7 @@ class CloudAtlasChecksControl:
         self.mrProject = mrProject
         self.mrURL = mrURL
         self.jar = jar
-        self.s3dbFolder = s3dbFolder
+        self.s3ExtraFolder = s3ExtraFolder
 
         self.instanceName = "AtlasChecks"
         self.localJar = '/tmp/atlas-checks.jar'
@@ -199,10 +199,10 @@ class CloudAtlasChecksControl:
                 )
             ):
                 self.finish("Failed to copy sharding.txt", -1)
-            if self.s3dbFolder is not None:
-                logger.info(f"syncing {self.s3dbFolder}")
-                if self.ssh_cmd(f"aws s3 sync --only-show-errors {self.s3dbFolder} {self.atlasDBDir}"):
-                    self.finish(f"Failed to sync {self.s3dbFolder}", -1)
+            if self.s3ExtraFolder is not None:
+                logger.info(f"syncing {self.s3ExtraFolder}")
+                if self.ssh_cmd(f"aws s3 sync --only-show-errors {self.s3ExtraFolder} {self.atlasExtraDir}"):
+                    self.finish(f"Failed to sync {self.s3ExtraFolder}", -1)
 
             if self.info is not None:
                 logger.info(f"creating INFO: {self.info}")
@@ -712,8 +712,8 @@ def parse_args():
         help="JAR - s3://path/to/atlas_checks.jar or /local/path/to/atlas_checks.jar to execute",
     )
     parser_check.add_argument(
-        "--db",
-        help="db - The full path to the db folder used for external db checks.",
+        "--extra",
+        help="EXTRA - The full path to the extra folder used for external info checks.",
     )
     parser_check.add_argument(
         "--info",
@@ -867,8 +867,8 @@ def evaluate(args, cloudctl):
         cloudctl.mrProject = args.project
     if hasattr(args, "jar") and args.jar is not None:
         cloudctl.jar = args.jar
-    if hasattr(args, "db") and args.db is not None:
-        cloudctl.s3dbFolder = args.db
+    if hasattr(args, "extra") and args.extra is not None:
+        cloudctl.s3ExtraFolder = args.extra
     if hasattr(args, "info") and args.info is not None:
         cloudctl.info = args.info
     if hasattr(args, "id") and args.id != "" and args.id is not None:


### PR DESCRIPTION
### Description:

Add Support for DBs needed for new GenericTagCheck to AWS script

### Potential Impact:

Without this the AWS script will not be able to execute the GenericTagCheck. This should not affect other checks.
This adds a dependency in the AWS VM to have ~/sqlite-jdbc-latest.jar available.
Since this depends on https://github.com/osmlab/atlas-checks/pull/357 I will keep it in draft until that PR is accepted.

### Unit Test Approach:

Used this script to test the Generic Tag Check for QA

### Test Results:

NA