### PR TITLE
Add Duplicate Relation Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -268,6 +268,14 @@
       "difficulty": "EASY"
     }
   },
+  "DuplicateRelationCheck": {
+    "challenge": {
+      "description": "Tasks contain Relations where duplicate relations are found.",
+      "blurb": "Duplicate Relations",
+      "instruction": "Open your favorite editor and  remove one or more of the duplicate relations until only one remains.",
+      "difficulty": "EASY"
+    }
+  },
   "DuplicateWaysCheck": {
     "enabled": false,
     "challenge": {

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -66,6 +66,7 @@ This document is a list of tables with a description and link to documentation f
 | Check Name | Check Description |
 | :--------- | :---------------- |
 | BoundaryIntersectionCheck |  This check is designed to scan relations marked as boundaries or with ways marked as boundaries and flag them for intersections with other boundaries of the same type. |
+| [DuplicateRelationCheck](checks/DuplicateRelationCheck.md) | This check attempts to scan multiple members Relations to identify duplicate Relations based on the same OSM tags and the same members with same roles. |
 | InvalidMultiPolygonRelationCheck |  This check is designed to scan through MultiPolygon relations and flag them for invalid geometry. |
 | [InvalidTurnRestrictionCheck](checks/invalidTurnRestrictionCheck.md) | The purpose of this check is to identify invalid turn restrictions in OSM. Invalid turn restrictions occur in a variety of ways from invalid members, Edge geometry issues, not being routable, or wrong topology. |
 | [MissingRelationType](checks/missingRelationType.md) | The purpose of this check is to identify Relations without relation type. |

--- a/docs/checks/duplicateRelationCheck.md
+++ b/docs/checks/duplicateRelationCheck.md
@@ -1,0 +1,16 @@
+# Duplicate Relation Check
+
+#### Description
+The Duplicate Relation check flags multiple members Relations in OSM that have the same OSM tags and the same members with same roles.
+We don't want instances of duplicate Relations that represent the same feature.
+
+#### Live Example
+The following examples illustrate two relations have the same OSM tags and the same members.
+1) This Relation [id:2096616](https://www.openstreetmap.org/relation/2096616)
+2) This Relation [id:2845741](https://www.openstreetmap.org/relation/2845741)
+
+
+#### Code Review
+
+To learn more about the code, please look at the comments in the source code for the check.
+[DuplicateRelationCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/relation/DuplicateRelationCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/DuplicateRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/DuplicateRelationCheck.java
@@ -1,0 +1,154 @@
+package org.openstreetmap.atlas.checks.validation.relations;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.checks.utility.CommonMethods;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMemberList;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * This check looks for multiple members {@link Relation}s duplicate with same OSM tags and same
+ * members with same roles.
+ *
+ * @author Xiaohong Tang
+ */
+public class DuplicateRelationCheck extends BaseCheck<Object>
+{
+    public static final String DUPLICATE_RELATION_INSTRUCTIONS = "Relation {0} and {1} are duplicates with same OSM tags and same members with same roles.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(DUPLICATE_RELATION_INSTRUCTIONS);
+    private static final long serialVersionUID = 2723186269280026809L;
+
+    public DuplicateRelationCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return object instanceof Relation && !isFlagged(object.getOsmIdentifier());
+    }
+
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Relation relation = (Relation) object;
+
+        this.markAsFlagged(relation.getOsmIdentifier());
+
+        // Exclude one member relations in this check, and leave that for the OneMemberRelationCheck
+        if (CommonMethods.getOSMRelationMemberSize(relation) == 1)
+        {
+            return Optional.empty();
+        }
+
+        final Set<Relation> relations = new HashSet<>();
+        final List<RelationMember> members = relation.members().stream()
+                .collect(Collectors.toList());
+
+        for (final RelationMember member : members)
+        {
+            relations.addAll(member.getEntity().relations());
+        }
+
+        relations.remove(relation);
+
+        final List<Long> duplicates = new ArrayList<>();
+
+        for (final Relation possibleDuplicate : relations)
+        {
+            if (relation.getOsmTags().equals(possibleDuplicate.getOsmTags())
+                    && this.areSameMembers(relation.members(), possibleDuplicate.members()))
+            {
+                duplicates.add(possibleDuplicate.getOsmIdentifier());
+                this.markAsFlagged(possibleDuplicate.getOsmIdentifier());
+            }
+        }
+
+        final String duplicatesString = duplicates.toString().replace("[", "").replace("]", "");
+
+        if (!duplicates.isEmpty())
+        {
+            return Optional.of(this.createFlag(object, this.getLocalizedInstruction(0,
+                    Long.toString(relation.getOsmIdentifier()), duplicatesString)));
+
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * Checks if two {@link RelationMemberList}s have same members with same roles
+     *
+     * @param first
+     *            the first {@link RelationMemberList} to check
+     * @param second
+     *            the second {@link RelationMemberList} to check
+     * @return true if the two RelationMemberList have same members with same roles.
+     */
+    private boolean areSameMembers(final RelationMemberList first, final RelationMemberList second)
+    {
+        final List<RelationMember> firstMembers = first.stream().collect(Collectors.toList());
+        final List<RelationMember> secondMembers = second.stream().collect(Collectors.toList());
+
+        if (firstMembers.size() != secondMembers.size())
+        {
+            return false;
+        }
+
+        for (final RelationMember relationMember : first)
+        {
+            final Optional<RelationMember> secondMember = this.containsMember(secondMembers,
+                    relationMember);
+            if (secondMember.isPresent())
+            {
+                secondMembers.remove(secondMember.get());
+            }
+            else
+            {
+                return false;
+            }
+        }
+        return secondMembers.isEmpty();
+    }
+
+    /**
+     * Checks if the {@link RelationMemberList} contains the {@link RelationMember}.
+     *
+     * @param membersList
+     *            {@link RelationMemberList} to check
+     * @param member
+     *            {@link RelationMember} to check
+     * @return the RelationMember if the RelationMemberList contains the member or an empty
+     *         optional.
+     */
+    private Optional<RelationMember> containsMember(final List<RelationMember> membersList,
+            final RelationMember member)
+    {
+        for (final RelationMember relationMember : membersList)
+        {
+            if (relationMember.compareTo(member) == 0)
+            {
+                return Optional.of(relationMember);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/DuplicateRelationCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/DuplicateRelationCheckTest.java
@@ -1,0 +1,65 @@
+package org.openstreetmap.atlas.checks.validation.relations;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link DuplicateRelationCheck}
+ *
+ * @author Xiaohong Tang
+ */
+public class DuplicateRelationCheckTest
+{
+    private static final DuplicateRelationCheck check = new DuplicateRelationCheck(
+            ConfigurationResolver.emptyConfiguration());
+
+    @Rule
+    public final DuplicateRelationCheckTestRule setup = new DuplicateRelationCheckTestRule();
+
+    @Rule
+    public final ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testDifferentMembersRelations()
+    {
+        this.verifier.actual(this.setup.getDifferentMembersRelations(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testDifferentOSMTagsAndMembersRelations()
+    {
+        this.verifier.actual(this.setup.getDifferentOSMTagsAndMembersRelations(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testDifferentRolesOnMembersRelations()
+    {
+        this.verifier.actual(this.setup.getDifferentRolesOnMembersRelations(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testDuplicateRelation()
+    {
+        this.verifier.actual(this.setup.getDuplicateRelations(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testOneMemberRelation()
+    {
+        this.verifier.actual(this.setup.getOneMemberRelations(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testSameOSMTagsAndMembersRelations()
+    {
+        this.verifier.actual(this.setup.getSameOSMTagsAndMembersRelations(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/relations/DuplicateRelationCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/relations/DuplicateRelationCheckTestRule.java
@@ -1,0 +1,183 @@
+package org.openstreetmap.atlas.checks.validation.relations;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * {@link DuplicateRelationCheckTest} data generator
+ *
+ * @author Xiaohong Tang
+ */
+public class DuplicateRelationCheckTestRule extends CoreTestRule
+{
+    private static final String ONE = "18.4360044, -71.7194204";
+    private static final String TWO = "18.4360737, -71.6970306";
+    private static final String THREE = "18.4273807, -71.7052283";
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "123", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any" }),
+                                    @Relation(id = "124", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any") }, tags = {
+                                                    "type=any" }) })
+    private Atlas differentMembersRelations;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "123", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any", "last_edit_user_name=any",
+                                                    "last_edit_changeset=43406696",
+                                                    "last_edit_time=1478282906000",
+                                                    "last_edit_user_id=1311281",
+                                                    "last_edit_version=3" }),
+                                    @Relation(id = "124", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=route", "last_edit_user_name=any",
+                                                    "last_edit_changeset=43406696",
+                                                    "last_edit_time=1478282906000",
+                                                    "last_edit_user_id=1311281",
+                                                    "last_edit_version=4" }) })
+    private Atlas differentOSMTagsAndMembersRelations;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "123", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any" }),
+                                    @Relation(id = "124", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "outer") }, tags = {
+                                                    "type=any" }) })
+    private Atlas differentRolesOnMembersRelations;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "123", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any" }),
+                                    @Relation(id = "124", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any" }) })
+    private Atlas duplicateRelations;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "123", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any", "last_edit_user_name=any",
+                                                    "last_edit_changeset=43406696",
+                                                    "last_edit_time=1478282906000",
+                                                    "last_edit_user_id=1311281",
+                                                    "last_edit_version=3" }),
+                                    @Relation(id = "124", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any", "last_edit_user_name=any",
+                                                    "last_edit_changeset=43406697",
+                                                    "last_edit_time=1478282906001",
+                                                    "last_edit_user_id=1311282",
+                                                    "last_edit_version=4" }) })
+    private Atlas sameOSMTagsAndMembersRelations;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE), @Loc(value = TWO) }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "123", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any" }),
+                                    @Relation(id = "124", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any") }, tags = {
+                                                    "type=any" }) })
+    private Atlas oneMemberRelations;
+
+    public Atlas getDifferentMembersRelations()
+    {
+        return this.differentMembersRelations;
+    }
+
+    public Atlas getDifferentOSMTagsAndMembersRelations()
+    {
+        return this.differentOSMTagsAndMembersRelations;
+    }
+
+    public Atlas getDifferentRolesOnMembersRelations()
+    {
+        return this.differentRolesOnMembersRelations;
+    }
+
+    public Atlas getDuplicateRelations()
+    {
+        return this.duplicateRelations;
+    }
+
+    public Atlas getOneMemberRelations()
+    {
+        return this.oneMemberRelations;
+    }
+
+    public Atlas getSameOSMTagsAndMembersRelations()
+    {
+        return this.sameOSMTagsAndMembersRelations;
+    }
+}


### PR DESCRIPTION
### Description:

Add Duplicate Relation Check, this check flags multiple members Relations in OSM that have the same OSM tags and the same members with same roles.
As discussed,  this check excludes one member relations and leave that for the OneMemberRelationCheck for avoiding one member relations overlap. 

### Test Results:
| ISO | Sampled | TP | FP | False Positive Rate |
|-----|----------|----|----| ------------------- |
|  ARG |   99 |    97     |   2 |  2%   |
|  AUS |   100 |    100     |   0 |  0%   |
|  ISR |   56 |    56     |   0 |  0%   |
|  MLT |   7 |    7     |   0 |  0%   |
|  NZL |   49 |    49     |   0 |  0%   |
|  SWE |   61 |    61     |   0 |  0%   |
|  TUR |   51 |    45     |   6 |  11%   |

### Note: 
The False Positive flagged relations in ARG and TUR are actually caused by those relations atlas objects generated from atlas having different members from the Relations in OSM, I filed [atlas issue#763 ](https://github.com/osmlab/atlas/issues/763) for it.


