### PR TITLE
Disable DuplicateMapFeatureCheck by default.

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -253,6 +253,7 @@
     }
   },
   "DuplicateMapFeatureCheck": {
+    "enabled": false,
     "features.tags.should.represent.only.once.in.area": [
       "amenity",
       "leisure",


### PR DESCRIPTION
Until this check can be fixed so that it doesn't take so long I propose that we disable the check by default in the configuration. 

This won't have any other effect on the actual check and if you want to execute that specific check then you can still do it. It will only change the default atlas checks that are executed when the configuration.json is used.
