### PR TITLE
Improving FPR by removing all "links" from the check combining cases.

### DIFF
--- a/docs/checks/suddenHighwayTypeChangeCheck.md
+++ b/docs/checks/suddenHighwayTypeChangeCheck.md
@@ -24,17 +24,9 @@ We first validate that the incoming object is:
 ##### Flagging the Edge
 Gather the ways' in and out edges. Iterate over these edges and determining if they fit within the 3 classifications of this check.
 
-##### Three classifications of Sudden Highway Tag Changes
-###### Class 1
-* Way with following classification: **Motorway, Trunk, or Primary**
-* Above way terminates and connects to following classification: **Tertiary, Unclassified, Residential, or Service**
-###### Class 2
-* Way with following classification: **Motorway_Link, Trunk_Link, Primary_Link, Secondary_Link, or Secondary**
-* Above way terminates and connects to following classification: **Unclassified, Residential, or Service**
-###### Class 3
-* Way with following classification: **Tertiary or Tertiary_Link**
-* Above way terminates and connects to following classification: **Living_Street, Service, or Track**
-
+##### Concerning Highway Change Classification
+* Way with following classification: **Motorway, Trunk, Primary, Secondary, or Tertiary**
+* Above way terminates and connects to following classification: **Unclassified, Residential, Living Street, Track, or Service**
 
 To learn more about the code, please look at the comments in the source code for the check.  
 [SuddenHighwayTypeChangeCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SuddenHighwayTypeChangeCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SuddenHighwayTypeChangeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SuddenHighwayTypeChangeCheck.java
@@ -131,40 +131,13 @@ public class SuddenHighwayTypeChangeCheck extends BaseCheck<Long>
      *            tag for edge being verified
      * @return boolean
      */
-    private boolean edgeBeingVerifiedCaseOne(final HighwayTag edgeHighwayTag)
+    private boolean edgeBeingVerifiedConcerningJump(final HighwayTag edgeHighwayTag)
     {
         return HighwayTag.MOTORWAY.equals(edgeHighwayTag)
                 || HighwayTag.PRIMARY.equals(edgeHighwayTag)
-                || HighwayTag.TRUNK.equals(edgeHighwayTag);
-    }
-
-    /**
-     * Case three: edge being verified is tertiary or tertiary_link
-     * 
-     * @param edgeHighwayTag
-     *            tag for edge being verified
-     * @return boolean
-     */
-    private boolean edgeBeingVerifiedCaseThree(final HighwayTag edgeHighwayTag)
-    {
-        return HighwayTag.TERTIARY.equals(edgeHighwayTag)
-                || HighwayTag.TERTIARY_LINK.equals(edgeHighwayTag);
-    }
-
-    /**
-     * case two: edge being verified is any link but tertiary.
-     * 
-     * @param edgeHighwayTag
-     *            tag for edge being verified
-     * @return boolean
-     */
-    private boolean edgeBeingVerifiedCaseTwo(final HighwayTag edgeHighwayTag)
-    {
-        return HighwayTag.MOTORWAY_LINK.equals(edgeHighwayTag)
-                || HighwayTag.PRIMARY_LINK.equals(edgeHighwayTag)
-                || HighwayTag.TRUNK_LINK.equals(edgeHighwayTag)
+                || HighwayTag.TRUNK.equals(edgeHighwayTag)
                 || HighwayTag.SECONDARY.equals(edgeHighwayTag)
-                || HighwayTag.SECONDARY_LINK.equals(edgeHighwayTag);
+                || HighwayTag.TERTIARY.equals(edgeHighwayTag);
     }
 
     /**
@@ -174,40 +147,13 @@ public class SuddenHighwayTypeChangeCheck extends BaseCheck<Long>
      *            connected edge highway tag
      * @return boolean
      */
-    private boolean edgeCheckedAgainstCaseOne(final HighwayTag edgeHighwayTag)
-    {
-        return HighwayTag.TERTIARY.equals(edgeHighwayTag)
-                || HighwayTag.UNCLASSIFIED.equals(edgeHighwayTag)
-                || HighwayTag.RESIDENTIAL.equals(edgeHighwayTag)
-                || HighwayTag.SERVICE.equals(edgeHighwayTag);
-    }
-
-    /**
-     * case three: edge checked against is living_Street, service, or track
-     * 
-     * @param edgeHighwayTag
-     *            connected edge highway tag
-     * @return boolean
-     */
-    private boolean edgeCheckedAgainstCaseThree(final HighwayTag edgeHighwayTag)
-    {
-        return HighwayTag.LIVING_STREET.equals(edgeHighwayTag)
-                || HighwayTag.TRACK.equals(edgeHighwayTag)
-                || HighwayTag.SERVICE.equals(edgeHighwayTag);
-    }
-
-    /**
-     * case two: edge checked against is residential, service, or unclassified
-     * 
-     * @param edgeHighwayTag
-     *            connected edge highway tag
-     * @return boolean
-     */
-    private boolean edgeCheckedAgainstCaseTwo(final HighwayTag edgeHighwayTag)
+    private boolean edgeCheckedAgainstConcerningJump(final HighwayTag edgeHighwayTag)
     {
         return HighwayTag.UNCLASSIFIED.equals(edgeHighwayTag)
                 || HighwayTag.RESIDENTIAL.equals(edgeHighwayTag)
-                || HighwayTag.SERVICE.equals(edgeHighwayTag);
+                || HighwayTag.SERVICE.equals(edgeHighwayTag)
+                || HighwayTag.LIVING_STREET.equals(edgeHighwayTag)
+                || HighwayTag.TRACK.equals(edgeHighwayTag);
     }
 
     /**
@@ -245,10 +191,8 @@ public class SuddenHighwayTypeChangeCheck extends BaseCheck<Long>
                     && !firstEdgeEdgeHighwayTag.equals(HighwayTag.NO)
                     && !firstEdgeStartNodeEdgesHighwayTags.contains(edgeBeingVerifiedHighwayTag)
                     && !this.edgeIsRoundaboutOrCircular(firstEdgeEdge))
-                    && (this.isCaseOne(edgeBeingVerifiedHighwayTag, firstEdgeEdgeHighwayTag)
-                            || this.isCaseTwo(edgeBeingVerifiedHighwayTag, firstEdgeEdgeHighwayTag)
-                            || this.isCaseThree(edgeBeingVerifiedHighwayTag,
-                                    firstEdgeEdgeHighwayTag)))
+                    && (this.isConcerningHighwayTagJump(edgeBeingVerifiedHighwayTag,
+                            firstEdgeEdgeHighwayTag)))
             {
                 return true;
             }
@@ -287,40 +231,11 @@ public class SuddenHighwayTypeChangeCheck extends BaseCheck<Long>
      *            some edge tag
      * @return boolean
      */
-    private boolean isCaseOne(final HighwayTag edgeHighwayTag1, final HighwayTag edgeHighwayTag2)
+    private boolean isConcerningHighwayTagJump(final HighwayTag edgeHighwayTag1,
+            final HighwayTag edgeHighwayTag2)
     {
-        return this.edgeBeingVerifiedCaseOne(edgeHighwayTag1)
-                && this.edgeCheckedAgainstCaseOne(edgeHighwayTag2);
-    }
-
-    /**
-     * checks if case three for edge being verified and edge checked against is true
-     * 
-     * @param edgeHighwayTag1
-     *            some edge tag
-     * @param edgeHighwayTag2
-     *            some edge tag
-     * @return boolean
-     */
-    private boolean isCaseThree(final HighwayTag edgeHighwayTag1, final HighwayTag edgeHighwayTag2)
-    {
-        return this.edgeBeingVerifiedCaseThree(edgeHighwayTag1)
-                && this.edgeCheckedAgainstCaseThree(edgeHighwayTag2);
-    }
-
-    /**
-     * checks if case two for edge being verified and edge checked against is true
-     * 
-     * @param edgeHighwayTag1
-     *            some edge tag
-     * @param edgeHighwayTag2
-     *            some edge tag
-     * @return boolean
-     */
-    private boolean isCaseTwo(final HighwayTag edgeHighwayTag1, final HighwayTag edgeHighwayTag2)
-    {
-        return this.edgeBeingVerifiedCaseTwo(edgeHighwayTag1)
-                && this.edgeCheckedAgainstCaseTwo(edgeHighwayTag2);
+        return this.edgeBeingVerifiedConcerningJump(edgeHighwayTag1)
+                && this.edgeCheckedAgainstConcerningJump(edgeHighwayTag2);
     }
 
     /**
@@ -346,10 +261,8 @@ public class SuddenHighwayTypeChangeCheck extends BaseCheck<Long>
                     && !edgeBeingVerifiedHighwayTag.equals(HighwayTag.NO)
                     && !lastEdgeEndNodeEdgesHighwayTags.contains(edgeBeingVerifiedHighwayTag)
                     && !this.edgeIsRoundaboutOrCircular(lastEdgeEdge))
-                    && (this.isCaseOne(edgeBeingVerifiedHighwayTag, lastEdgeEdgeHighwayTag)
-                            || this.isCaseTwo(edgeBeingVerifiedHighwayTag, lastEdgeEdgeHighwayTag)
-                            || this.isCaseThree(edgeBeingVerifiedHighwayTag,
-                                    lastEdgeEdgeHighwayTag)))
+                    && (this.isConcerningHighwayTagJump(edgeBeingVerifiedHighwayTag,
+                            lastEdgeEdgeHighwayTag)))
             {
                 return true;
             }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SuddenHighwayTypeChangeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SuddenHighwayTypeChangeCheckTest.java
@@ -36,25 +36,4 @@ public class SuddenHighwayTypeChangeCheckTest
         this.verifier.actual(this.setup.truePositiveSuddenHighwayTypeChangeCheck(), this.check);
         this.verifier.verifyExpectedSize(1);
     }
-
-    @Test
-    public void truePositiveCase1()
-    {
-        this.verifier.actual(this.setup.truePositiveCase1(), this.check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void truePositiveCase2()
-    {
-        this.verifier.actual(this.setup.truePositiveCase2(), this.check);
-        this.verifier.verifyExpectedSize(1);
-    }
-
-    @Test
-    public void truePositiveCase3()
-    {
-        this.verifier.actual(this.setup.truePositiveCase3(), this.check);
-        this.verifier.verifyExpectedSize(1);
-    }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SuddenHighwayTypeChangeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SuddenHighwayTypeChangeCheckTestRule.java
@@ -37,51 +37,9 @@ public class SuddenHighwayTypeChangeCheckTestRule extends CoreTestRule
                             @Loc(value = WAY2_NODE2) }, tags = "highway=secondary") })
     private Atlas falsePositiveSuddenHighwayTypeChangeCheck;
 
-    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = WAY1_NODE1)),
-            @Node(coordinates = @Loc(value = WAY1_WAY2_INTERSECTION)),
-            @Node(coordinates = @Loc(value = WAY2_NODE2)) }, edges = {
-                    @Edge(id = "5000001", coordinates = { @Loc(value = WAY1_NODE1),
-                            @Loc(value = WAY1_WAY2_INTERSECTION) }, tags = "highway=motorway"),
-                    @Edge(id = "6000001", coordinates = { @Loc(value = WAY1_WAY2_INTERSECTION),
-                            @Loc(value = WAY2_NODE2) }, tags = "highway=tertiary") })
-    private Atlas truePositiveCase1;
-
-    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = WAY1_NODE1)),
-            @Node(coordinates = @Loc(value = WAY1_WAY2_INTERSECTION)),
-            @Node(coordinates = @Loc(value = WAY2_NODE2)) }, edges = {
-                    @Edge(id = "7000001", coordinates = { @Loc(value = WAY1_NODE1),
-                            @Loc(value = WAY1_WAY2_INTERSECTION) }, tags = "highway=primary_link"),
-                    @Edge(id = "8000001", coordinates = { @Loc(value = WAY1_WAY2_INTERSECTION),
-                            @Loc(value = WAY2_NODE2) }, tags = "highway=residential") })
-    private Atlas truePositiveCase2;
-
-    @TestAtlas(nodes = { @Node(coordinates = @Loc(value = WAY1_NODE1)),
-            @Node(coordinates = @Loc(value = WAY1_WAY2_INTERSECTION)),
-            @Node(coordinates = @Loc(value = WAY2_NODE2)) }, edges = {
-                    @Edge(id = "9000001", coordinates = { @Loc(value = WAY1_NODE1),
-                            @Loc(value = WAY1_WAY2_INTERSECTION) }, tags = "highway=tertiary"),
-                    @Edge(id = "10000001", coordinates = { @Loc(value = WAY1_WAY2_INTERSECTION),
-                            @Loc(value = WAY2_NODE2) }, tags = "highway=service") })
-    private Atlas truePositiveCase3;
-
     public Atlas falsePositiveSuddenHighwayTypeChangeCheck()
     {
         return this.falsePositiveSuddenHighwayTypeChangeCheck;
-    }
-
-    public Atlas truePositiveCase1()
-    {
-        return this.truePositiveCase1;
-    }
-
-    public Atlas truePositiveCase2()
-    {
-        return this.truePositiveCase2;
-    }
-
-    public Atlas truePositiveCase3()
-    {
-        return this.truePositiveCase3;
     }
 
     public Atlas truePositiveSuddenHighwayTypeChangeCheck()


### PR DESCRIPTION
Improving FPR by removing all "links" from the check and combined left over cases into one.

After feedback from the editorial team, removing the links from this check would help reduce the FPR. In doing so, there no longer need to be cases and the check has one case instead of 3.

