### PR TITLE
ConnectivityCheck Dead End improved logic

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheck.java
@@ -548,7 +548,7 @@ public class ConnectivityCheck extends BaseCheck<Long>
         final boolean validHighwayValue = this.checkedHighwayValues.isEmpty()
                 ? HighwayTag.isCarNavigableHighway(edge)
                 : this.checkedHighwayValues.contains(edge.highwayTag().getTagValue());
-        return validHighwayValue && !this.denylistedHighwaysTaggableFilter.test(edge)
-                && !BarrierTag.isBarrier(edge);
+        return edge.isMainEdge() && validHighwayValue
+                && !this.denylistedHighwaysTaggableFilter.test(edge) && !BarrierTag.isBarrier(edge);
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTest.java
@@ -68,6 +68,14 @@ public class ConnectivityCheckTest
     }
 
     @Test
+    public void invalidConnectedNodesTestNavigableDeadEndReversible()
+    {
+        this.verifier.actual(this.setup.invalidConnectedNodesAtlasNavigableDeadEndReversible(),
+                new ConnectivityCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
     public void invalidDisconnectedEdgesTest()
     {
         this.verifier.actual(this.setup.invalidDisconnectedEdgesAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/points/ConnectivityCheckTestRule.java
@@ -50,6 +50,23 @@ public class ConnectivityCheckTestRule extends CoreTestRule
 
     @TestAtlas(
             // Nodes
+            nodes = { @Node(id = "1000000", coordinates = @Loc(TEST1)),
+                    @Node(id = "2000000", coordinates = @Loc(TEST2)),
+                    @Node(id = "3000000", coordinates = @Loc(TEST3)),
+                    @Node(id = "4000000", coordinates = @Loc(TEST4)),
+                    @Node(id = "6000000", coordinates = @Loc(TEST6)) }, edges = {
+                            @Edge(id = "1234000000", coordinates = { @Loc(TEST1),
+                                    @Loc(TEST2) }, tags = { "highway=secondary" }),
+                            @Edge(id = "-1234000000", coordinates = { @Loc(TEST1),
+                                    @Loc(TEST2) }, tags = { "highway=secondary" }),
+                            @Edge(id = "2345000000", coordinates = { @Loc(TEST3),
+                                    @Loc(TEST4) }, tags = { "highway=secondary" }),
+                            @Edge(id = "3456000000", coordinates = { @Loc(TEST2),
+                                    @Loc(TEST6) }, tags = { "boundary=administrative" }) })
+    private Atlas invalidDisconnectedNodesAtlasNavigableDeadEndReversible;
+
+    @TestAtlas(
+            // Nodes
             nodes = { @Node(coordinates = @Loc(TEST1)), @Node(coordinates = @Loc(TEST2)),
                     @Node(coordinates = @Loc(TEST3)), @Node(coordinates = @Loc(TEST4)) }, edges = {
                             @Edge(coordinates = { @Loc(TEST1), @Loc(TEST2) }, tags = {
@@ -332,6 +349,11 @@ public class ConnectivityCheckTestRule extends CoreTestRule
     public Atlas invalidConnectedNodesAtlasNavigableDeadEnd()
     {
         return this.invalidDisconnectedNodesAtlasNavigableDeadEnd;
+    }
+
+    public Atlas invalidConnectedNodesAtlasNavigableDeadEndReversible()
+    {
+        return this.invalidDisconnectedNodesAtlasNavigableDeadEndReversible;
     }
 
     public Atlas invalidDisconnectedEdgesAtlas()


### PR DESCRIPTION
### Description:

please refer to https://github.com/osmlab/atlas-checks/issues/627

### Potential Impact:

More true dead end cases will be flagged. 

### Unit Test Approach:

Added unit test covering reversible edge. 

### Test Results:
Both reported cases are flagging now:
[CheckFlag: 6230687868000000, 1. Node 6230687868 is likely supposed to be connected to: way 525179930]
[CheckFlag: 7148640414000000, 1. Node 7148640414 is likely supposed to be connected to: way 855789796]  