### PR TITLE
Fix Extra Points Created By MR Upload Command

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/flag/CheckFlag.java
@@ -454,23 +454,6 @@ public class CheckFlag implements Iterable<Location>, Located, Serializable
         task.setChallengeName(this.getChallengeName().orElse(this.getClass().getSimpleName()));
         task.setTaskIdentifier(this.identifier);
 
-        // Add custom pin point(s), if supplied.
-        final Set<Location> points = this.getPoints();
-        if (!points.isEmpty())
-        {
-            task.setPoints(points);
-        }
-        else
-        {
-            final Set<PolyLine> polyLines = this.getPolyLines();
-            if (!polyLines.isEmpty())
-            {
-                // Retrieve the first item in the list and retrieve the first point in the
-                // geometry for the object
-                task.setPoint(polyLines.iterator().next().iterator().next());
-            }
-        }
-
         final JsonArray features = new JsonArray();
         // Features
         if (!this.getGeometryWithProperties().isEmpty())


### PR DESCRIPTION
### Description:
This removes logic that was creating duplicate and erroneous points in MapRoulette tasks created using the MapRouletteUpload Command. 
The logic took all points from the geojson and added then to a Task.points List, or created points from the beginning of polylines and added them. This was causing duplication as the original points were  still added with the rest of the geojson features.

Resolves https://github.com/osmlab/atlas-checks/issues/522

### Potential Impact:
No more erroneous points in MR tasks.

### Unit Test Approach:

Passes current tests.

### Test Results:

Tried uploading flags from LineCrossingWaterBodyCheck that included synthetic highlight points to a test MR project, with and without the removed logic. Before the logic was removed duplicate point were present in uploaded task geojson. After the logic was removed the only points were those present in the original flag geojson. 

Task Geojson from MR dashboard:
Before:
```json
{
    "type": "FeatureCollection",
    "features":
    [
        {
            "type": "Feature",
            "geometry":
            {
                "type": "Point",
                "coordinates":
                [
                    56.1192051,
                    24.8185386
                ]
            },
            "properties":
            {}
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "Point",
                "coordinates":
                [
                    56.1192462,
                    24.8185139
                ]
            },
            "properties":
            {}
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "Point",
                "coordinates":
                [
                    56.1192051,
                    24.8185386
                ]
            },
            "properties":
            {
                "flag:check": "United Arab Emirates - Line Crossing Water Body Check",
                "flag:generator": "Atlas Checks",
                "synthetic_highlight_point": "yes"
            }
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "Point",
                "coordinates":
                [
                    56.1192462,
                    24.8185139
                ]
            },
            "properties":
            {
                "synthetic_highlight_point": "yes"
            }
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "LineString",
                "coordinates":
                [
                    [
                        56.1192051,
                        24.8185386
                    ],
                    [
                        56.1191967,
                        24.818527
                    ],
                    [
                        56.1192378,
                        24.8185024
                    ],
                    [
                        56.1192462,
                        24.8185139
                    ],
                    [
                        56.1192051,
                        24.8185386
                    ]
                ]
            },
            "properties":
            {
                "source": "Maxar Premium Imagery",
                "building": "yes",
                "itemType": "Area",
                "identifier": "886292376000000",
                "osmIdentifier": "886292376",
                "last_edit_time": "1608318518000",
                "iso_country_code": "ARE",
                "last_edit_user_id": "556498",
                "last_edit_version": "1",
                "last_edit_changeset": "96087377",
                "last_edit_user_name": "tungstentt"
            }
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "LineString",
                "coordinates":
                [
                    [
                        56.1192051,
                        24.8185386
                    ],
                    [
                        56.1192401,
                        24.8185865
                    ],
                    [
                        56.1192811,
                        24.8185619
                    ],
                    [
                        56.1192462,
                        24.8185139
                    ],
                    [
                        56.1192051,
                        24.8185386
                    ]
                ]
            },
            "properties":
            {
                "source": "Maxar Premium Imagery",
                "landuse": "reservoir",
                "itemType": "Area",
                "identifier": "886292375000000",
                "osmIdentifier": "886292375",
                "last_edit_time": "1608318518000",
                "iso_country_code": "ARE",
                "last_edit_user_id": "556498",
                "last_edit_version": "1",
                "last_edit_changeset": "96087377",
                "last_edit_user_name": "tungstentt"
            }
        }
    ]
}
```

After:
```json
{
    "type": "FeatureCollection",
    "features":
    [
        {
            "type": "Feature",
            "geometry":
            {
                "type": "Point",
                "coordinates":
                [
                    56.1192051,
                    24.8185386
                ]
            },
            "properties":
            {
                "flag:check": "United Arab Emirates - Line Crossing Water Body Check",
                "flag:generator": "Atlas Checks",
                "synthetic_highlight_point": "yes"
            }
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "Point",
                "coordinates":
                [
                    56.1192462,
                    24.8185139
                ]
            },
            "properties":
            {
                "synthetic_highlight_point": "yes"
            }
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "LineString",
                "coordinates":
                [
                    [
                        56.1192051,
                        24.8185386
                    ],
                    [
                        56.1191967,
                        24.818527
                    ],
                    [
                        56.1192378,
                        24.8185024
                    ],
                    [
                        56.1192462,
                        24.8185139
                    ],
                    [
                        56.1192051,
                        24.8185386
                    ]
                ]
            },
            "properties":
            {
                "source": "Maxar Premium Imagery",
                "building": "yes",
                "itemType": "Area",
                "identifier": "886292376000000",
                "osmIdentifier": "886292376",
                "last_edit_time": "1608318518000",
                "iso_country_code": "ARE",
                "last_edit_user_id": "556498",
                "last_edit_version": "1",
                "last_edit_changeset": "96087377",
                "last_edit_user_name": "tungstentt"
            }
        },
        {
            "type": "Feature",
            "geometry":
            {
                "type": "LineString",
                "coordinates":
                [
                    [
                        56.1192051,
                        24.8185386
                    ],
                    [
                        56.1192401,
                        24.8185865
                    ],
                    [
                        56.1192811,
                        24.8185619
                    ],
                    [
                        56.1192462,
                        24.8185139
                    ],
                    [
                        56.1192051,
                        24.8185386
                    ]
                ]
            },
            "properties":
            {
                "source": "Maxar Premium Imagery",
                "landuse": "reservoir",
                "itemType": "Area",
                "identifier": "886292375000000",
                "osmIdentifier": "886292375",
                "last_edit_time": "1608318518000",
                "iso_country_code": "ARE",
                "last_edit_user_id": "556498",
                "last_edit_version": "1",
                "last_edit_changeset": "96087377",
                "last_edit_user_name": "tungstentt"
            }
        }
    ]
}
```

