### PR TITLE
lineCrossingWaterBodyCheck adding handling for footway, bridleway, steps, corridor, path

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -586,6 +586,7 @@
     "highways.exclude": ["bus_guideway"],
     "lineItems.offending": "railway->rail,narrow_gauge,preserved,subway,disused,monorail,tram,light_rail,funicular,construction,miniature",
     "lineItems.non_offending": "waterway->*|boundary->*|landuse->*|bridge->yes,viaduct,aqueduct,boardwalk,covered,low_water_crossing,movable,suspension|tunnel->yes,culvert,building_passage|embankment->yes|location->underwater,underground|power->line,minor_line|man_made->pier,breakwater,embankment,groyne,dyke,pipeline|route->ferry|highway->proposed,construction|ice_road->yes|winter_road->yes|snowmobile->yes|ski->yes|ford->!no&ford->*",
+    "lineItems.footpath": "highway->footway,bridleway,steps,corridor,path",
     "nodes.intersecting.non_offending": "ferry->!no&ferry->*|ford->!no&ford->*|leisure->slipway|amenity->ferry_terminal",
     "buildings.flag": true,
     "challenge": {

--- a/docs/checks/lineCrossingWaterBodyCheck.md
+++ b/docs/checks/lineCrossingWaterBodyCheck.md
@@ -8,6 +8,8 @@ An Edge should be flagged if it has the appropriate highway tag (specified in "h
 
 A building should be flagged if the "buildings.flag" is set to true, and the building is not a public_transport->station,aerialway=station, is on the same level as the waterbody, and intersects a valid part of the waterbody.
 
+Footpaths highway=(footway|bridleway|steps|corridor|path) should not be flagged if they are ending at waterbody. Special handling of highway=steps, which may go inside a waterbody. 
+
 #### Live Examples
 
 1. Street [id:32845241](https://www.openstreetmap.org/way/32845241) and building [id:753774494](https://www.openstreetmap.org/way/753774494) intersect waterbody feature [id:10886166](https://www.openstreetmap.org/relation/10886166) invalidly. Both the street and waterbody share a location (node) at the point of intersection, but this node is not tagged with something from "nodes.intersecting.non_offending".

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
@@ -528,11 +528,11 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
 
     /**
      * Handling footpath cases: https://github.com/osmlab/atlas-checks/issues/561
+     * 
      * @param interactionsPerWaterbodyComponent
-     *      Set of Locations that crossing a waterbody
+     *            Set of Locations that crossing a waterbody
      * @param lineItem
-     *      Atlas line entity
-     * @return true if footpath crossing waterbody only ones. case highway=steps may go inside waterbody.
+     *            Atlas line entity
      */
     private void handlingFootPath(
             final Set<Tuple<PolyLine, Set<Location>>> interactionsPerWaterbodyComponent,

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
@@ -156,7 +156,7 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
     private final TaggableFilter intersectingNodesNonoffending;
     private final long shapepointsMin;
     private final long shapepointsMax;
-    private final AtomicBoolean validCrossWaterbody = new AtomicBoolean();
+    private final AtomicBoolean validCrossWaterbody;
 
     /**
      * Checks if the relation has permitlisted tags that makes its members cross water bodies
@@ -243,6 +243,7 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
                 SHAPEPOINTS_MIN_DEFAULT);
         this.shapepointsMax = this.configurationValue(configuration, "shapepoints.max",
                 SHAPEPOINTS_MAX_DEFAULT);
+        this.validCrossWaterbody = new AtomicBoolean();
     }
 
     @Override
@@ -526,8 +527,12 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
     }
 
     /**
+     * Handling footpath cases: https://github.com/osmlab/atlas-checks/issues/561
      * @param interactionsPerWaterbodyComponent
+     *      Set of Locations that crossing a waterbody
      * @param lineItem
+     *      Atlas line entity
+     * @return true if footpath crossing waterbody only ones. case highway=steps may go inside waterbody.
      */
     private void handlingFootPath(
             final Set<Tuple<PolyLine, Set<Location>>> interactionsPerWaterbodyComponent,

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
@@ -526,11 +526,8 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
     }
 
     /**
-     *
      * @param interactionsPerWaterbodyComponent
-     *
      * @param lineItem
-     *
      */
     private void handlingFootPath(
             final Set<Tuple<PolyLine, Set<Location>>> interactionsPerWaterbodyComponent,

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
@@ -437,17 +437,14 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
                     {
                         final Set<Location> interactionLocations = tuple.getSecond();
                         // crossing only ones or touching.
-                        // ways with highway=steps may go inside waterbody.
-                        if (interactionLocations.size() == 1)
+                        // ways with highway=steps may go inside the waterbody.
+                        if (interactionLocations.size() == 1 && (interactionLocations
+                                .contains(((Edge) lineItem).start().iterator().next())
+                                || interactionLocations
+                                        .contains(((Edge) lineItem).end().iterator().next())
+                                || ((Edge) lineItem).highwayTag().getTagValue().equals("steps")))
                         {
-                            if (interactionLocations
-                                    .contains(((Edge) lineItem).start().iterator().next())
-                                    || interactionLocations
-                                            .contains(((Edge) lineItem).end().iterator().next())
-                                    || ((Edge) lineItem).highwayTag().getTagValue().equals("steps"))
-                            {
-                                validCrossWaterbody.getAndSet(true);
-                            }
+                            validCrossWaterbody.getAndSet(true);
                         }
                     });
                 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
@@ -86,7 +86,7 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
             + "embankment->yes|location->underwater,underground|power->line,minor_line|"
             + "man_made->pier,breakwater,embankment,groyne,dyke,pipeline|route->ferry|highway->proposed,construction|ice_road->yes|winter_road->yes|snowmobile->yes|ski->yes|"
             + "ford->!no&ford->*";
-    private static final String DEFAULT_LINE_ITEMS_OFFENDING_CROSSING_ONLY = "highway->footway,bridleway,steps,corridor,path";
+    private static final String DEFAULT_LINE_ITEMS_FOOTPATH = "highway->footway,bridleway,steps,corridor,path";
     private static final String DEFAULT_HIGHWAY_MINIMUM = "TOLL_GANTRY";
     private static final List<String> DEFAULT_HIGHWAYS_EXCLUDE = Collections.emptyList();
     private static final String BUILDING_TAGS_DO_NOT_FLAG = "waterway->dam|public_transport->station,platform|aerialway->station";
@@ -222,9 +222,8 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
         super(configuration);
         this.lineItemsOffending = TaggableFilter
                 .forDefinition(this.configurationValue(configuration, "lineItems.offending", ""));
-        this.lineItemsOffendingCrossingOnly = TaggableFilter.forDefinition(
-                this.configurationValue(configuration, "lineItems.offending.crossing.only",
-                        DEFAULT_LINE_ITEMS_OFFENDING_CROSSING_ONLY));
+        this.lineItemsOffendingCrossingOnly = TaggableFilter.forDefinition(this.configurationValue(
+                configuration, "lineItems.footpath", DEFAULT_LINE_ITEMS_FOOTPATH));
         this.flagBuildings = this.configurationValue(configuration, "buildings.flag", false);
         this.canCrossWaterBodyFilter = TaggableFilter.forDefinition(this.configurationValue(
                 configuration, "lineItems.non_offending", DEFAULT_CAN_CROSS_WATER_BODY_TAGS));
@@ -544,7 +543,7 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
             {
                 final Set<Location> interactionLocations = tuple.getSecond();
                 // crossing only ones or touching.
-                // ways with highway=steps may go inside if the waterbody.
+                // ways with highway=steps may go inside of the waterbody.
                 if (interactionLocations.size() == 1 && (interactionLocations
                         .contains(((Edge) lineItem).start().iterator().next())
                         || interactionLocations.contains(((Edge) lineItem).end().iterator().next())

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTest.java
@@ -96,6 +96,16 @@ public class LineCrossingWaterBodyCheckTest
     }
 
     @Test
+    public void testInvalidLineItemNotCrossingWaterBody()
+    {
+        this.verifier.actual(this.setup.invalidCrossingLineItemAtlasNotCrossingWaterBody(),
+                new LineCrossingWaterBodyCheck(ConfigurationResolver.inlineConfiguration(
+                        "{  \"LineCrossingWaterBodyCheck\": {" + "    \"enabled\": true,"
+                                + "    \"lineItems.offending\": \"highway->footway,bridleway,steps,corridor,path\" }}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testInvalidWithinOuterMemberNoInteractionWithInnerMember()
     {
         this.verifier.actual(this.setup.invalidWithinOuterMemberNoInteractionWithInnerMember(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTest.java
@@ -101,7 +101,7 @@ public class LineCrossingWaterBodyCheckTest
         this.verifier.actual(this.setup.invalidCrossingLineItemAtlasNotCrossingWaterBody(),
                 new LineCrossingWaterBodyCheck(ConfigurationResolver.inlineConfiguration(
                         "{  \"LineCrossingWaterBodyCheck\": {" + "    \"enabled\": true,"
-                                + "    \"lineItems.offending\": \"highway->footway,bridleway,steps,corridor,path\" }}")));
+                                + "    \"lineItems.footpath\": \"highway->footway,bridleway,steps,corridor,path\" }}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTestRule.java
@@ -31,6 +31,7 @@ public class LineCrossingWaterBodyCheckTestRule extends CoreTestRule
     private static final String LOCATION_OUTSIDE_AREA_2 = "47.581829, -122.303734";
     private static final String LOCATION_OUTSIDE_AREA_3 = "47.573128, -122.292999";
     private static final String LOCATION_OUTSIDE_AREA_4 = "47.569073, -122.309608";
+    private static final String LOCATION_INSIDE_AREA_1 = "47.5758164, -122.3059201";
 
     private static final String MULIPOLYGON_OUTER_1 = "47.6265, -122.3815";
     private static final String MULIPOLYGON_OUTER_2 = "47.5948, -122.3854";
@@ -469,6 +470,36 @@ public class LineCrossingWaterBodyCheckTestRule extends CoreTestRule
     private Atlas invalidCrossingLineItemAtlas;
 
     @TestAtlas(
+            // nodes
+            nodes = { @Node(id = "1234000000", coordinates = @Loc(value = AREA_LOCATION_1)),
+                    @Node(id = "2345000000", coordinates = @Loc(value = AREA_LOCATION_2)),
+                    @Node(id = "3467000000", coordinates = @Loc(value = AREA_LOCATION_3)),
+                    @Node(id = "4567000000", coordinates = @Loc(value = AREA_LOCATION_4)),
+                    @Node(id = "5678000000", coordinates = @Loc(value = AREA_LOCATION_5)),
+                    @Node(id = "6789000000", coordinates = @Loc(value = LOCATION_OUTSIDE_AREA_1)),
+                    @Node(id = "7891000000", coordinates = @Loc(value = LOCATION_OUTSIDE_AREA_2)),
+                    @Node(id = "8912000000", coordinates = @Loc(value = LOCATION_OUTSIDE_AREA_3)),
+                    @Node(id = "9123000000", coordinates = @Loc(value = LOCATION_OUTSIDE_AREA_4)),
+                    @Node(id = "9234000000", coordinates = @Loc(value = LOCATION_INSIDE_AREA_1)) },
+            // area
+            areas = { @Area(id = "9876000000", coordinates = { @Loc(value = AREA_LOCATION_1),
+                    @Loc(value = AREA_LOCATION_2), @Loc(value = AREA_LOCATION_3),
+                    @Loc(value = AREA_LOCATION_4),
+                    @Loc(value = AREA_LOCATION_5) }, tags = { "natural=water" }) },
+            // edges
+            edges = {
+                    // an edge
+                    @Edge(id = "4321000000", coordinates = { @Loc(value = LOCATION_OUTSIDE_AREA_1),
+                            @Loc(value = AREA_LOCATION_1) }, tags = { "highway=footway" }),
+                    // another edge
+                    @Edge(id = "9876000000", coordinates = { @Loc(value = LOCATION_OUTSIDE_AREA_2),
+                            @Loc(value = LOCATION_OUTSIDE_AREA_4) }, tags = { "highway=path" }),
+                    // another edge steps case
+                    @Edge(id = "5432000000", coordinates = { @Loc(value = LOCATION_OUTSIDE_AREA_2),
+                            @Loc(value = LOCATION_INSIDE_AREA_1) }, tags = { "highway=steps" }), })
+    private Atlas invalidCrossingLineItemAtlasNotCrossingWaterBody;
+
+    @TestAtlas(
             // Nodes
             nodes = { @Node(coordinates = @Loc(value = AREA_LOCATION_1)),
                     @Node(coordinates = @Loc(value = AREA_LOCATION_2)),
@@ -651,6 +682,11 @@ public class LineCrossingWaterBodyCheckTestRule extends CoreTestRule
     public Atlas invalidCrossingLineItemAtlas()
     {
         return this.invalidCrossingLineItemAtlas;
+    }
+
+    public Atlas invalidCrossingLineItemAtlasNotCrossingWaterBody()
+    {
+        return this.invalidCrossingLineItemAtlasNotCrossingWaterBody;
     }
 
     public Atlas invalidIntersectionItemsAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheckTestRule.java
@@ -492,8 +492,8 @@ public class LineCrossingWaterBodyCheckTestRule extends CoreTestRule
                     @Edge(id = "4321000000", coordinates = { @Loc(value = LOCATION_OUTSIDE_AREA_1),
                             @Loc(value = AREA_LOCATION_1) }, tags = { "highway=footway" }),
                     // another edge
-                    @Edge(id = "9876000000", coordinates = { @Loc(value = LOCATION_OUTSIDE_AREA_2),
-                            @Loc(value = LOCATION_OUTSIDE_AREA_4) }, tags = { "highway=path" }),
+                    @Edge(id = "8765000000", coordinates = { @Loc(value = LOCATION_OUTSIDE_AREA_2),
+                            @Loc(value = AREA_LOCATION_5) }, tags = { "highway=path" }),
                     // another edge steps case
                     @Edge(id = "5432000000", coordinates = { @Loc(value = LOCATION_OUTSIDE_AREA_2),
                             @Loc(value = LOCATION_INSIDE_AREA_1) }, tags = { "highway=steps" }), })


### PR DESCRIPTION
### Description:

Please refer to: https://github.com/osmlab/atlas-checks/issues/561

mapping rules:
1. ways that end on the edge of a water body with the following tags should not be flagged as issues:
highway=(footway|bridleway|steps|corridor|path)
2. ways that cross into a water body (and end there) with the highway=steps should also not be flagged.

### Potential Impact:

better handling for footway, bridleway, steps, corridor, path 

### Unit Test Approach:

created unit tests to validate logic according to mapping rules 

### Test Results:

passed