### PR TITLE
ConnectivityCheck flags parallel way as connectable

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
+    "enabled.value.default": false
   },
   "PoolSizeCheck": {
     "surface": {
@@ -186,6 +186,7 @@
     }
   },
   "ConnectivityCheck": {
+    "enabled": true,
     "nearby.edge.distance.meters": 2.0,
     "denylisted.highway.filter": "highway->no",
     "challenge": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {
@@ -186,7 +186,6 @@
     }
   },
   "ConnectivityCheck": {
-    "enabled": true,
     "nearby.edge.distance.meters": 2.0,
     "denylisted.highway.filter": "highway->no",
     "challenge": {

--- a/docs/checks/connectivityCheck.md
+++ b/docs/checks/connectivityCheck.md
@@ -4,6 +4,11 @@
 
 This check flags disconnected Edges in OSM that should be connected. 
 
+##### Scope
+08/10/21 (Change) 
+Reducing the scope by removing disconnected crossing edges cases due to logic duplication with [edgeCrossingEdgeCheck](edgeCrossingEdgeCheck.md). 
+Corresponded unit tests moved to edgeCrossingEdgeCheck: invalidDisconnectedNodesCrossingTest, invalidDisconnectedEdgeCrossingTest.
+
 #### Configuration
 
 This check has one configurable that can be changed in the configuration file [config.json](../../config/configuration.json)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -72,7 +72,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
         return object instanceof Node && !SyntheticBoundaryNodeTag.isSyntheticBoundaryNode(object)
                 && !this.isFlagged(object.getOsmIdentifier()) && !BarrierTag.isBarrier(object)
                 && !Validators.isOfType(object, NoExitTag.class, NoExitTag.YES)
-                && !this.connectedEdgesHaveLevelTags((Node) object)
+                && !this.connectedEdgesHaveLevelTags((Node) object) && this.isDeadEnd((Node) object)
                 // Node is part of a valid road, for this check
                 && ((Node) object).connectedEdges().stream().anyMatch(this::validEdgeFilter);
     }
@@ -518,6 +518,18 @@ public class ConnectivityCheck extends BaseCheck<Long>
             return this.headingsFormTriangle(firstHeading, connectionHeading, lastHeading);
         }
         return false;
+    }
+
+    /**
+     * Checks if {@link Node} is at the start or end of the {@link Edge} segment.
+     * 
+     * @param node
+     *            {@link Node} to check.
+     * @return true if {@link Node} has only one connected {@link Edge}
+     */
+    private boolean isDeadEnd(final Node node)
+    {
+        return node.connectedEdges().stream().count() < 2;
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -525,7 +525,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
      * 
      * @param node
      *            {@link Node} to check.
-     * @return true if {@link Node} has only one connected valid {@link Edge}
+     * @return true if {@link Node} has only one connected valid navigable {@link Edge}
      */
     private boolean isDeadEnd(final Node node)
     {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -525,11 +525,11 @@ public class ConnectivityCheck extends BaseCheck<Long>
      * 
      * @param node
      *            {@link Node} to check.
-     * @return true if {@link Node} has only one connected {@link Edge}
+     * @return true if {@link Node} has only one connected valid {@link Edge}
      */
     private boolean isDeadEnd(final Node node)
     {
-        return node.connectedEdges().stream().count() < 2;
+        return node.connectedEdges().stream().filter(this::validEdgeFilter).count() < 2;
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -148,6 +148,22 @@ public class EdgeCrossingEdgeCheckTest
     }
 
     @Test
+    public void testInvalidDisconnectedEdgeCrossingTest()
+    {
+        this.verifier.actual(this.setup.invalidDisconnectedEdgeCrossingAtlas(),
+                new EdgeCrossingEdgeCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void testInvalidDisconnectedNodesCrossingTest()
+    {
+        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(),
+                new EdgeCrossingEdgeCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void testNoCrossingItemsAtlas()
     {
         this.verifier.actual(this.setup.noCrossingItemsAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -19,6 +19,12 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     private static final String LOCATION_3 = "47.574612, -122.305855";
     private static final String LOCATION_4 = "47.575371, -122.308121";
     private static final String LOCATION_5 = "47.576485, -122.307098";
+    private static final String TEST1 = "47.2620768463041,-122.474848242369";
+    private static final String TEST2 = "47.2618703753848,-122.474832590205";
+    private static final String TEST3 = "47.26186971149,-122.474824764123";
+    private static final String TEST4 = "47.2618624086451,-122.475082046561";
+    private static final String TEST5 = "47.2618624086451,-122.474591938191";
+    private static final String TEST6 = "47.2617588409197,-122.474843351067";
 
     @TestAtlas(
             // nodes
@@ -248,6 +254,33 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_5) }, tags = { "highway=motorway" }) })
     private Atlas validIntersectionItemsAtlas;
 
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(TEST1)),
+                    @Node(id = "2000000", coordinates = @Loc(TEST2)),
+                    @Node(id = "3000000", coordinates = @Loc(TEST3)),
+                    @Node(id = "4000000", coordinates = @Loc(TEST4)),
+                    @Node(id = "5000000", coordinates = @Loc(TEST5)),
+                    @Node(id = "6000000", coordinates = @Loc(TEST6)) }, edges = {
+                            @Edge(id = "1234000000", coordinates = { @Loc(TEST1), @Loc(TEST3),
+                                    @Loc(TEST6) }, tags = { "highway=secondary" }),
+                            @Edge(id = "2345000000", coordinates = { @Loc(TEST4), @Loc(TEST2),
+                                    @Loc(TEST5) }, tags = { "highway=secondary" }), })
+    private Atlas invalidDisconnectedNodesCrossingAtlas;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(TEST1)),
+                    @Node(id = "2000000", coordinates = @Loc(TEST3)),
+                    @Node(id = "3000000", coordinates = @Loc(TEST4)),
+                    @Node(id = "4000000", coordinates = @Loc(TEST5)),
+                    @Node(id = "5000000", coordinates = @Loc(TEST6)) }, edges = {
+                            @Edge(id = "1234000000", coordinates = { @Loc(TEST1), @Loc(TEST3),
+                                    @Loc(TEST6) }, tags = { "highway=secondary" }),
+                            @Edge(id = "2345000000", coordinates = { @Loc(TEST4),
+                                    @Loc(TEST5) }, tags = { "highway=secondary" }) })
+    private Atlas invalidDisconnectedEdgeCrossingAtlas;
+
     public Atlas invalidCrossingItemsAtlas()
     {
         return this.invalidCrossingItemsAtlas;
@@ -286,6 +319,16 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     public Atlas invalidCrossingNonMainItemsAtlas()
     {
         return this.invalidCrossingNonMainItemsAtlas;
+    }
+
+    public Atlas invalidDisconnectedEdgeCrossingAtlas()
+    {
+        return this.invalidDisconnectedEdgeCrossingAtlas;
+    }
+
+    public Atlas invalidDisconnectedNodesCrossingAtlas()
+    {
+        return this.invalidDisconnectedNodesCrossingAtlas;
     }
 
     public Atlas noCrossingItemsAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
@@ -56,6 +56,14 @@ public class ConnectivityCheckTest
     }
 
     @Test
+    public void invalidConnectedNodesTestNavigableDeadEnd()
+    {
+        this.verifier.actual(this.setup.invalidConnectedNodesAtlasNavigableDeadEnd(),
+                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void invalidDisconnectedEdgesTest()
     {
         this.verifier.actual(this.setup.invalidDisconnectedEdgesAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
@@ -55,13 +55,12 @@ public class ConnectivityCheckTest
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
-    @Test
-    public void invalidDisconnectedEdgeCrossingTest()
-    {
-        this.verifier.actual(this.setup.invalidDisconnectedEdgeCrossingAtlas(),
-                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
+    /*
+     * @Test public void invalidDisconnectedEdgeCrossingTest() {
+     * this.verifier.actual(this.setup.invalidDisconnectedEdgeCrossingAtlas(), new
+     * ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
+     * this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size())); }
+     */
 
     @Test
     public void invalidDisconnectedEdgesTest()
@@ -79,21 +78,19 @@ public class ConnectivityCheckTest
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
-    @Test
-    public void invalidDisconnectedNodesCrossingLayerTest()
-    {
-        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingLayerAtlas(),
-                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
+    /*
+     * @Test public void invalidDisconnectedNodesCrossingLayerTest() {
+     * this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingLayerAtlas(), new
+     * ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
+     * this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size())); }
+     */
 
-    @Test
-    public void invalidDisconnectedNodesCrossingTest()
-    {
-        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(),
-                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
+    /*
+     * @Test public void invalidDisconnectedNodesCrossingTest() {
+     * this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(), new
+     * ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
+     * this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size())); }
+     */
 
     @Test
     public void invalidDisconnectedNodesOppositeTest()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
@@ -55,13 +55,6 @@ public class ConnectivityCheckTest
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
-    /*
-     * @Test public void invalidDisconnectedEdgeCrossingTest() {
-     * this.verifier.actual(this.setup.invalidDisconnectedEdgeCrossingAtlas(), new
-     * ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-     * this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size())); }
-     */
-
     @Test
     public void invalidDisconnectedEdgesTest()
     {
@@ -77,20 +70,6 @@ public class ConnectivityCheckTest
                 new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
-
-    /*
-     * @Test public void invalidDisconnectedNodesCrossingLayerTest() {
-     * this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingLayerAtlas(), new
-     * ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-     * this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size())); }
-     */
-
-    /*
-     * @Test public void invalidDisconnectedNodesCrossingTest() {
-     * this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(), new
-     * ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-     * this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size())); }
-     */
 
     @Test
     public void invalidDisconnectedNodesOppositeTest()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
@@ -184,40 +184,10 @@ public class ConnectivityCheckTestRule extends CoreTestRule
                             @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
                                     "highway=secondary" }),
                             @Edge(coordinates = { @Loc(TEST5), @Loc(TEST2) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
-                                    "highway=secondary" }) })
-    private Atlas invalidDisconnectedNodesCrossingAtlas;
-
-    @TestAtlas(
-            // Nodes
-            nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
-                    @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST5)),
-                    @Node(coordinates = @Loc(TEST7)), @Node(coordinates = @Loc(TEST8)) }, edges = {
-                            @Edge(coordinates = { @Loc(TEST1), @Loc(TEST3) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST5), @Loc(TEST2) }, tags = {
                                     "highway=secondary", "layer=1" }),
                             @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
                                     "highway=secondary", "layer=1" }) })
     private Atlas validDisconnectedNodesCrossingLayerAtlas;
-
-    @TestAtlas(
-            // Nodes
-            nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
-                    @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST5)),
-                    @Node(coordinates = @Loc(TEST7)), @Node(coordinates = @Loc(TEST8)) }, edges = {
-                            @Edge(coordinates = { @Loc(TEST1), @Loc(TEST3) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST5), @Loc(TEST2) }, tags = {
-                                    "highway=secondary", "layer=1" }),
-                            @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
-                                    "highway=secondary" }) })
-    private Atlas invalidDisconnectedNodesCrossingLayerAtlas;
 
     @TestAtlas(
             // Nodes
@@ -263,19 +233,6 @@ public class ConnectivityCheckTestRule extends CoreTestRule
                             @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
                                     "highway=pedestrian" }) })
     private Atlas validDisconnectedNodesCrossingPedestrianAtlas;
-
-    @TestAtlas(
-            // Nodes
-            nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST3)),
-                    @Node(coordinates = @Loc(TEST5)), @Node(coordinates = @Loc(TEST7)),
-                    @Node(coordinates = @Loc(TEST8)) }, edges = {
-                            @Edge(coordinates = { @Loc(TEST1), @Loc(TEST3) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST5), @Loc(TEST7) }, tags = {
-                                    "highway=secondary" }) })
-    private Atlas invalidDisconnectedEdgeCrossingAtlas;
 
     @TestAtlas(
             // Nodes
@@ -357,11 +314,6 @@ public class ConnectivityCheckTestRule extends CoreTestRule
         return this.invalidConnectedNodesAtlas;
     }
 
-    public Atlas invalidDisconnectedEdgeCrossingAtlas()
-    {
-        return this.invalidDisconnectedEdgeCrossingAtlas;
-    }
-
     public Atlas invalidDisconnectedEdgesAtlas()
     {
         return this.invalidDisconnectedEdgesAtlas;
@@ -375,16 +327,6 @@ public class ConnectivityCheckTestRule extends CoreTestRule
     public Atlas invalidDisconnectedNodesAtlas()
     {
         return this.invalidDisconnectedNodesOppositeAtlas;
-    }
-
-    public Atlas invalidDisconnectedNodesCrossingAtlas()
-    {
-        return this.invalidDisconnectedNodesCrossingAtlas;
-    }
-
-    public Atlas invalidDisconnectedNodesCrossingLayerAtlas()
-    {
-        return this.invalidDisconnectedNodesCrossingLayerAtlas;
     }
 
     public Atlas invalidDisconnectedNodesOppositeAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
@@ -35,6 +35,21 @@ public class ConnectivityCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(TEST1)),
+                    @Node(id = "2000000", coordinates = @Loc(TEST2)),
+                    @Node(id = "3000000", coordinates = @Loc(TEST3)),
+                    @Node(id = "4000000", coordinates = @Loc(TEST4)),
+                    @Node(id = "6000000", coordinates = @Loc(TEST6)) }, edges = {
+                            @Edge(id = "1234000000", coordinates = { @Loc(TEST1),
+                                    @Loc(TEST2) }, tags = { "highway=secondary" }),
+                            @Edge(id = "2345000000", coordinates = { @Loc(TEST3),
+                                    @Loc(TEST4) }, tags = { "highway=secondary" }),
+                            @Edge(id = "3456000000", coordinates = { @Loc(TEST2),
+                                    @Loc(TEST6) }, tags = { "boundary=administrative" }) })
+    private Atlas invalidDisconnectedNodesAtlasNavigableDeadEnd;
+
+    @TestAtlas(
+            // Nodes
             nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
                     @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST4)) }, edges = {
                             @Edge(coordinates = { @Loc(TEST1), @Loc(TEST2) }, tags = {
@@ -312,6 +327,11 @@ public class ConnectivityCheckTestRule extends CoreTestRule
     public Atlas invalidConnectedNodesAtlas()
     {
         return this.invalidConnectedNodesAtlas;
+    }
+
+    public Atlas invalidConnectedNodesAtlasNavigableDeadEnd()
+    {
+        return this.invalidDisconnectedNodesAtlasNavigableDeadEnd;
     }
 
     public Atlas invalidDisconnectedEdgesAtlas()


### PR DESCRIPTION
### Description:

Please refer to https://github.com/osmlab/atlas-checks/issues/504

ConnectivityCheck scope is reduced by removing duplicated logic of crossing edges to EdgeCrossingEdge check.  

### Potential Impact:

Nodes that too close but connected to two+ edges won't be flagged. 

### Unit Test Approach:

Corresponded unit tests: invalidDisconnectedNodesCrossingTest, invalidDisconnectedEdgeCrossingTest  from ConnectivityCheck moved to EdgeCrossingEdge. 


### Test Results:
passed