### PR TITLE
Redisable DuplicateMapFeatureCheck

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -253,6 +253,7 @@
     }
   },
   "DuplicateMapFeatureCheck": {
+    "enabled": false,
     "features.tags.should.represent.only.once.in.area": [
       "amenity",
       "leisure",


### PR DESCRIPTION
### Description:
Re-disables DuplicateMapFeatureCheck, as run times are still way too high, even after https://github.com/osmlab/atlas-checks/pull/616.

I actually misinterpreted the run times the first time this check was enabled, thinking the longest shard took 22 minutes. It in fact too 22 hours. Times are down slightly now, with the worst shard being 15 hours. However any shard should be taking more than about 5 minute. There are over 1500 shards currently that take more than an hour. 

### Potential Impact:

Fix overall execution time. 

### Unit Test Approach:

None

### Test Results:
None
