### PR TITLE
Lvlcrossfix

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -347,7 +347,7 @@
       "tags":"coastline"
     }
   },
-    "GenericTagCheck": {
+  "GenericTagCheck": {
     "db": {
       "taginfo": "extra/taginfo-db.db",
       "wikidata": "extra/wikidata.db"

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheck.java
@@ -143,9 +143,12 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
          *  2) Any object that is tagged with railway=level_crossing.
          *  3) Any object that is tagged as a railway as indicted in railway.filter.
          */
-        return object instanceof Node
-                || Validators.isOfType(object, RailwayTag.class, RailwayTag.LEVEL_CROSSING)
-                || this.railwayFilter.test(object);
+        return !this.isFlagged(object.getOsmIdentifier())
+                // don't look at edges that are not main edge
+                && !(object instanceof Edge && !((Edge) object).isMainEdge())
+                && (object instanceof Node
+                        || Validators.isOfType(object, RailwayTag.class, RailwayTag.LEVEL_CROSSING)
+                        || this.railwayFilter.test(object));
     }
 
     /**
@@ -158,6 +161,7 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
+        this.markAsFlagged(object.getOsmIdentifier());
         /*-
          * The following invalid situations are to be flagged:
          *  1) object is node and


### PR DESCRIPTION
### Description:

This patch fixes two main issues:
1) The level crossing on railway check might produce multiple flags for the same OSM feature.
To fix this I will add a call to mark each feature scanned as flagged and check that each feature being checked has not yet been processed.

2) The level crossing on railway check can produce a flag with a negative OSM feature ID.
To fix this I have added to the check filter to only check edge features that are the main edge. 

### Potential Impact:

This will eliminate duplicated flags and prevent bad fix suggestion content when pushing to Map Roulette.

### Unit Test Approach:

I will be running a full scan of a country to make sure the bad features are now filtered.
