### PR TITLE
Add purgeIncompleteTasks parameter to MapRouletteUploadCommand.

### DIFF
--- a/scripts/cloud-check-control/cloudAtlasCheckControl.py
+++ b/scripts/cloud-check-control/cloudAtlasCheckControl.py
@@ -304,6 +304,7 @@ class CloudAtlasChecksControl:
                     + f" -countries='{c}'"
                     + f" -checks='{check}'"
                     +  " -includeFixSuggestions=true"
+                    +  " -purgeIncompleteTasks=true"
                     + f" > {self.atlasCheckLog}"
                 )
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
@@ -189,6 +189,11 @@ public class MapRouletteClient implements Serializable
             challenge.setId(challengeId);
             challengeMap.put(challenge.getName(), challenge);
             this.challenges.put(project.getId(), challengeMap);
+            /* If purge is requested then do it now */
+            if (challengeId >= 0 && challenge.isPurge())
+            {
+                this.connection.purgeIncompleteTasks(challengeId);
+            }
         }
         return Optional.of(challenge);
     }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -185,24 +185,17 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     public long purgeIncompleteTasks(final long challengeID)
             throws UnsupportedEncodingException, URISyntaxException
     {
-        HttpResource purge = null;
-        try
+        try (HttpResource purge = new DeleteResource(
+                this.uriBuilder.setPath(String.format("/api/v2/challenge/%s/tasks", challengeID))
+                        .addParameter("statusFilters", "0,3").build().toString());)
         {
-            final URIBuilder purgeUrl = this.uriBuilder
-                    .setPath(String.format("/api/v2/challenge/%s/tasks", challengeID))
-                    .addParameter("statusFilters", "0,3");
             logger.info("challenge {}: purging incomplete tasks...", challengeID);
-            purge = new DeleteResource(purgeUrl.build().toString());
             this.setAuth(purge);
             if (purge.getStatusCode() != HttpStatus.SC_OK)
             {
                 logger.error("failed to purge challenge {}...", challengeID);
                 return -1;
             }
-        }
-        finally
-        {
-            purge.close();
         }
         logger.trace("challenge {}: purged all incomplete tasks.", challengeID);
         return challengeID;

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -17,6 +17,7 @@ import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.Project;
 import org.openstreetmap.atlas.checks.maproulette.data.Survey;
 import org.openstreetmap.atlas.checks.maproulette.data.Task;
+import org.openstreetmap.atlas.streaming.resource.http.DeleteResource;
 import org.openstreetmap.atlas.streaming.resource.http.GetResource;
 import org.openstreetmap.atlas.streaming.resource.http.HttpResource;
 import org.openstreetmap.atlas.streaming.resource.http.PostResource;
@@ -167,6 +168,44 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     public String getConnectionInfo()
     {
         return this.configuration.toString();
+    }
+
+    /**
+     * Will purge incomplete tasks from a challenge.
+     *
+     * @param challengeID
+     *            The challenge ID to purge
+     * @return The id of the challenge
+     * @throws UnsupportedEncodingException
+     *             if cannot encode string for post/put to map roulette
+     * @throws URISyntaxException
+     *             if URI supplied is invalid and cannot be built
+     */
+    @Override
+    public long purgeIncompleteTasks(final long challengeID)
+            throws UnsupportedEncodingException, URISyntaxException
+    {
+        HttpResource purge = null;
+        try
+        {
+            final URIBuilder purgeUrl = this.uriBuilder
+                    .setPath(String.format("/api/v2/challenge/%s/tasks", challengeID))
+                    .addParameter("statusFilters", "0,3");
+            logger.info("challenge {}: purging incomplete tasks...", challengeID);
+            purge = new DeleteResource(purgeUrl.build().toString());
+            this.setAuth(purge);
+            if (purge.getStatusCode() != HttpStatus.SC_OK)
+            {
+                logger.error("failed to purge challenge {}...", challengeID);
+                return -1;
+            }
+        }
+        finally
+        {
+            purge.close();
+        }
+        logger.trace("challenge {}: purged all incomplete tasks.", challengeID);
+        return challengeID;
     }
 
     public HttpResource setAuth(final HttpResource resource)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -181,16 +181,15 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                             {
                                 final Map<String, Challenge> countryToChallengeMap = this.checkNameChallengeMap
                                         .computeIfAbsent(checkName, ignore -> new HashMap<>());
-                                // by default, do NOT purge incomplete tasks from challenges
-                                final boolean purgeIncompleteTasks = (boolean) commandMap
-                                        .getOrDefault(PURGE_CHALLENGES.getName(), false);
                                 final Challenge challengeObject = countryToChallengeMap
                                         .computeIfAbsent(countryCode,
                                                 ignore -> this.getChallenge(checkName, instructions,
                                                         countryCode, checkinCommentPrefix,
                                                         checkinComment, discoverableChallenges,
-                                                        undiscoverableChallenges,
-                                                        purgeIncompleteTasks));
+                                                        undiscoverableChallenges));
+                                // by default, do NOT purge incomplete tasks from challenges
+                                challengeObject.setPurge((boolean) commandMap
+                                        .getOrDefault(PURGE_CHALLENGES.getName(), false));
                                 // by default, upload fix suggestions
                                 final boolean includeFixSuggestions = (boolean) commandMap
                                         .getOrDefault(INCLUDE_FIX_SUGGESTIONS.getName(), true);
@@ -239,8 +238,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             final Configuration fallbackConfiguration, final String countryCode,
             final String checkinCommentPrefix, final String checkinComment,
             final Optional<List<String>> discoverableChallenges,
-            final Optional<List<String>> undiscoverableChallenges,
-            final boolean purgeIncompleteTasks)
+            final Optional<List<String>> undiscoverableChallenges)
     {
         final Map<String, String> challengeMap = fallbackConfiguration
                 .get(this.getChallengeParameter(checkName), Collections.emptyMap()).value();
@@ -279,8 +277,6 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
                 || undiscoverableChallenges.isPresent()
                         && !undiscoverableChallenges.get().get(0).equals(StringUtils.EMPTY)
                         && !undiscoverableChallenges.get().contains(checkName));
-        // Store purge flag to indicate if a purge is requested to precede upload.
-        result.setPurge(purgeIncompleteTasks);
         return result;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/TaskLoader.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/TaskLoader.java
@@ -54,6 +54,20 @@ public interface TaskLoader
     String getConnectionInfo();
 
     /**
+     * Will purge incomplete tasks from a challenge
+     *
+     * @param challengeID
+     *            The challenge ID to purge
+     * @return The id of the challenge
+     * @throws UnsupportedEncodingException
+     *             if json data for API payload cannot be encoded correctly
+     * @throws URISyntaxException
+     *             if the URI for getting/creating/updating project is incorrectly generated
+     */
+    long purgeIncompleteTasks(long challengeID)
+            throws UnsupportedEncodingException, URISyntaxException;
+
+    /**
      * Uploads tasks as a batch, instead of one at a time
      *
      * @param challengeId

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -62,6 +62,7 @@ public class Challenge implements Serializable
     private boolean enabled;
     private boolean updateTasks;
     private String checkName;
+    private boolean purge;
 
     public Challenge(final Challenge challenge)
     {
@@ -109,6 +110,7 @@ public class Challenge implements Serializable
         this.checkinComment = DEFAULT_CHECKIN_COMMENT;
         this.updateTasks = true;
         this.enabled = enabled;
+        this.purge = false;
     }
 
     public String getBlurb()
@@ -196,6 +198,11 @@ public class Challenge implements Serializable
         return this.enabled;
     }
 
+    public boolean isPurge()
+    {
+        return this.purge;
+    }
+
     public boolean isUpdateTasks()
     {
         return this.updateTasks;
@@ -229,6 +236,11 @@ public class Challenge implements Serializable
     public void setParentIdentifier(final long identifier)
     {
         this.parent = identifier;
+    }
+
+    public void setPurge(final boolean purge)
+    {
+        this.purge = purge;
     }
 
     public void setStatus(final long status)

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -108,6 +108,22 @@ public class MapRouletteUploadCommandTest
     }
 
     @Test
+    public void testIncludeFixSuggestion()
+    {
+        final String[] additionalArguments = { "-includeFixSuggestions=true" };
+        this.runAndTest(additionalArguments, 1, 4, 4, true, Collections.emptyList(),
+                Arrays.asList("SomeCheck", "SomeOtherCheck", "AnotherCheck"));
+    }
+
+    @Test
+    public void testPurgeIncompleteTasks()
+    {
+        final String[] additionalArguments = { "-purgeIncompleteTasks=true" };
+        this.runAndTest(additionalArguments, 1, 4, 4, true, Collections.emptyList(),
+                Arrays.asList("SomeCheck", "SomeOtherCheck", "AnotherCheck"));
+    }
+
+    @Test
     public void testUndiscoverableProject()
     {
         final String[] additionalArguments = { "-discoverableProject=false" };

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
@@ -68,6 +68,19 @@ public class TestMapRouletteConnection implements TaskLoader
         return "";
     }
 
+    @Override
+    public long purgeIncompleteTasks(final long challengeID) throws URISyntaxException
+    {
+        if (this.challengeToTasks.containsKey(challengeID))
+        {
+            return challengeID;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+
     public void setProjectNameToId(final Map<String, Long> projectIdMap)
     {
         this.projectNameToId = projectIdMap;


### PR DESCRIPTION
### Description:

This patch will add a new parameter (defaults to false) that if set to true will instruct the MapRouletteUploadCommand to purge all "Incomplete tasks" from any challenge that is being uploaded before uploading tasks to the challenge. Incomplete tasks are any task with a status of "created" or "skipped". These types of tasks have either not been processed or skipped for some reason. This purge parameter will delete them from the challenge before uploading a new task list so that any stale tasks that might have been fixed since the last update will be removed from the challenge. This prevents mappers from processing old tasks that have already been fixed and will (obviously) reduce the number of "already-fixed" task statuses.

### Potential Impact:

This is a new parameter that if not specified will act exactly the way things used to. If the user wants to purge old tasks then the parameter can be specified when calling the MapRouletteUploadComand. This could potentially extend the amount of time it takes to upload a challenge to Map Roulette because the delete command can take minutes if there are a lot of tasks in the challenge. 

### Unit Test Approach:

I tested this code by uploading a challenge using maproulette upload command. Then setting one task to each of the different statuses. I then ran the upload command again with the purgeIncompleteTasks parameter set and verified that the single "skipped" task and all the "created" tasks were deleted, and then verified that the upload command uploaded a new set of tasks into the challenge. 
I also tested that I could specify the parameter when uploading to a brand new (non existent) challenge.
I also tested that not specifying the parameter did NOT delete old tasks and continue to work as usual.

### Test Results:

All good.
