### PR TITLE
ConnectivityCheck flags parallel way as connectable

### DIFF
--- a/docs/checks/connectivityCheck.md
+++ b/docs/checks/connectivityCheck.md
@@ -4,6 +4,11 @@
 
 This check flags disconnected Edges in OSM that should be connected. 
 
+##### Scope
+08/10/21 (Change)
+Reducing the scope by removing disconnected crossing edges cases due to logic duplication with [edgeCrossingEdgeCheck](edgeCrossingEdgeCheck.md).
+Corresponded unit tests moved to edgeCrossingEdgeCheck: invalidDisconnectedNodesCrossingTest, invalidDisconnectedEdgeCrossingTest.
+
 #### Configuration
 
 This check has some configurables that can be changed in the configuration file [config.json](../../config/configuration.json)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -75,7 +75,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
         return object instanceof Node && !SyntheticBoundaryNodeTag.isSyntheticBoundaryNode(object)
                 && !this.isFlagged(object.getOsmIdentifier()) && !BarrierTag.isBarrier(object)
                 && !Validators.isOfType(object, NoExitTag.class, NoExitTag.YES)
-                && !this.connectedEdgesHaveLevelTags((Node) object)
+                && !this.connectedEdgesHaveLevelTags((Node) object) && this.isDeadEnd((Node) object)
                 // Node is part of a valid road, for this check
                 && ((Node) object).connectedEdges().stream().anyMatch(this::validEdgeFilter);
     }
@@ -521,6 +521,18 @@ public class ConnectivityCheck extends BaseCheck<Long>
             return this.headingsFormTriangle(firstHeading, connectionHeading, lastHeading);
         }
         return false;
+    }
+
+    /**
+     * Checks if {@link Node} is at the start or end of the {@link Edge} segment.
+     *
+     * @param node
+     *            {@link Node} to check.
+     * @return true if {@link Node} has only one connected valid navigable {@link Edge}
+     */
+    private boolean isDeadEnd(final Node node)
+    {
+        return node.connectedEdges().stream().filter(this::validEdgeFilter).count() < 2;
     }
 
     /**

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -148,6 +148,22 @@ public class EdgeCrossingEdgeCheckTest
     }
 
     @Test
+    public void testInvalidDisconnectedEdgeCrossingTest()
+    {
+        this.verifier.actual(this.setup.invalidDisconnectedEdgeCrossingAtlas(),
+                new EdgeCrossingEdgeCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void testInvalidDisconnectedNodesCrossingTest()
+    {
+        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(),
+                new EdgeCrossingEdgeCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void testNoCrossingItemsAtlas()
     {
         this.verifier.actual(this.setup.noCrossingItemsAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -19,6 +19,12 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     private static final String LOCATION_3 = "47.574612, -122.305855";
     private static final String LOCATION_4 = "47.575371, -122.308121";
     private static final String LOCATION_5 = "47.576485, -122.307098";
+    private static final String TEST1 = "47.2620768463041,-122.474848242369";
+    private static final String TEST2 = "47.2618703753848,-122.474832590205";
+    private static final String TEST3 = "47.26186971149,-122.474824764123";
+    private static final String TEST4 = "47.2618624086451,-122.475082046561";
+    private static final String TEST5 = "47.2618624086451,-122.474591938191";
+    private static final String TEST6 = "47.2617588409197,-122.474843351067";
 
     @TestAtlas(
             // nodes
@@ -248,6 +254,33 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                             @Loc(value = LOCATION_5) }, tags = { "highway=motorway" }) })
     private Atlas validIntersectionItemsAtlas;
 
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(TEST1)),
+                    @Node(id = "2000000", coordinates = @Loc(TEST2)),
+                    @Node(id = "3000000", coordinates = @Loc(TEST3)),
+                    @Node(id = "4000000", coordinates = @Loc(TEST4)),
+                    @Node(id = "5000000", coordinates = @Loc(TEST5)),
+                    @Node(id = "6000000", coordinates = @Loc(TEST6)) }, edges = {
+                            @Edge(id = "1234000000", coordinates = { @Loc(TEST1), @Loc(TEST3),
+                                    @Loc(TEST6) }, tags = { "highway=secondary" }),
+                            @Edge(id = "2345000000", coordinates = { @Loc(TEST4), @Loc(TEST2),
+                                    @Loc(TEST5) }, tags = { "highway=secondary" }), })
+    private Atlas invalidDisconnectedNodesCrossingAtlas;
+
+    @TestAtlas(
+            // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(TEST1)),
+                    @Node(id = "2000000", coordinates = @Loc(TEST3)),
+                    @Node(id = "3000000", coordinates = @Loc(TEST4)),
+                    @Node(id = "4000000", coordinates = @Loc(TEST5)),
+                    @Node(id = "5000000", coordinates = @Loc(TEST6)) }, edges = {
+                            @Edge(id = "1234000000", coordinates = { @Loc(TEST1), @Loc(TEST3),
+                                    @Loc(TEST6) }, tags = { "highway=secondary" }),
+                            @Edge(id = "2345000000", coordinates = { @Loc(TEST4),
+                                    @Loc(TEST5) }, tags = { "highway=secondary" }) })
+    private Atlas invalidDisconnectedEdgeCrossingAtlas;
+
     public Atlas invalidCrossingItemsAtlas()
     {
         return this.invalidCrossingItemsAtlas;
@@ -286,6 +319,16 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     public Atlas invalidCrossingNonMainItemsAtlas()
     {
         return this.invalidCrossingNonMainItemsAtlas;
+    }
+
+    public Atlas invalidDisconnectedEdgeCrossingAtlas()
+    {
+        return this.invalidDisconnectedEdgeCrossingAtlas;
+    }
+
+    public Atlas invalidDisconnectedNodesCrossingAtlas()
+    {
+        return this.invalidDisconnectedNodesCrossingAtlas;
     }
 
     public Atlas noCrossingItemsAtlas()

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
@@ -60,9 +60,9 @@ public class ConnectivityCheckTest
     }
 
     @Test
-    public void invalidDisconnectedEdgeCrossingTest()
+    public void invalidConnectedNodesTestNavigableDeadEnd()
     {
-        this.verifier.actual(this.setup.invalidDisconnectedEdgeCrossingAtlas(),
+        this.verifier.actual(this.setup.invalidConnectedNodesAtlasNavigableDeadEnd(),
                 new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
@@ -84,22 +84,6 @@ public class ConnectivityCheckTest
     }
 
     @Test
-    public void invalidDisconnectedNodesCrossingLayerTest()
-    {
-        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingLayerAtlas(),
-                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void invalidDisconnectedNodesCrossingTest()
-    {
-        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(),
-                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
     public void invalidDisconnectedNodesOppositeTest()
     {
         this.verifier.actual(this.setup.invalidDisconnectedNodesOppositeAtlas(),
@@ -112,14 +96,6 @@ public class ConnectivityCheckTest
     {
         this.verifier.actual(this.setup.invalidDisconnectedNodesAtlas(),
                 new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-    }
-
-    @Test
-    public void specificHighwayValuesFlaggedTest()
-    {
-        this.verifier.actual(this.setup.invalidDisconnectedNodesCrossingAtlas(),
-                new ConnectivityCheck(this.secondaryHighwayConfig));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
@@ -35,6 +35,21 @@ public class ConnectivityCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(TEST1)),
+                    @Node(id = "2000000", coordinates = @Loc(TEST2)),
+                    @Node(id = "3000000", coordinates = @Loc(TEST3)),
+                    @Node(id = "4000000", coordinates = @Loc(TEST4)),
+                    @Node(id = "6000000", coordinates = @Loc(TEST6)) }, edges = {
+                            @Edge(id = "1234000000", coordinates = { @Loc(TEST1),
+                                    @Loc(TEST2) }, tags = { "highway=secondary" }),
+                            @Edge(id = "2345000000", coordinates = { @Loc(TEST3),
+                                    @Loc(TEST4) }, tags = { "highway=secondary" }),
+                            @Edge(id = "3456000000", coordinates = { @Loc(TEST2),
+                                    @Loc(TEST6) }, tags = { "boundary=administrative" }) })
+    private Atlas invalidDisconnectedNodesAtlasNavigableDeadEnd;
+
+    @TestAtlas(
+            // Nodes
             nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
                     @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST4)) }, edges = {
                             @Edge(coordinates = { @Loc(TEST1), @Loc(TEST2) }, tags = {
@@ -184,40 +199,10 @@ public class ConnectivityCheckTestRule extends CoreTestRule
                             @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
                                     "highway=secondary" }),
                             @Edge(coordinates = { @Loc(TEST5), @Loc(TEST2) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
-                                    "highway=secondary" }) })
-    private Atlas invalidDisconnectedNodesCrossingAtlas;
-
-    @TestAtlas(
-            // Nodes
-            nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
-                    @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST5)),
-                    @Node(coordinates = @Loc(TEST7)), @Node(coordinates = @Loc(TEST8)) }, edges = {
-                            @Edge(coordinates = { @Loc(TEST1), @Loc(TEST3) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST5), @Loc(TEST2) }, tags = {
                                     "highway=secondary", "layer=1" }),
                             @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
                                     "highway=secondary", "layer=1" }) })
     private Atlas validDisconnectedNodesCrossingLayerAtlas;
-
-    @TestAtlas(
-            // Nodes
-            nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
-                    @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST5)),
-                    @Node(coordinates = @Loc(TEST7)), @Node(coordinates = @Loc(TEST8)) }, edges = {
-                            @Edge(coordinates = { @Loc(TEST1), @Loc(TEST3) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST5), @Loc(TEST2) }, tags = {
-                                    "highway=secondary", "layer=1" }),
-                            @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
-                                    "highway=secondary" }) })
-    private Atlas invalidDisconnectedNodesCrossingLayerAtlas;
 
     @TestAtlas(
             // Nodes
@@ -263,19 +248,6 @@ public class ConnectivityCheckTestRule extends CoreTestRule
                             @Edge(coordinates = { @Loc(TEST2), @Loc(TEST7) }, tags = {
                                     "highway=pedestrian" }) })
     private Atlas validDisconnectedNodesCrossingPedestrianAtlas;
-
-    @TestAtlas(
-            // Nodes
-            nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST3)),
-                    @Node(coordinates = @Loc(TEST5)), @Node(coordinates = @Loc(TEST7)),
-                    @Node(coordinates = @Loc(TEST8)) }, edges = {
-                            @Edge(coordinates = { @Loc(TEST1), @Loc(TEST3) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST3), @Loc(TEST8) }, tags = {
-                                    "highway=secondary" }),
-                            @Edge(coordinates = { @Loc(TEST5), @Loc(TEST7) }, tags = {
-                                    "highway=secondary" }) })
-    private Atlas invalidDisconnectedEdgeCrossingAtlas;
 
     @TestAtlas(
             // Nodes
@@ -357,9 +329,9 @@ public class ConnectivityCheckTestRule extends CoreTestRule
         return this.invalidConnectedNodesAtlas;
     }
 
-    public Atlas invalidDisconnectedEdgeCrossingAtlas()
+    public Atlas invalidConnectedNodesAtlasNavigableDeadEnd()
     {
-        return this.invalidDisconnectedEdgeCrossingAtlas;
+        return this.invalidDisconnectedNodesAtlasNavigableDeadEnd;
     }
 
     public Atlas invalidDisconnectedEdgesAtlas()
@@ -375,16 +347,6 @@ public class ConnectivityCheckTestRule extends CoreTestRule
     public Atlas invalidDisconnectedNodesAtlas()
     {
         return this.invalidDisconnectedNodesOppositeAtlas;
-    }
-
-    public Atlas invalidDisconnectedNodesCrossingAtlas()
-    {
-        return this.invalidDisconnectedNodesCrossingAtlas;
-    }
-
-    public Atlas invalidDisconnectedNodesCrossingLayerAtlas()
-    {
-        return this.invalidDisconnectedNodesCrossingLayerAtlas;
     }
 
     public Atlas invalidDisconnectedNodesOppositeAtlas()


### PR DESCRIPTION
Please refer to first PR for the comments: https://github.com/osmlab/atlas-checks/pull/608

Description:

Please refer to #504

ConnectivityCheck scope is reduced by removing duplicated logic of crossing edges to EdgeCrossingEdge check.

Potential Impact:

Nodes that too close but connected to two+ edges won't be flagged.

Unit Test Approach:

Corresponded unit tests: invalidDisconnectedNodesCrossingTest, invalidDisconnectedEdgeCrossingTest from ConnectivityCheck moved to EdgeCrossingEdge.

Test Results:

passed