### PR TITLE
Fix bug #557 to exclude atlas internal segments

### DIFF
--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ShortSegmentCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ShortSegmentCheckTest.java
@@ -119,6 +119,14 @@ public class ShortSegmentCheckTest
     }
 
     @Test
+    public void testShortSegmentsWithOneValence2NodeOneSyntheticBoundaryNode()
+    {
+        this.verifier.actual(
+                this.setup.shortSegmentWithOneValence2NodeOneSyntheticBoundaryNodeAtlas(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testShortSegmentsWithTwoValence2Nodes()
     {
         this.verifier.actual(this.setup.shortSegmentsWithTwoValence2NodesAtlas(), check);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ShortSegmentCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/ShortSegmentCheckTestRule.java
@@ -161,6 +161,19 @@ public class ShortSegmentCheckTestRule extends CoreTestRule
                                     HIGHWAY_RESIDENTIAL }) })
     private Atlas shortSegmentWithOneValence2NodeOneBarrierNodeAtlas;
 
+    @TestAtlas(nodes = {
+            @Node(coordinates = @Loc(value = COMPANY_STORE), tags = {
+                    "synthetic_boundary_node=yes" }),
+            @Node(coordinates = @Loc(value = A_LOCATION_CLOSE_TO_COMPANY_STORE_1)),
+            @Node(coordinates = @Loc(value = ALVES_CAFFE)) }, edges = {
+                    @Edge(id = "444342903000000", coordinates = { @Loc(value = COMPANY_STORE),
+                            @Loc(value = A_LOCATION_CLOSE_TO_COMPANY_STORE_1) }, tags = {
+                                    HIGHWAY_RESIDENTIAL }),
+                    @Edge(id = "444342904000000", coordinates = { @Loc(value = ALVES_CAFFE),
+                            @Loc(value = A_LOCATION_CLOSE_TO_COMPANY_STORE_1) }, tags = {
+                                    HIGHWAY_RESIDENTIAL }) })
+    private Atlas shortSegmentWithOneValence2NodeOneSyntheticBoundaryNodeAtlas;
+
     @TestAtlas(nodes = { @Node(coordinates = @Loc(value = COMPANY_STORE)),
             @Node(coordinates = @Loc(value = A_LOCATION_CLOSE_TO_COMPANY_STORE_1)),
             @Node(coordinates = @Loc(value = A_LOCATION_CLOSE_TO_COMPANY_STORE_2)),
@@ -230,6 +243,11 @@ public class ShortSegmentCheckTestRule extends CoreTestRule
         return this.shortSegmentWithOneValence2NodeOneBarrierNodeAtlas;
     }
 
+    public Atlas shortSegmentWithOneValence2NodeOneSyntheticBoundaryNodeAtlas()
+    {
+        return this.shortSegmentWithOneValence2NodeOneSyntheticBoundaryNodeAtlas;
+    }
+
     public Atlas shortSegmentWithTwoValence1NodesAtlas()
     {
         return this.shortSegmentWithTwoValence1NodesAtlas;
@@ -249,4 +267,5 @@ public class ShortSegmentCheckTestRule extends CoreTestRule
     {
         return this.shortSegmentsWithValence1And2NodesAtlas;
     }
+
 }


### PR DESCRIPTION
### Description:

1. Exclude atlas internal synthetic segments
2. Change instructions to use OSMId, and include startNode, endNode, like below:
      "instructions": "1. This segment from startNode 268179597 to endNode 7392913442 on way 24673494 is short (length < 1 m) and node 268179597 has less than 3 connections."
3. Add a new unit test for internal synthetic segment.
  
I have run the fix for ISR,ISL,MLT,LUX,CPY,PER,NZL,MAR, the synthetic segments/nodes are removed successfully 
