### PR TITLE
Change Calls to isMultiPolygon to isGeometric

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/FlaggedRelation.java
@@ -198,7 +198,7 @@ public class FlaggedRelation extends FlaggedObject
      */
     private MultiPolygon relationGeometry(final Relation relation)
     {
-        if (relation.isMultiPolygon())
+        if (relation.isGeometric())
         {
             try
             {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LineCrossingWaterBodyCheck.java
@@ -206,8 +206,8 @@ public class LineCrossingWaterBodyCheck extends BaseCheck<Long>
     {
         final Map<String, String> osmTags = crossingLine.getOsmTags();
         final Set<Relation> relations = crossingLine.relations();
-        final Set<Relation> multipolygonRelations = relations.stream()
-                .filter(Relation::isMultiPolygon).collect(Collectors.toSet());
+        final Set<Relation> multipolygonRelations = relations.stream().filter(Relation::isGeometric)
+                .collect(Collectors.toSet());
         // Crossing item is not part of any relation and has no tags, then infer it as part of a
         // boundary/coastline relation that is not ingested in the atlas.
         return osmTags.isEmpty() && relations.isEmpty()

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/relations/OneMemberRelationCheck.java
@@ -62,7 +62,7 @@ public class OneMemberRelationCheck extends BaseCheck<Object>
                                 members.get(0).getEntity().getOsmIdentifier())));
             }
             // If the relation is a multi-polygon,
-            if (relation.isMultiPolygon())
+            if (relation.isGeometric())
             {
                 return Optional.of(this.createFlag(this.getRelationMembers((Relation) object),
                         this.getLocalizedInstruction(1, relation.getOsmIdentifier())));

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidAccessTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidAccessTagCheck.java
@@ -149,7 +149,7 @@ public class InvalidAccessTagCheck extends BaseCheck<Long>
                 object.bounds(),
                 relation -> (Validators.isOfType(relation, LandUseTag.class, LandUseTag.MILITARY)
                         || Validators.hasValuesFor(relation, MilitaryTag.class))
-                        && relation.isMultiPolygon()))
+                        && relation.isGeometric()))
         {
             try
             {


### PR DESCRIPTION
### Description:
https://github.com/osmlab/atlas/pull/754 changed the logic of Relation.isMultiPolygon, and moved the previous logic to Relation.isGeometric. This introduced a few false positive flags across a couple of checks, as well as some changes in flag geometries.
The changes in this PR alter the effected checks and classes by changing to use isGeometric. 3 checks are effected, OneMemberRelationCheck, LineCrossingWaterBodyCheck, and InvalidAccessTagCheck. FlaggedRelation is also changed to allow all geometric relations to once again be output with multipolygon geometry, instead of just bounding boxes. 

### Potential Impact:
None

### Unit Test Approach:

Passes existing tests. 

### Test Results:
Ran in over 200 countries and calculated diffs. 

5 flags for InvalidAccessTagCheck were dropped, and all were in found to be intersecting military boundary relations. This is what is expected from this check.
Dropped flag features:
https://www.openstreetmap.org/way/202404790
https://www.openstreetmap.org/way/5205062
https://www.openstreetmap.org/way/721778383
https://www.openstreetmap.org/way/721778382
https://www.openstreetmap.org/way/910938149

3 flags for LineCrossingWaterBodyCheck were dropped. All were false positives, and where dropped due to being part of boundary relations.
Dropped flag features:
https://www.openstreetmap.org/way/112077775
https://www.openstreetmap.org/way/647501394
https://www.openstreetmap.org/way/192168453

The OneMemberRelationCheck changes just effected the instruction used.

