### PR TITLE
ConnectivityCheck - extracted highway values

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -55,6 +55,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
     private static final long serialVersionUID = -380675222726130708L;
     private final TaggableFilter denylistedHighwaysTaggableFilter;
     private final Distance threshold;
+    private final List<String> checkedHighwayValues;
 
     public ConnectivityCheck(final Configuration configuration)
     {
@@ -64,6 +65,8 @@ public class ConnectivityCheck extends BaseCheck<Long>
         this.denylistedHighwaysTaggableFilter = TaggableFilter
                 .forDefinition(this.configurationValue(configuration, "denylisted.highway.filter",
                         DEFAULT_DENYLISTED_HIGHWAYS_TAG_FILTER));
+        this.checkedHighwayValues = this.configurationValue(configuration, "checked.highway.values",
+                new ArrayList<>());
     }
 
     @Override
@@ -530,7 +533,10 @@ public class ConnectivityCheck extends BaseCheck<Long>
      */
     private boolean validEdgeFilter(final Edge edge)
     {
-        return HighwayTag.isCarNavigableHighway(edge)
-                && !this.denylistedHighwaysTaggableFilter.test(edge) && !BarrierTag.isBarrier(edge);
+        final boolean validHighwayValue = this.checkedHighwayValues.isEmpty()
+                ? HighwayTag.isCarNavigableHighway(edge)
+                : this.checkedHighwayValues.contains(edge.highwayTag().getTagValue());
+        return validHighwayValue && !this.denylistedHighwaysTaggableFilter.test(edge)
+                && !BarrierTag.isBarrier(edge);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
@@ -22,6 +22,10 @@ public class ConnectivityCheckTest
     private final Configuration denylistedHighwayFilterConfig = ConfigurationResolver
             .inlineConfiguration(
                     "{\"ConnectivityCheck\":{\"denylisted.highway.filter\":\"highway->secondary\"}}");
+    private final Configuration highwayValuesConfig = ConfigurationResolver.inlineConfiguration(
+            "{\"ConnectivityCheck\":{\"checked.highway.values\":[\"motorway\", \"trunk\"]}}");
+    private final Configuration secondaryHighwayConfig = ConfigurationResolver.inlineConfiguration(
+            "{\"ConnectivityCheck\":{\"checked.highway.values\":[\"secondary\"]}}");
 
     @Test
     public void highwayFilterOnInvalidDisconnectedEdgeCrossingTest()
@@ -109,6 +113,22 @@ public class ConnectivityCheckTest
         this.verifier.actual(this.setup.invalidDisconnectedNodesAtlas(),
                 new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void specificHighwayValuesFlaggedTest()
+    {
+        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(),
+                new ConnectivityCheck(this.secondaryHighwayConfig));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void specificHighwayValuesTest()
+    {
+        this.verifier.actual(this.setup.invalidDisconnectedNodesAtlas(),
+                new ConnectivityCheck(this.highwayValuesConfig));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
 
     @Test
@@ -262,5 +282,4 @@ public class ConnectivityCheckTest
                 new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
     }
-
 }


### PR DESCRIPTION
### Description:

The check only flagged navigable roads. This update extracts highway values to be checked in a configurable in order to
expand the type of flagged edges when required. Default remains navigable roads.

### Potential Impact:

This could increase/decrease the quantity of flags based on configuration. No other changes have been made.

### Unit Test Approach:

Added 2 unit tests, one does not output flags because the highway configured does not match and one which matches and outputs a flag. 

### Test Results:

No country tests have been run since there was no change to logic.

