### PR TITLE
MultipleValuesInKeyCheck OSMOSE 9005 

### DIFF
--- a/src/main/resources/org/openstreetmap/atlas/checks/validation/tag/invalid-tags-check-regex-filter.json
+++ b/src/main/resources/org/openstreetmap/atlas/checks/validation/tag/invalid-tags-check-regex-filter.json
@@ -91,6 +91,102 @@
           ]
         }
       ]
-    }
+    },
+    {
+      "instruction": "The tag: {0} contains MULTIPLE VALUES separated by semicolons.",
+      "regex": [";"],      
+      "tagNames": [
+        "addr:street",
+        "highway",
+        "lanes",
+        "maxspeed",
+        "name",
+        "surface",
+        "telecom:medium",
+        "water", "waterway"
+      ],      
+      "exceptions": []
+    },
+    {
+      "instruction": "The tag: {0} BEGINS WITH semicolons.",
+      "regex": ["^;"],
+      "tagNames": [
+        "abutters", "access", "admin_level", "aerialway", "aeroway", "amenity",
+        "barrier", "bicycle", "boat", "border_type", "boundary", "bridge", "building", "construction",
+        "covered", "craft", "crossing", "cuisine", "cutting",
+        "disused", "drive_in", "drive_through",
+        "electrified", "embankment", "emergency",
+        "fenced", "foot", "ford",
+        "geological", "goods",
+        "hgv", "highway", "historic",
+        "internet_access",
+        "landuse", "lanes", "leisure",
+        "man_made", "military", "mooring", "motorboat", "mountain_pass", "name", "natural", "noexit", "note",
+        "office",
+        "power", "public_transport",
+        "railway", "route",
+        "sac_scale", "service", "shop", "smoothness", "source", "source_ref", "sport", "surface",
+        "tactile_paving", "toll", "tourism", "tracktype", "traffic_calming", "trail_visibility",
+        "tunnel",
+        "usage",
+        "vehicle",
+        "wall", "waterway", "wheelchair", "wood"
+      ],          
+      "exceptions": []
+    },    
+    {
+      "instruction": "The tag: {0} ENDS WITH semicolons.",
+      "regex": [";$"],
+      "tagNames": [
+        "abutters", "access", "admin_level", "aerialway", "aeroway", "amenity",
+        "barrier", "bicycle", "boat", "border_type", "boundary", "bridge", "building", "construction",
+        "covered", "craft", "crossing", "cuisine", "cutting",
+        "disused", "drive_in", "drive_through",
+        "electrified", "embankment", "emergency",
+        "fenced", "foot", "ford",
+        "geological", "goods",
+        "hgv", "highway", "historic",
+        "internet_access",
+        "landuse", "lanes", "leisure",
+        "man_made", "military", "mooring", "motorboat", "mountain_pass", "name", "natural", "noexit", "note",
+        "office",
+        "power", "public_transport",
+        "railway", "route",
+        "sac_scale", "service", "shop", "smoothness", "source", "source_ref", "sport", "surface",
+        "tactile_paving", "toll", "tourism", "tracktype", "traffic_calming", "trail_visibility",
+        "tunnel",
+        "usage",
+        "vehicle",
+        "wall", "waterway", "wheelchair", "wood"
+      ],          
+      "exceptions": []
+    },
+    {
+      "instruction": "The tag: {0} contains EMPTY SPACE in between semicolons.",
+      "regex": [";\\s*;"],
+      "tagNames": [
+        "abutters", "access", "admin_level", "aerialway", "aeroway", "amenity",
+        "barrier", "bicycle", "boat", "border_type", "boundary", "bridge", "building", "construction",
+        "covered", "craft", "crossing", "cuisine", "cutting",
+        "disused", "drive_in", "drive_through",
+        "electrified", "embankment", "emergency",
+        "fenced", "foot", "ford",
+        "geological", "goods",
+        "hgv", "highway", "historic",
+        "internet_access",
+        "landuse", "lanes", "leisure",
+        "man_made", "military", "mooring", "motorboat", "mountain_pass", "name", "natural", "noexit", "note",
+        "office",
+        "power", "public_transport",
+        "railway", "route",
+        "sac_scale", "service", "shop", "smoothness", "source", "source_ref", "sport", "surface",
+        "tactile_paving", "toll", "tourism", "tracktype", "traffic_calming", "trail_visibility",
+        "tunnel",
+        "usage",
+        "vehicle",
+        "wall", "waterway", "wheelchair", "wood"
+      ],             
+      "exceptions": []
+    }    
   ]
 }


### PR DESCRIPTION
### Description:

This PR is to address OSMOSE 9005:
Class 9005001 "{0.key} with multiple values" 
Class 9005002 "empty value in semicolon-separated {0.key}" 

e.g. the following are examples of tags that are flagged by OSMOSE 9005:

- lanes with multiple values 
lanes = 1;2;3 

- name with multiple values 
name = Historica;Marker 
name = 4;22 

- highway with multiple values 
highway = traffic_signals;crossing 

- addr:street with multiple values 
addr:street = Fagerquist Rd; Wolf Ln; Pearce Lane 

- maxspeed with multiple values 
maxspeed = 40;50  

- water with multiple values 
water = service;cattle 

- telecom:medium with multiple values 
telecom:medium = fibre;copper 

- begins with semicolons
source = ;survey 

- ends with semicolons
cuisine = noodle;soba; 

- empty value in semicolon-separated tag
cuisine = noodle;    ;soba; 

So REGEX filters have been added with 4 separate cases to make sure the instructions are clear with potential Auto-Fix capabilities. This is a resource update for InvalidTagsCheck.

Case 1: Tags should NOT allow MULTIPLE VALUES (e.g. maxspeed = 40;50). True positive if true. 
Case 2: Tags should NOT START WITH semicolons (e.g. source = ;survey). True positive if true. 
Case 3: Tags should NOT END WITH semicolons (e.g. source_ref = http://wiki.osm.org/wiki/GSI_KIBAN;). True positive if true.  
Case 4: Tags should NOT have empty values IN BETWEEN semicolons. (e.g. example;;example or example; ;example) True positive if true.  

### Test Results:

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
|  AUS  |    477         |    200      |     42%       |   200 |   0 | 0%   |
|  PRT   |    283         |    100      |     35%       |   100 |   0 | 0%   |
|  DZA  |    799         |    200      |     25%       |   200 |   0 | 0%   |
|  ROU |    292         |    35      |     12%       |   35 |   0 | 0%   |
|  TUR  |    161         |    87      |     54%       |   87 |   0 | 0%   |
|  FIN   |    298         |    200      |     67%       |   100 |   0 | 0%   |
|  COL  |    776         |    200      |     26%       |   200 |   0 | 0%   |

