### PR TITLE
GenericTagCheck: Fail fast when databases cannot be read

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -362,7 +362,7 @@
     }
   },
     "GenericTagCheck": {
-    "db": {
+    "database": {
       "taginfo": "extra/taginfo-db.db",
       "wikidata": "extra/wikidata.db"
     },

--- a/docs/checks/genericTagCheck.md
+++ b/docs/checks/genericTagCheck.md
@@ -3,14 +3,14 @@
 This check uses TagInfo and WikiData databases to look for invalid, deprecated, or otherwise invalid tags.
 In addition, there is a fallback check that uses TagInfo data and WikiData items to determine if a tag is valid.
 The fallback check can be enabled or disabled by setting `"fallback"` to `false`. The location of the databases are
-set in a `"db"` section with either `"wikidata"` or `"taginfo"` as the key, and then the path as the value. This
+set in a `"database"` section with either `"wikidata"` or `"taginfo"` as the key, and then the path as the value. This
 _must_ be changed in Microsoft Windows environments (due to differences in file path separators). There is an additional
 key for the `wikidata` database, `"wikidata.tag_removal"` in main GenericTagCheck check configuration section. This
 controls the detection of tags that can be removed. By default, tags that have been marked with "abandoned",
 "deprecated", "imported", "obsolete", or "rejected" are removable.
 
 ## First steps
-You need to get a TagInfo db and a WikiData db. To that end, use the following scripts:
+You need to get a TagInfo database and a WikiData database. To that end, use the following scripts:
 * [scripts/taginfo/downloadTagInfo.py](../../scripts/taginfo/downloadTagInfo.py)
 * [scripts/wikidata/get\_wikidata.py](../../scripts/wikidata/get_wikidata.py)
 
@@ -24,7 +24,7 @@ be performed on changes, if desired.
 Example json:
 ```json
   "GenericTagCheck": {
-    "db": {
+    "database": {
       "taginfo": "extra/taginfo-db.db",
       "wikidata": "extra/wikidata.db"
     },
@@ -43,7 +43,7 @@ Example json:
   }
 ```
 
-### `db.{taginfo,wikidata}`
+### `database.{taginfo,wikidata}`
 This variable controls where the check looks for the TagInfo and WikiData databases. This is currently relative to the
 `atlas` file directory.
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/GenericTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/GenericTagCheck.java
@@ -178,9 +178,10 @@ public class GenericTagCheck extends BaseCheck<String>
         this.wikiTable = DEFAULT_WIKI_TABLE;
         this.tagInfoTagTable = DEFAULT_TAGINFO_TAG_TABLE;
         this.tagInfoKeyTable = DEFAULT_TAGINFO_KEY_TABLE;
-        this.tagInfoDB = this.configurationValue(configuration, "db.taginfo", DEFAULT_TAGINFO_DB);
-        this.wikiDataDB = this.configurationValue(configuration, "db.wikidata",
-                DEFAULT_WIKIDATA_DB);
+        this.tagInfoDB = this.configurationValue(configuration, "database.taginfo",
+                this.configurationValue(configuration, "db.taginfo", DEFAULT_TAGINFO_DB));
+        this.wikiDataDB = this.configurationValue(configuration, "database.wikidata",
+                this.configurationValue(configuration, "db.wikidata", DEFAULT_WIKIDATA_DB));
 
         // At time of implementation, this.configurationValue(..., ..., Integer) returns
         // a Long.
@@ -215,7 +216,7 @@ public class GenericTagCheck extends BaseCheck<String>
          * *always* required.
          */
         final boolean errorIfDatabaseNotFound = this.configurationValue(configuration,
-                "db.require_all", DEFAULT_ERROR_IF_DATABASE_IS_MISSING);
+                "database.require_all", DEFAULT_ERROR_IF_DATABASE_IS_MISSING);
         if (errorIfDatabaseNotFound && (this.sqliteUtilsTagInfoKeyTable == null
                 || this.sqliteUtilsTagInfoTagTable == null || this.sqliteUtilsWikiData == null))
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/GenericTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/GenericTagCheck.java
@@ -214,9 +214,9 @@ public class GenericTagCheck extends BaseCheck<String>
          * popular (i.e., they ran with wiki data but no tag info). Regardless, wiki data is
          * *always* required.
          */
-        final boolean errorIfDbNotFound = this.configurationValue(configuration, "db.require_all",
-                DEFAULT_ERROR_IF_DATABASE_IS_MISSING);
-        if (errorIfDbNotFound && (this.sqliteUtilsTagInfoKeyTable == null
+        final boolean errorIfDatabaseNotFound = this.configurationValue(configuration,
+                "db.require_all", DEFAULT_ERROR_IF_DATABASE_IS_MISSING);
+        if (errorIfDatabaseNotFound && (this.sqliteUtilsTagInfoKeyTable == null
                 || this.sqliteUtilsTagInfoTagTable == null || this.sqliteUtilsWikiData == null))
         {
             throw new CoreException(

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/GenericTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/GenericTagCheck.java
@@ -35,6 +35,7 @@ import org.openstreetmap.atlas.checks.utility.SQLiteUtils;
 import org.openstreetmap.atlas.checks.utility.feature_change.IFeatureChange;
 import org.openstreetmap.atlas.checks.utility.feature_change.RemoveTagFeatureChange;
 import org.openstreetmap.atlas.checks.utility.feature_change.ReplaceTagFeatureChange;
+import org.openstreetmap.atlas.exception.CoreException;
 import org.openstreetmap.atlas.geography.atlas.change.FeatureChange;
 import org.openstreetmap.atlas.geography.atlas.items.Area;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasEntity;
@@ -91,6 +92,9 @@ public class GenericTagCheck extends BaseCheck<String>
     private static final String DEFAULT_WIKI_TABLE = "wiki_data";
     private static final String DEFAULT_TAGINFO_TAG_TABLE = "tags";
     private static final String DEFAULT_TAGINFO_KEY_TABLE = "keys";
+    // The following are to ensure that the databases are present and have expected keys
+    // highway=residential should be present all the time
+    private static final boolean DEFAULT_ERROR_IF_DATABASE_IS_MISSING = true;
 
     private static final Logger logger = LoggerFactory.getLogger(GenericTagCheck.class);
 
@@ -201,6 +205,23 @@ public class GenericTagCheck extends BaseCheck<String>
         }
         this.fetchWikiData(fileFetcher);
         this.fetchTagInfo(fileFetcher);
+
+        /*
+         * Prevent this check from running, unless the user has indicated that not all databases are
+         * required Specifically leave these configuration values undocumented -- if people want to
+         * use only one or the other, they should understand all the issues involved. Namely, they
+         * may have many issues where they are told "key is not documented or popular" even if it is
+         * popular (i.e., they ran with wiki data but no tag info). Regardless, wiki data is
+         * *always* required.
+         */
+        final boolean errorIfDbNotFound = this.configurationValue(configuration, "db.require_all",
+                DEFAULT_ERROR_IF_DATABASE_IS_MISSING);
+        if (errorIfDbNotFound && (this.sqliteUtilsTagInfoKeyTable == null
+                || this.sqliteUtilsTagInfoTagTable == null || this.sqliteUtilsWikiData == null))
+        {
+            throw new CoreException(
+                    "GenericTagCheck: All databases are required and must be readable");
+        }
     }
 
     /**


### PR DESCRIPTION
### Description:

GenericTagCheck: Fail fast when databases cannot be read

In the interest of allowing people to not use the TagInfo db, i.e., if they
want to find tags without entries in wikidata, there are some new
*undocumented* options.


### Potential Impact:

People who depend upon GenericTagsCheck to always run will have to add an undocumented config option to the configuration json.

### Unit Test Approach:

N/A