### PR TITLE
DuplicateLocationInPolyLineCheck: Fix #553, do not flag terminating loops

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheck.java
@@ -66,8 +66,10 @@ public class DuplicateLocationInPolyLineCheck extends BaseCheck<Long>
                             || object instanceof Area || firstHit > 1))
             {
                 this.markAsFlagged(object.getOsmIdentifier());
-                return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0,
-                        currentLocation.toString(), object.getOsmIdentifier())));
+                return Optional.of(this.createFlag(object,
+                        this.getLocalizedInstruction(0, currentLocation.toString(),
+                                object.getOsmIdentifier()),
+                        Collections.singletonList(currentLocation)));
             }
             else
             {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheck.java
@@ -1,6 +1,6 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -25,8 +25,8 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
  */
 public class DuplicateLocationInPolyLineCheck extends BaseCheck<Long>
 {
-    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("Repeated location found at {0} for feature id {1,number,#} ");
+    private static final List<String> FALLBACK_INSTRUCTIONS = Collections
+            .singletonList("Repeated location found at {0} for feature id {1,number,#} ");
     private static final long serialVersionUID = 7403488805532662065L;
 
     public DuplicateLocationInPolyLineCheck(final Configuration configuration)
@@ -45,14 +45,28 @@ public class DuplicateLocationInPolyLineCheck extends BaseCheck<Long>
     {
         final Set<Location> visitedLocations = new HashSet<>();
         final Iterator<Location> locations = ((AtlasItem) object).getRawGeometry().iterator();
+        var firstHit = 0;
+        Location first = null;
         while (locations.hasNext())
         {
-            final Location currentLocation = locations.next();
+            final var currentLocation = locations.next();
+
+            if (first == null)
+            {
+                first = currentLocation;
+            }
+            else if (first.equals(currentLocation))
+            {
+                firstHit++;
+            }
+
             if (visitedLocations.contains(currentLocation)
-                    && !this.isFlagged(object.getOsmIdentifier()))
+                    && !this.isFlagged(object.getOsmIdentifier())
+                    && (!first.equals(currentLocation) && locations.hasNext()
+                            || object instanceof Area || firstHit > 1))
             {
                 this.markAsFlagged(object.getOsmIdentifier());
-                return Optional.of(createFlag(object, this.getLocalizedInstruction(0,
+                return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0,
                         currentLocation.toString(), object.getOsmIdentifier())));
             }
             else

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheckTest.java
@@ -1,18 +1,23 @@
 package org.openstreetmap.atlas.checks.validation.points;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.Assert;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
-import org.openstreetmap.atlas.geography.Location;
-import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
 import org.openstreetmap.atlas.geography.atlas.Atlas;
 import org.openstreetmap.atlas.geography.atlas.builder.AtlasBuilder;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Line;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedAtlasBuilder;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 
@@ -21,34 +26,183 @@ import org.openstreetmap.atlas.utilities.collections.Iterables;
  */
 public class DuplicateLocationInPolyLineCheckTest
 {
-    @Test
-    public void testCheck()
+    @Rule
+    public final DuplicateLocationInPolyLineCheckTestRule setup = new DuplicateLocationInPolyLineCheckTestRule();
+
+    @Rule
+    public final ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    /**
+     * Reverse the polyline geometries in an atlas
+     *
+     * @param atlas
+     *            The atlas with the lines to reverse
+     * @return A new atlas
+     */
+    private static Atlas reverseLineItems(final Atlas atlas)
     {
-        final AtlasBuilder builder = new PackedAtlasBuilder();
-        final Map<String, String> tags = new HashMap<String, String>();
-        final Location location1 = Location.TEST_6;
-        final Location location2 = Location.TEST_2;
-        final Location location3 = Location.TEST_1;
-        final Location location4 = Location.TEST_6;
-        final List<Location> locations = new ArrayList<Location>();
-        locations.add(location1);
-        locations.add(location2);
-        locations.add(location3);
-        locations.add(location4);
+        final AtlasBuilder atlasBuilder = new PackedAtlasBuilder();
+        for (final Point point : atlas.points())
+        {
+            atlasBuilder.addPoint(point.getIdentifier(), point.getLocation(), point.getTags());
+        }
+        for (final Node node : atlas.nodes())
+        {
+            atlasBuilder.addNode(node.getIdentifier(), node.getLocation(), node.getTags());
+        }
+        for (final Area area : atlas.areas())
+        {
+            atlasBuilder.addArea(area.getIdentifier(), area.asPolygon().reversed(), area.getTags());
+        }
+        for (final Line line : atlas.lines())
+        {
+            atlasBuilder.addLine(line.getIdentifier(), line.asPolyLine().reversed(),
+                    line.getTags());
+        }
+        for (final Edge line : atlas.edges())
+        {
+            atlasBuilder.addEdge(line.getIdentifier(), line.asPolyLine().reversed(),
+                    line.getTags());
+        }
+        return atlasBuilder.get();
+    }
 
-        final PolyLine polyLine = new PolyLine(locations);
-        builder.addNode(1, location1, tags);
-        builder.addNode(2, location2, tags);
-        builder.addNode(3, location3, tags);
-        builder.addNode(4, location4, tags);
+    @Test
+    public void testInvalidFigureEight()
+    {
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.actual(this.setup.getInvalidFigureEightLine(),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
 
-        builder.addEdge(1, polyLine, tags);
+    /**
+     * The simple area is invalid since the last location should not be the same as the first
+     * location
+     */
+    @Test
+    public void testInvalidSimpleArea()
+    {
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.actual(this.setup.getInvalidSimpleArea(),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
 
-        final Atlas atlas = builder.get();
+    /**
+     * The simple area is invalid since the last location should not be the same as the first
+     * location
+     */
+    @Test
+    public void testInvalidSimpleAreaReversed()
+    {
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.actual(reverseLineItems(this.setup.getInvalidSimpleArea()),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
 
-        final List<CheckFlag> flags = Iterables.asList(
-                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration())
-                        .flags(atlas));
-        Assert.assertEquals(1, flags.size());
+    @Test
+    public void testInvalidSimpleEdge()
+    {
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.actual(this.setup.getInvalidSimpleEdge(),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    @Test
+    public void testInvalidSimpleEdgeAlreadyChecked()
+    {
+        // Cannot use verifier -- it doesn't run the same id through twice
+        final DuplicateLocationInPolyLineCheck check = new DuplicateLocationInPolyLineCheck(
+                ConfigurationResolver.emptyConfiguration());
+        final List<CheckFlag> found = IntStream.range(0, 10)
+                .mapToObj(randomVar -> check.flags(this.setup.getInvalidSimpleEdge()))
+                .flatMap(iterable -> Iterables.asList(iterable).stream())
+                .collect(Collectors.toList());
+        assertEquals(1, found.size());
+        // Needed to avoid verifier complaints
+        this.testInvalidSimpleEdge();
+    }
+
+    @Test
+    public void testInvalidSimpleEdgeReversed()
+    {
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.actual(reverseLineItems(this.setup.getInvalidSimpleEdge()),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    @Test
+    public void testInvalidSimpleLine()
+    {
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.actual(this.setup.getInvalidSimpleLine(),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    @Test
+    public void testInvalidSimpleLineReversed()
+    {
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.actual(reverseLineItems(this.setup.getInvalidSimpleLine()),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    @Test
+    public void testValidServiceHighway()
+    {
+        this.verifier.verifyEmpty();
+        this.verifier.actual(this.setup.getValidSimpleServiceEdge(),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    @Test
+    public void testValidServiceHighwayReversed()
+    {
+        this.verifier.verifyEmpty();
+        this.verifier.actual(reverseLineItems(this.setup.getValidSimpleServiceEdge()),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    /**
+     * A loop is not invalid
+     */
+    @Test
+    public void testValidSimpleEdgeLoop()
+    {
+        this.verifier.verifyEmpty();
+        this.verifier.actual(this.setup.getValidSimpleEdge(),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    /**
+     * A loop is not invalid
+     */
+    @Test
+    public void testValidSimpleEdgeLoopReversed()
+    {
+        this.verifier.verifyEmpty();
+        this.verifier.actual(reverseLineItems(this.setup.getValidSimpleEdge()),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    /**
+     * A loop is not invalid
+     */
+    @Test
+    public void testValidSimpleLineItemLoop()
+    {
+        this.verifier.verifyEmpty();
+        this.verifier.actual(this.setup.getValidSimpleLine(),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
+    }
+
+    /**
+     * A loop is not invalid
+     */
+    @Test
+    public void testValidSimpleLineItemLoopReversed()
+    {
+        this.verifier.verifyEmpty();
+        this.verifier.actual(reverseLineItems(this.setup.getValidSimpleLine()),
+                new DuplicateLocationInPolyLineCheck(ConfigurationResolver.emptyConfiguration()));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/DuplicateLocationInPolyLineCheckTestRule.java
@@ -1,0 +1,177 @@
+package org.openstreetmap.atlas.checks.validation.points;
+
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Line;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * A class holding test atlases for {@link DuplicateLocationInPolyLineCheckTest}
+ *
+ * @author Taylor Smock
+ */
+public class DuplicateLocationInPolyLineCheckTestRule extends CoreTestRule
+{
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_6_COORDINATES)),
+                    @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)),
+                    @Node(id = "3000000", coordinates = @Loc(Location.TEST_1_COORDINATES)) }, edges = {
+                            @Edge(id = "1000000", coordinates = { @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_1_COORDINATES),
+                                    @Loc(Location.TEST_6_COORDINATES) }) })
+    private Atlas validSimpleEdge;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_6_COORDINATES)),
+                    @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)),
+                    @Node(id = "3000000", coordinates = @Loc(Location.TEST_1_COORDINATES)),
+                    @Node(id = "4000000", coordinates = @Loc(Location.TEST_3_COORDINATES)) }, edges = {
+                            @Edge(id = "1000000", coordinates = { @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_1_COORDINATES),
+                                    @Loc(Location.TEST_3_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES) }, tags = {
+                                            "highway=service" }) })
+    private Atlas validSimpleServiceEdge;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_6_COORDINATES)),
+                    @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)),
+                    @Node(id = "3000000", coordinates = @Loc(Location.TEST_1_COORDINATES)),
+                    @Node(id = "4000000", coordinates = @Loc(Location.TEST_3_COORDINATES)) }, edges = {
+                            @Edge(id = "1000000", coordinates = { @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_1_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_3_COORDINATES) }) })
+    private Atlas invalidSimpleEdge;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_6_COORDINATES)),
+                    @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)),
+                    @Node(id = "3000000", coordinates = @Loc(Location.TEST_1_COORDINATES)) }, lines = {
+                            @Line(id = "1000000", coordinates = { @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_1_COORDINATES),
+                                    @Loc(Location.TEST_6_COORDINATES) }) })
+    private Atlas validSimpleLine;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_6_COORDINATES)),
+                    @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)),
+                    @Node(id = "3000000", coordinates = @Loc(Location.TEST_1_COORDINATES)) }, lines = {
+                            @Line(id = "1000000", coordinates = { @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_1_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_3_COORDINATES) }) })
+    private Atlas invalidSimpleLine;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_6_COORDINATES)),
+                    @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)),
+                    @Node(id = "3000000", coordinates = @Loc(Location.TEST_1_COORDINATES)) }, areas = {
+                            @Area(id = "1000000", coordinates = { @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_1_COORDINATES),
+                                    @Loc(Location.TEST_6_COORDINATES) }) })
+    private Atlas invalidSimpleArea;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(Location.TEST_6_COORDINATES)),
+                    @Node(id = "2000000", coordinates = @Loc(Location.TEST_2_COORDINATES)),
+                    @Node(id = "3000000", coordinates = @Loc(Location.TEST_1_COORDINATES)),
+                    @Node(id = "4000000", coordinates = @Loc(Location.TEST_4_COORDINATES)),
+                    @Node(id = "5000000", coordinates = @Loc(Location.TEST_3_COORDINATES)) }, lines = {
+                            @Line(id = "1000000", coordinates = { @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_1_COORDINATES),
+                                    @Loc(Location.TEST_2_COORDINATES),
+                                    @Loc(Location.TEST_6_COORDINATES),
+                                    @Loc(Location.TEST_3_COORDINATES),
+                                    @Loc(Location.TEST_4_COORDINATES),
+                                    @Loc(Location.TEST_6_COORDINATES) }) })
+    private Atlas invalidFigureEightLine;
+
+    /**
+     * Get a figure 8 line
+     *
+     * @return A figure 8 line
+     */
+    public Atlas getInvalidFigureEightLine()
+    {
+        return this.invalidFigureEightLine;
+    }
+
+    /**
+     * Get a closed loop area (no tags)
+     *
+     * @return The closed area (duplicate end point)
+     */
+    public Atlas getInvalidSimpleArea()
+    {
+        return this.invalidSimpleArea;
+    }
+
+    /**
+     * Get an edge that self-intersects and continues on
+     *
+     * @return The invalid edge
+     */
+    public Atlas getInvalidSimpleEdge()
+    {
+        return this.invalidSimpleEdge;
+    }
+
+    /**
+     * Get a line that self-intersects and continues on
+     *
+     * @return The invalid line
+     */
+    public Atlas getInvalidSimpleLine()
+    {
+        return this.invalidSimpleLine;
+    }
+
+    /**
+     * Get a closed loop edge (no highway tags)
+     *
+     * @return The closed loop
+     */
+    public Atlas getValidSimpleEdge()
+    {
+        return this.validSimpleEdge;
+    }
+
+    /**
+     * Get a closed loop line (no tags)
+     *
+     * @return The closed loop
+     */
+    public Atlas getValidSimpleLine()
+    {
+        return this.validSimpleLine;
+    }
+
+    /**
+     * Get a simple service edge (closed, but not at ends)
+     *
+     * @return A simple service edge
+     */
+    public Atlas getValidSimpleServiceEdge()
+    {
+        return this.validSimpleServiceEdge;
+    }
+}


### PR DESCRIPTION
* Stop flagging closed loops (Edges and LineItems)
* Continue flagging closed loops (Areas -- the last location in an area line
  _should not_ be the same as the first location in the area line)

### Description:

This fixes #553 by not flagging terminating loops (Edges and LineItems). It continues to flag closed Area loops.

### Potential Impact:

N/A

### Unit Test Approach:

Added unit tests check that the last node does not flag the object when the last node already exists on the line.

### Test Results:
Country | Flags | Sampled | False Positives
-|-|-|-
GBR|138|100%|0

Note: The atlas used for the test samples was from sometime between 2020-12-11 and 2020-12-13 -- some that I initially thought were FP turned out to have been fixed already.