### PR TITLE
Add Duplicate Map Feature Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -252,6 +252,20 @@
       }
     }
   },
+  "DuplicateMapFeatureCheck": {
+    "features.tags.should.represent.only.once.in.area": [
+      "amenity",
+      "leisure",
+      "building",
+      "shop"
+    ],
+    "challenge": {
+      "description": "Tasks contain node, way or relation where duplicate map features are found.",
+      "blurb": "Duplicate Relations.",
+      "instruction": "Open your favorite editor and  remove one or more of the duplicate map features until only one remains..",
+      "difficulty": "NORMAL"
+    }
+  },
   "DuplicateNodeCheck": {
     "challenge": {
       "description": "Tasks contain node locations that have duplicate nodes found.",

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -82,6 +82,7 @@ This document is a list of tables with a description and link to documentation f
 | [ConflictingAreaTagCombination](checks/conflictingAreaTagCombination.md) | The purpose of this check is to identify Areas with invalid tag combinations. |
 | ConflictingTagCombinationCheck | This check verifies whether an atlas object has a conflicting tag combination or not. |
 | [ConstructionCheck](checks/constructionCheck.md) | The purpose of this check is to identify construction tags where the construction hasn't been checked on recently, or the expected finish date has been passed. |
+| [DuplicateMapFeatureCheck](checks/duplicateMapFeatureCheck) | The purpose of this check is to identify node, way or relation which have duplicate map features in areas or connected locations. |
 | [FixMeReviewCheck](checks/fixMeReviewCheck.md) | The purpose of this check is to flag features that contain the "fixme"/"FIXME" tags with along with a variety of other important tags. |
 | [GenericTagCheck](checks/genericTagCheck.md) | This check uses TagInfo and Wiki Data databases to look for invalid tags and suggest replacements. |
 | [HighwayAccessCheck](checks/highwayAccessCheck.md) | The check flags the objects that contain the proper access and highway tags. |

--- a/docs/checks/duplicateMapFeatureCheck.md
+++ b/docs/checks/duplicateMapFeatureCheck.md
@@ -1,0 +1,35 @@
+# Duplicate Map Feature Check
+
+#### Description
+The DuplicateMapFeaturecheck flags node, way or relation which have duplicate map features in areas or connected locations.
+[Osmose#4080](https://wiki.openstreetmap.org/wiki/Osmose/issues#4080):
+    Details
+    Object tagged twice as node, way or relation:
+    Class 1 "Object tagged twice as node and way" 
+    Class 2 "Object tagged twice as way and relation" 
+    Class 3 "Object tagged twice as node and relation" 
+
+This check attempts to identify duplicate map features in areas or connected locations for Class#1/#2/#3 when they have the same OSM tags or have the same following features on node/way/relation:
+    1)  amenity
+    2)  leisure
+    3)  building 
+    4)  shop  
+
+
+#### Live Example
+The following examples illustrate map feature tagged as node and way.
+1) Way [id:945675753](https://www.openstreetmap.org/way/945675753)
+2) Node [id:8738551735](https://www.openstreetmap.org/node/8738551735)
+
+The following examples illustrate map feature tagged as way and relation.
+1) Relation [id:3916231](https://www.openstreetmap.org/relation/3916231)
+2) Way [id:167449892](https://www.openstreetmap.org/way/167449892)
+
+The following examples illustrate map feature tagged as node and relation.
+1) Relation [id:12331039](https://www.openstreetmap.org/relation/12331039)
+2) Node [id:2499265898](https://www.openstreetmap.org/node/2499265898)
+
+#### Code Review
+
+To learn more about the code, please look at the comments in the source code for the check.
+[DuplicateMapFeatureCheck.java](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/DuplicateMapFeatureCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/DuplicateMapFeatureCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/DuplicateMapFeatureCheck.java
@@ -1,0 +1,424 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.Area;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.ItemType;
+import org.openstreetmap.atlas.geography.atlas.items.LocationItem;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
+import org.openstreetmap.atlas.geography.atlas.items.Relation;
+import org.openstreetmap.atlas.geography.atlas.items.RelationMember;
+import org.openstreetmap.atlas.tags.AmenityTag;
+import org.openstreetmap.atlas.tags.BuildingTag;
+import org.openstreetmap.atlas.tags.LeisureTag;
+import org.openstreetmap.atlas.tags.ShopTag;
+import org.openstreetmap.atlas.tags.SportTag;
+import org.openstreetmap.atlas.tags.names.NameTag;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+import org.openstreetmap.atlas.utilities.tuples.Tuple;
+
+/**
+ * This check is to detect and flag node, way or relation which have duplicate map features in areas
+ * or connected locations (Osmose 4080).
+ *
+ * @author Xiaohong Tang
+ */
+public class DuplicateMapFeatureCheck extends BaseCheck<Object>
+{
+    private static final String Duplicate_Features_INSTRUCTIONS = "{0} and {1} are duplicate feature {2}.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList(Duplicate_Features_INSTRUCTIONS);
+
+    private static final List<String> FeaturesTagsShouldRepresentOnlyOnce = Arrays
+            .asList(AmenityTag.KEY, LeisureTag.KEY, BuildingTag.KEY, ShopTag.KEY);
+
+    private static final List<ItemType> NodeItemsTypesToCompare = Arrays.asList(ItemType.NODE,
+            ItemType.POINT);
+
+    private static final List<ItemType> WayNodeItemsTypesToCompare = Arrays.asList(ItemType.AREA,
+            ItemType.EDGE, ItemType.LINE, ItemType.NODE, ItemType.POINT);
+
+    private static final long serialVersionUID = 7595976166632982218L;
+
+    private final List<String> featuresTagsShouldRepresentOnlyOnce;
+
+    public DuplicateMapFeatureCheck(final Configuration configuration)
+    {
+        super(configuration);
+        this.featuresTagsShouldRepresentOnlyOnce = this.configurationValue(configuration,
+                "features.tags.should.represent.only.once.in.area",
+                this.FeaturesTagsShouldRepresentOnlyOnce);
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return (object instanceof Area || object instanceof Edge || object instanceof Relation)
+                && !isFlagged(object.getOsmIdentifier());
+    }
+
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        this.markAsFlagged(object.getOsmIdentifier());
+
+        if (object.getOsmTags().isEmpty())
+        {
+            return Optional.empty();
+        }
+
+        final Set<String> duplicateFeatures = new HashSet<>();
+        final Map<String, String> duplicateFeaturesTags = new HashMap<>();
+
+        if (object instanceof Area)
+        {
+            final Area area = (Area) object;
+            try
+            {
+                final Iterable<AtlasEntity> entities = area.getAtlas().entitiesWithin(area.bounds(),
+                        entity -> NodeItemsTypesToCompare.contains(entity.getType()));
+
+                for (final AtlasEntity entity : entities)
+                {
+                    if (entity.getOsmTags().isEmpty())
+                    {
+                        continue;
+                    }
+                    final Optional<Tuple<String, Map<String, String>>> duplicateFeature = this
+                            .verifyDuplicateFeature(area, entity);
+
+                    if (duplicateFeature.isPresent())
+                    {
+                        duplicateFeatures.add(duplicateFeature.get().getFirst());
+                        duplicateFeaturesTags.putAll(duplicateFeature.get().getSecond());
+                    }
+                }
+            }
+            catch (final Exception ignored)
+            {
+                // Do Nothing
+            }
+
+            if (!duplicateFeatures.isEmpty())
+            {
+                final String duplicateFeatureString = this.getStringForList(duplicateFeatures);
+
+                return Optional.of(this.createFlag(object,
+                        this.getLocalizedInstruction(0,
+                                "Area type Way " + Long.toString(object.getOsmIdentifier()),
+                                duplicateFeatureString, duplicateFeaturesTags)));
+            }
+        }
+
+        if (object instanceof Edge)
+        {
+            final Edge edge = (Edge) object;
+
+            final Set<Node> nodes = edge.connectedNodes();
+            for (final Node node : nodes)
+            {
+                if (node.getOsmTags().isEmpty())
+                {
+                    continue;
+                }
+                final Optional<Tuple<String, Map<String, String>>> duplicateFeature = this
+                        .verifyDuplicateFeature(edge, node);
+
+                if (duplicateFeature.isPresent())
+                {
+                    duplicateFeatures.add(duplicateFeature.get().getFirst());
+                    duplicateFeaturesTags.putAll(duplicateFeature.get().getSecond());
+                }
+            }
+
+            if (!duplicateFeatures.isEmpty())
+            {
+                final String duplicateFeatureString = this.getStringForList(duplicateFeatures);
+
+                return Optional.of(this.createFlag(object,
+                        this.getLocalizedInstruction(0,
+                                "Way " + Long.toString(object.getOsmIdentifier()),
+                                duplicateFeatureString, duplicateFeaturesTags)));
+            }
+        }
+
+        if (object instanceof Relation)
+        {
+            final Relation relation = (Relation) object;
+
+            final List<RelationMember> members = relation.members().stream()
+                    .filter(m -> WayNodeItemsTypesToCompare.contains(m.getEntity().getType()))
+                    .collect(Collectors.toList());
+
+            for (final RelationMember member : members)
+            {
+                if (member.getEntity().getOsmTags().isEmpty())
+                {
+                    continue;
+                }
+                final Optional<Tuple<String, Map<String, String>>> duplicateFeature = this
+                        .verifyDuplicateFeature(relation, member.getEntity());
+
+                if (duplicateFeature.isPresent())
+                {
+                    duplicateFeatures.add(duplicateFeature.get().getFirst());
+                    duplicateFeaturesTags.putAll(duplicateFeature.get().getSecond());
+                }
+            }
+
+            if (relation.isGeometric())
+            {
+                try
+                {
+                    final Iterable<AtlasEntity> entities = relation.getAtlas().entitiesWithin(
+                            relation.bounds(),
+                            entity -> WayNodeItemsTypesToCompare.contains(entity.getType()));
+
+                    for (final AtlasEntity entity : entities)
+                    {
+                        if (this.isRelationMember(relation, entity)
+                                || entity.getOsmTags().isEmpty())
+                        {
+                            continue;
+                        }
+
+                        final Optional<Tuple<String, Map<String, String>>> duplicateFeature = this
+                                .verifyDuplicateFeature(relation, entity);
+
+                        if (duplicateFeature.isPresent())
+                        {
+                            duplicateFeatures.add(duplicateFeature.get().getFirst());
+                            duplicateFeaturesTags.putAll(duplicateFeature.get().getSecond());
+                        }
+                    }
+                }
+                catch (final Exception ignored)
+                {
+                    // Do Nothing
+                }
+            }
+
+            if (!duplicateFeatures.isEmpty())
+            {
+                final String duplicateFeatureString = this.getStringForList(duplicateFeatures);
+
+                return Optional.of(this.createFlag(object,
+                        this.getLocalizedInstruction(0,
+                                "Relation " + Long.toString(object.getOsmIdentifier()),
+                                duplicateFeatureString, duplicateFeaturesTags)));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    private String getStringForList(final Set<String> list)
+    {
+        return list.toString().replace("[", "").replace("]", "");
+    }
+
+    /**
+     * Checks if the {@link AtlasEntity} is a member of the {@link Relation}.
+     *
+     * @param relation
+     *            {@link Relation} to check
+     * @param entity
+     *            {@link AtlasEntity} to check
+     * @return true if the AtlasEntity is a member of the Relation
+     */
+    private boolean isRelationMember(final Relation relation, final AtlasEntity entity)
+    {
+        final List<RelationMember> members = relation.members().stream()
+                .collect(Collectors.toList());
+
+        for (final RelationMember relationMember : members)
+        {
+            if (relationMember.getEntity().getOsmIdentifier() == entity.getOsmIdentifier())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * check if two entities are duplicate feature
+     *
+     * @param firstEntity
+     *            the first entity to check
+     * @param secondEntity
+     *            the second entity to check
+     * @return duplicate feature and tags if the two entities are duplicate feature.
+     */
+    private Optional<Tuple<String, Map<String, String>>> verifyDuplicateFeature(
+            final AtlasEntity firstEntity, final AtlasEntity secondEntity)
+    {
+        final String duplicateFeatureStr;
+
+        if (firstEntity.getOsmTags().isEmpty() || secondEntity.getOsmTags().isEmpty())
+        {
+            return Optional.empty();
+        }
+
+        if (firstEntity.getOsmTags().equals(secondEntity.getOsmTags()))
+        {
+            final String firstEntityString = ((firstEntity instanceof Relation) ? "Relation "
+                    : "Way ") + Long.toString(firstEntity.getOsmIdentifier());
+
+            if (secondEntity instanceof LocationItem)
+            {
+                duplicateFeatureStr = "Node " + Long.toString(secondEntity.getOsmIdentifier())
+                        + " with the same tags as " + firstEntityString;
+            }
+            else
+            {
+                duplicateFeatureStr = "Way " + Long.toString(secondEntity.getOsmIdentifier())
+                        + " with the same tags as " + firstEntityString;
+            }
+
+            final Tuple<String, Map<String, String>> duplicateFeature = Tuple
+                    .createTuple(duplicateFeatureStr, firstEntity.getOsmTags());
+
+            return Optional.of(duplicateFeature);
+
+        }
+        else
+        {
+            final Optional<Map<String, String>> featuresTaggedTwice = this
+                    .verifyObjectTaggedTwice(firstEntity.getTags(), secondEntity.getOsmTags());
+
+            if (featuresTaggedTwice.isPresent())
+            {
+                if (secondEntity instanceof LocationItem)
+                {
+                    duplicateFeatureStr = "Node " + Long.toString(secondEntity.getOsmIdentifier());
+                }
+                else
+                {
+                    duplicateFeatureStr = "Way " + Long.toString(secondEntity.getOsmIdentifier());
+                }
+
+                final Tuple<String, Map<String, String>> duplicateFeature = Tuple
+                        .createTuple(duplicateFeatureStr, featuresTaggedTwice.get());
+
+                return Optional.of(duplicateFeature);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Checks if two set tags have object tagged twice
+     *
+     * @param firstTags
+     *            the first Osm tags to check
+     * @param secondTags
+     *            the second Osm tags to check
+     * @return duplicate feature tags if two set tags have object tagged twice.
+     */
+    private Optional<Map<String, String>> verifyObjectTaggedTwice(
+            final Map<String, String> firstTags, final Map<String, String> secondTags)
+    {
+        if (firstTags.isEmpty() || secondTags.isEmpty())
+        {
+            return Optional.empty();
+        }
+
+        final Map<String, String> inFirstTagsFeatureAllowRepresentOnce = firstTags.entrySet()
+                .stream()
+                .filter(map -> this.featuresTagsShouldRepresentOnlyOnce.contains(map.getKey()))
+                .collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
+        final Map<String, String> inSecondTagsFeatureAllowRepresentOnce = secondTags.entrySet()
+                .stream()
+                .filter(map -> this.featuresTagsShouldRepresentOnlyOnce.contains(map.getKey()))
+                .collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
+
+        if (inFirstTagsFeatureAllowRepresentOnce.isEmpty()
+                || inSecondTagsFeatureAllowRepresentOnce.isEmpty())
+        {
+            return Optional.empty();
+        }
+
+        final Map<String, String> featuresTaggedTwice = inFirstTagsFeatureAllowRepresentOnce
+                .entrySet().stream()
+                .filter(map -> map.getValue()
+                        .equals(inSecondTagsFeatureAllowRepresentOnce.get(map.getKey())))
+                .collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
+
+        if (!featuresTaggedTwice.isEmpty())
+        {
+
+            // amenity or leisure with different building tags are not duplicate feature
+            if (firstTags.get(BuildingTag.KEY) != null && secondTags.get(BuildingTag.KEY) != null
+                    && !firstTags.get(BuildingTag.KEY).equals(secondTags.get(BuildingTag.KEY)))
+            {
+                return Optional.empty();
+            }
+
+            // only same building tags without name are not duplicate feature
+            if (featuresTaggedTwice.keySet().contains(BuildingTag.KEY)
+                    && featuresTaggedTwice.keySet().size() == 1
+                    && (firstTags.get(NameTag.KEY) == null || secondTags.get(NameTag.KEY) == null))
+            {
+                return Optional.empty();
+            }
+
+            // leisure=pitch and different sport=* tags are not duplicate feature
+            // leisure=track and different sport=* tags are not duplicate feature
+            if (LeisureTag.PITCH.name().toLowerCase()
+                    .equals(featuresTaggedTwice.get(LeisureTag.KEY))
+                    || LeisureTag.TRACK.name().toLowerCase()
+                            .equals(featuresTaggedTwice.get(LeisureTag.KEY)))
+            {
+                if (Objects.equals(firstTags.get(SportTag.KEY), secondTags.get(SportTag.KEY)))
+                {
+
+                    if (firstTags.get(SportTag.KEY) != null)
+                    {
+                        featuresTaggedTwice.put(SportTag.KEY, firstTags.get(SportTag.KEY));
+                    }
+                    return Optional.of(featuresTaggedTwice);
+                }
+                else
+                {
+                    if (firstTags.get(SportTag.KEY) != null && secondTags.get(SportTag.KEY) != null)
+                    {
+                        return Optional.empty();
+                    }
+                }
+            }
+
+            if (Objects.equals(firstTags.get(NameTag.KEY), secondTags.get(NameTag.KEY)))
+            {
+
+                if (firstTags.get(NameTag.KEY) != null)
+                {
+                    featuresTaggedTwice.put(NameTag.KEY, firstTags.get(NameTag.KEY));
+                }
+                return Optional.of(featuresTaggedTwice);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/DuplicateMapFeatureCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/DuplicateMapFeatureCheckTest.java
@@ -1,0 +1,80 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link DuplicateMapFeatureCheck}
+ *
+ * @author Xiaohong Tang
+ */
+public class DuplicateMapFeatureCheckTest
+{
+    private static final DuplicateMapFeatureCheck check = new DuplicateMapFeatureCheck(
+            ConfigurationResolver.inlineConfiguration(
+                    "{\"DuplicateMapFeatureCheck\": {\"features.tags.should.represent.only.once.in.area\": [\"amenity\", \"leisure\", \"building\", \"shop\"]}}"));
+
+    @Rule
+    public final DuplicateMapFeatureCheckTestRule setup = new DuplicateMapFeatureCheckTestRule();
+
+    @Rule
+    public final ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void testAreaNodeDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getAreaNodeDuplicateFeature(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testAreaNodeNotDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getAreaNodeNotDuplicateFeature(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testEdgeNodeDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getEdgeNodeDuplicateFeature(), check);
+        this.verifier.verifyExpectedSize(3);
+    }
+
+    @Test
+    public void testEdgeNodeNotDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getEdgeNodeNotDuplicateFeature(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testRelationEdgeDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getRelationEdgeDuplicateFeature(), check);
+        this.verifier.verifyExpectedSize(2);
+    }
+
+    @Test
+    public void testRelationEdgeNotDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getRelationEdgeNotDuplicateFeature(), check);
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testRelationNodeDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getRelationNodeDuplicateFeature(), check);
+        this.verifier.verifyExpectedSize(1);
+    }
+
+    @Test
+    public void testRelationNodeNotDuplicateFeature()
+    {
+        this.verifier.actual(this.setup.getRelationNodeNotDuplicateFeature(), check);
+        this.verifier.verifyEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/DuplicateMapFeatureCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/DuplicateMapFeatureCheckTestRule.java
@@ -1,0 +1,192 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Area;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Relation.Member;
+
+/**
+ * {@link DuplicateMapFeatureCheckTest} data generator
+ *
+ * @author Xiaohong Tang
+ */
+public class DuplicateMapFeatureCheckTestRule extends CoreTestRule
+{
+    private static final String ONE = "18.4360044, -71.7194204";
+    private static final String TWO = "18.4360737, -71.6970306";
+    private static final String THREE = "18.4273807, -71.7052283";
+    private static final String AREA_LOCATION_ONE = "37.320524859664474, -122.03601479530336";
+    private static final String AREA_LOCATION_TWO = "37.320524859664474,-122.03530669212341";
+    private static final String AREA_LOCATION_THREE = "37.32097706357857, -122.03530669212341";
+    private static final String AREA_LOCATION_FOUR = "37.32097706357857, -122.03601479530336";
+    private static final String Node_LOCATION = "37.32067706357857, -122.03591479530336";
+    private static final String Node_LOCATION2 = "37.32067706357867, -122.03591479530336";
+
+    @TestAtlas(nodes = {
+            @Node(id = "1000000", coordinates = @Loc(value = Node_LOCATION), tags = {
+                    "amenity=cafe" }),
+            @Node(id = "2000000", coordinates = @Loc(value = Node_LOCATION2)) }, areas = {
+                    @Area(id = "12000000", coordinates = { @Loc(value = AREA_LOCATION_ONE),
+                            @Loc(value = AREA_LOCATION_TWO), @Loc(value = AREA_LOCATION_THREE),
+                            @Loc(value = AREA_LOCATION_FOUR),
+                            @Loc(value = AREA_LOCATION_ONE) }, tags = { "amenity=cafe" }) })
+    private Atlas areaNodeDuplicateFeature;
+
+    @TestAtlas(nodes = {
+            @Node(id = "1000000", coordinates = @Loc(value = Node_LOCATION), tags = {
+                    "building=yes" }),
+            @Node(id = "2000000", coordinates = @Loc(value = Node_LOCATION2)) }, areas = {
+                    @Area(id = "12000000", coordinates = { @Loc(value = AREA_LOCATION_ONE),
+                            @Loc(value = AREA_LOCATION_TWO), @Loc(value = AREA_LOCATION_THREE),
+                            @Loc(value = AREA_LOCATION_FOUR),
+                            @Loc(value = AREA_LOCATION_ONE) }, tags = { "building=yes",
+                                    "type=any" }) })
+    private Atlas areaNodeNotDuplicateFeature;
+
+    @TestAtlas(nodes = {
+            @Node(id = "1000000", coordinates = @Loc(value = ONE), tags = { "type=destination_sign",
+                    "destination=Space Needle" }),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO), tags = { "building=yes",
+                    "name=one" }),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE), tags = { "amenity=school",
+                    "building=one" }) }, edges = {
+                            @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
+                                    @Loc(value = TWO) }, tags = { "type=destination_sign",
+                                            "destination=Space Needle" }),
+                            @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                                    @Loc(value = THREE) }, tags = { "building=yes", "name=one" }),
+                            @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                                    @Loc(value = ONE) }, tags = { "amenity=school",
+                                            "building=one" }) })
+    private Atlas edgeNodeDuplicateFeature;
+
+    @TestAtlas(nodes = {
+            @Node(id = "1000000", coordinates = @Loc(value = ONE), tags = { "type=destination_sign",
+                    "destination=Space Needle", "building=yes" }),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO), tags = { "building=yes",
+                    "name=two" }),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE), tags = { "amenity=school",
+                    "building=two" }) }, edges = {
+                            @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
+                                    @Loc(value = TWO) }, tags = { "type=destination_sign",
+                                            "destination=Space Needle" }),
+                            @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                                    @Loc(value = THREE) }, tags = { "building=yes", "name=one" }),
+                            @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                                    @Loc(value = ONE) }, tags = { "amenity=school",
+                                            "building=one" }) })
+    private Atlas edgeNodeNotDuplicateFeature;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "leisure=track", "sport=running" }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "amenity=park" }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "523318400000000", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "leisure=track", "sport=running", "type=any" }),
+                                    @Relation(id = "523318500000000", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "amenity=park", "type=any" }) })
+    private Atlas relationEdgeDuplicateFeature;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = ONE)),
+            @Node(id = "2000000", coordinates = @Loc(value = TWO)),
+            @Node(id = "3000000", coordinates = @Loc(value = THREE)) }, edges = {
+                    @Edge(id = "12000000", coordinates = { @Loc(value = ONE),
+                            @Loc(value = TWO) }, tags = { "leisure=track", "sport=cycling" }),
+                    @Edge(id = "23000000", coordinates = { @Loc(value = TWO),
+                            @Loc(value = THREE) }, tags = { "amenity=park", "name=two" }),
+                    @Edge(id = "31000000", coordinates = { @Loc(value = THREE),
+                            @Loc(value = ONE) }) }, relations = {
+                                    @Relation(id = "523318400000000", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "leisure=track", "sport=running", "type=any" }),
+                                    @Relation(id = "523318500000000", members = {
+                                            @Member(id = "12000000", type = "edge", role = "any"),
+                                            @Member(id = "2000000", type = "node", role = "any"),
+                                            @Member(id = "23000000", type = "edge", role = "any") }, tags = {
+                                                    "amenity=park", "name=one", "type=any" }) })
+    private Atlas relationEdgeNotDuplicateFeature;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = Node_LOCATION), tags = {
+            "leisure=pitch", "sport=soccer" }) }, areas = {
+                    @Area(id = "12000000", coordinates = { @Loc(value = AREA_LOCATION_ONE),
+                            @Loc(value = AREA_LOCATION_TWO), @Loc(value = AREA_LOCATION_THREE),
+                            @Loc(value = AREA_LOCATION_FOUR),
+                            @Loc(value = AREA_LOCATION_ONE) }, tags = {
+                                    "type=any" }) }, relations = {
+                                            @Relation(id = "123", members = {
+                                                    @Member(id = "12000000", type = "area", role = "inner") }, tags = {
+                                                            "type=multipolygon", "leisure=pitch",
+                                                            "sport=soccer" }) })
+    private Atlas relationNodeDuplicateFeature;
+
+    @TestAtlas(nodes = { @Node(id = "1000000", coordinates = @Loc(value = Node_LOCATION), tags = {
+            "leisure=pitch", "sport=soccer" }) }, areas = {
+                    @Area(id = "12000000", coordinates = { @Loc(value = AREA_LOCATION_ONE),
+                            @Loc(value = AREA_LOCATION_TWO), @Loc(value = AREA_LOCATION_THREE),
+                            @Loc(value = AREA_LOCATION_FOUR),
+                            @Loc(value = AREA_LOCATION_ONE) }, tags = {
+                                    "type=any" }) }, relations = {
+                                            @Relation(id = "123", members = {
+                                                    @Member(id = "12000000", type = "area", role = "any"), }, tags = {
+                                                            "type=multipolygon", "leisure=pitch",
+                                                            "sport=basketball" }) })
+    private Atlas relationNodeNotDuplicateFeature;
+
+    public Atlas getAreaNodeDuplicateFeature()
+    {
+        return this.areaNodeDuplicateFeature;
+    }
+
+    public Atlas getAreaNodeNotDuplicateFeature()
+    {
+        return this.areaNodeNotDuplicateFeature;
+    }
+
+    public Atlas getEdgeNodeDuplicateFeature()
+    {
+        return this.edgeNodeDuplicateFeature;
+    }
+
+    public Atlas getEdgeNodeNotDuplicateFeature()
+    {
+        return this.edgeNodeNotDuplicateFeature;
+    }
+
+    public Atlas getRelationEdgeDuplicateFeature()
+    {
+        return this.relationEdgeDuplicateFeature;
+    }
+
+    public Atlas getRelationEdgeNotDuplicateFeature()
+    {
+        return this.relationEdgeNotDuplicateFeature;
+    }
+
+    public Atlas getRelationNodeDuplicateFeature()
+    {
+        return this.relationNodeDuplicateFeature;
+    }
+
+    public Atlas getRelationNodeNotDuplicateFeature()
+    {
+        return this.relationNodeNotDuplicateFeature;
+    }
+}


### PR DESCRIPTION
### Description:

Add Duplicate Map Feature Check, this check flags Node, Way or Relation which have duplicate map features in areas or connected locations. [Osmose#4080](https://wiki.openstreetmap.org/wiki/Osmose/issues#4080):
    Class 1 "Object tagged twice as node and way" 
    Class 2 "Object tagged twice as way and relation" 
    Class 3 "Object tagged twice as node and relation"

This check attempts to identify duplicate map features in areas or connected locations for Class1/2/3 when they have the same OSM tags or have the same following features on node/way/relation:
    1)  amenity
    2)  leisure
    3)  building 
    4)  shop  

### Test Results:

| ISO | Sampled  | TP | FP | False Positive Rate |
|-----|----------|------------|----| ------------------- |
|  AND   |    6      |   6  |   0 | 0%   |
|  BLZ   |    20      |  20 |   0 | 0%   |
|  BRN   |    4      |   4  |   0 | 0%   |
|  BTN   |    20      |  20 |   0 | 0%   |
|  COM   |    4      |   4  |   0 | 0%   |
|  CPV   |    20      |  20 |   0 | 0%   |
|  MLT   |    20     |   20 |   0 | 0%   |
