### PR TITLE
Turn Lanes Value Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -565,6 +565,15 @@
       "tags":"tags"
     }
   },
+  "InvalidTurnLanesValueCheck": {
+    "challenge":{
+      "description":"Tasks contain invalid values for the turn:lanes tag.",
+      "blurb":"Invalid Turn Lanes Values",
+      "instruction":"Change the turn:lanes values to have a valid and representative value.",
+      "difficulty":"EASY",
+      "tags":"lanes,highway"
+    }
+  },
   "SourceMaxspeedCheck": {
     "countries.denylist": ["UK"],
     "values": [

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -92,8 +92,9 @@ This document is a list of tables with a description and link to documentation f
 | ImproperAndUnknownRoadNameCheck | This check flags improper road name values. |
 | [InvalidAccessTagCheck](checks/invalidAccessTagCheck.md) | The purpose of this check is to identify invalid access tags. |
 | [InvalidCharacterNameTagCheck](checks/invalidCharacterNameTagCheck.md) | The purpose of this checks is to identify Lines, Areas and Relations with invalid characters in name and localized name tags. |
-| [InvalidLanesTagCheck](docs/checks/invalidLanesTagCheck.md) | The purpose of this check is to identify highways in OSM with an invalid lanes tag value. |
+| [InvalidLanesTagCheck](checks/invalidTurnLanesValueCheck.md) | The purpose of this check is to identify highways in OSM with an invalid lanes tag value. |
 | InvalidTagsCheck | This flags features based on configurable filters. Each filter passed contains the atlas entity classes to check and a taggable filter to test objects against. If a feature is of one of the given classes and passes the associated TaggableFilter, it is flagged. |
+| [InvalidTurnLanesValueCheck](docs/checks/invalidTurnLanesValueCheck.md) | The purpose of this check is to identify highways in OSM with an invalid turn:lanes value. |
 | [LongNameCheck](checks/longNameCheck.md) | This check flags features with names longer than a configurable length. |
 | [MixedCaseNameCheck](checks/mixedCaseNameCheck.md) | The purpose of this check is to identify names that contain invalid mixed cases so that they can be edited to be the standard format. |
 | [RoadNameGapCheck](checks/RoadNameGapCheck.md) | The purpose of this check is to identify edge connected between two edges whose name tag is same. Flag the edge if the edge has a name tag different to name tag of edges connected to it or if there is no name tag itself.

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -92,7 +92,7 @@ This document is a list of tables with a description and link to documentation f
 | ImproperAndUnknownRoadNameCheck | This check flags improper road name values. |
 | [InvalidAccessTagCheck](checks/invalidAccessTagCheck.md) | The purpose of this check is to identify invalid access tags. |
 | [InvalidCharacterNameTagCheck](checks/invalidCharacterNameTagCheck.md) | The purpose of this checks is to identify Lines, Areas and Relations with invalid characters in name and localized name tags. |
-| [InvalidLanesTagCheck](checks/invalidTurnLanesValueCheck.md) | The purpose of this check is to identify highways in OSM with an invalid lanes tag value. |
+| [InvalidLanesTagCheck](checks/invalidLanesTagCheck.md) | The purpose of this check is to identify highways in OSM with an invalid lanes tag value. |
 | InvalidTagsCheck | This flags features based on configurable filters. Each filter passed contains the atlas entity classes to check and a taggable filter to test objects against. If a feature is of one of the given classes and passes the associated TaggableFilter, it is flagged. |
 | [InvalidTurnLanesValueCheck](docs/checks/invalidTurnLanesValueCheck.md) | The purpose of this check is to identify highways in OSM with an invalid turn:lanes value. |
 | [LongNameCheck](checks/longNameCheck.md) | This check flags features with names longer than a configurable length. |

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -94,7 +94,7 @@ This document is a list of tables with a description and link to documentation f
 | [InvalidCharacterNameTagCheck](checks/invalidCharacterNameTagCheck.md) | The purpose of this checks is to identify Lines, Areas and Relations with invalid characters in name and localized name tags. |
 | [InvalidLanesTagCheck](checks/invalidLanesTagCheck.md) | The purpose of this check is to identify highways in OSM with an invalid lanes tag value. |
 | InvalidTagsCheck | This flags features based on configurable filters. Each filter passed contains the atlas entity classes to check and a taggable filter to test objects against. If a feature is of one of the given classes and passes the associated TaggableFilter, it is flagged. |
-| [InvalidTurnLanesValueCheck](docs/checks/invalidTurnLanesValueCheck.md) | The purpose of this check is to identify highways in OSM with an invalid turn:lanes value. |
+| [InvalidTurnLanesValueCheck](checks/invalidTurnLanesValueCheck.md) | The purpose of this check is to identify highways in OSM with an invalid turn:lanes value. |
 | [LongNameCheck](checks/longNameCheck.md) | This check flags features with names longer than a configurable length. |
 | [MixedCaseNameCheck](checks/mixedCaseNameCheck.md) | The purpose of this check is to identify names that contain invalid mixed cases so that they can be edited to be the standard format. |
 | [RoadNameGapCheck](checks/RoadNameGapCheck.md) | The purpose of this check is to identify edge connected between two edges whose name tag is same. Flag the edge if the edge has a name tag different to name tag of edges connected to it or if there is no name tag itself.

--- a/docs/checks/invalidTurnLanesValueCheck.md
+++ b/docs/checks/invalidTurnLanesValueCheck.md
@@ -1,0 +1,130 @@
+# Invalid Turn Lanes Value Check 
+
+This check flags roads that have invalid `turn:lanes` tag values.
+
+Valid values contain keywords found in 
+https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/tags/TurnTag.java
+i.e. 
+```java
+    enum TurnType
+    {
+        LEFT,
+        SHARP_LEFT,
+        SLIGHT_LEFT,
+        THROUGH,
+        RIGHT,
+        SHARP_RIGHT,
+        SLIGHT_RIGHT,
+        REVERSE,
+        MERGE_TO_LEFT,
+        MERGE_TO_RIGHT,
+        NONE;
+    }
+    String TURN_LANE_DELIMITER = "\\|";
+    String TURN_TYPE_DELIMITER = ";";
+```
+e.g. "turn:lanes":"through|through|right" is valid
+e.g. "turn:lanes":"through|through|righ" is not valid
+
+
+#### Live Examples
+
+1. The way [id:730457851](https://www.openstreetmap.org/way/730457851) has an invalid `turn:lanes` 
+2. The way [id:836279618](https://www.openstreetmap.org/way/836279618) has an invalid `turn:lanes:forward`
+
+#### Code Review
+
+In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, Nodes & Relations; in our case, we’re are looking at [Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java).
+
+Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy the following conditions:
+
+* Is an Edge
+* Has a `highway` tag that is car navigable
+* Has a `turn:lanes` or `turn:lanes:forward` or `turn:lanes:backward` tag
+* Is not an OSM way that has already been flagged
+
+```java
+@Override
+public boolean validCheckForObject(final AtlasObject object)
+{
+    return TurnLanesTag.hasTurnLane(object) && HighwayTag.isCarNavigableHighway(object)
+            && object instanceof Edge && ((Edge) object).isMainEdge()
+            && !this.isFlagged(object.getOsmIdentifier());
+}
+```
+
+The valid objects (i.e. `turn:lanes` or `turn:lanes:forward` or `turn:lanes:backward`) 
+are then trimmed to remove all the keywords found in
+https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/tags/TurnTag.java
+i.e. 
+
+```java
+    enum TurnType
+    {
+        LEFT,
+        SHARP_LEFT,
+        SLIGHT_LEFT,
+        THROUGH,
+        RIGHT,
+        SHARP_RIGHT,
+        SLIGHT_RIGHT,
+        REVERSE,
+        MERGE_TO_LEFT,
+        MERGE_TO_RIGHT,
+        NONE;
+    }
+    String TURN_LANE_DELIMITER = "\\|";
+    String TURN_TYPE_DELIMITER = ";";
+```
+if the resulting trimmed string is non-empty, that means `turn:lanes` is malformed
+
+```java
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final String turnLanesTag = object.getTag(TurnLanesTag.KEY).isPresent()
+                ? object.getTag(TurnLanesTag.KEY).get().toLowerCase()
+                : "";
+        final String turnLanesForwardTag = object.getTag(TurnLanesForwardTag.KEY).isPresent()
+                ? object.getTag(TurnLanesForwardTag.KEY).get().toLowerCase()
+                : "";
+        final String turnLanesBackwardTag = object.getTag(TurnLanesBackwardTag.KEY).isPresent()
+                ? object.getTag(TurnLanesBackwardTag.KEY).get().toLowerCase()
+                : "";
+
+        if (!this.trimKeywords(turnLanesTag).isEmpty()
+                || !this.trimKeywords(turnLanesForwardTag).isEmpty()
+                || !this.trimKeywords(turnLanesBackwardTag).isEmpty())
+        {
+            this.markAsFlagged(object.getOsmIdentifier());
+
+            return Optional.of(this.createFlag(new OsmWayWalker((Edge) object).collectEdges(),
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+```
+
+Please note that the keywords "LEFT" and "RIGHT" are trimmed towards the end so that the phrases 
+"MERGE_TO_LEFT" AND "MERGE_TO_RIGHT" are trimmed first.
+```java
+    public final String trimKeywords(final String input)
+    {
+        String result = input;
+        for (final TurnType turnType : TurnTag.TurnType.values())
+        {
+            if (turnType != TurnTag.TurnType.LEFT && turnType != TurnTag.TurnType.RIGHT)
+            {
+                result = result.replaceAll(turnType.name().toLowerCase(), "");
+            }
+        }
+        result = result.replaceAll(TurnTag.TurnType.LEFT.name().toLowerCase(), "");
+        result = result.replaceAll(TurnTag.TurnType.RIGHT.name().toLowerCase(), "");
+        result = result.replaceAll(TurnTag.TURN_LANE_DELIMITER.toLowerCase(), "");
+        result = result.replaceAll(TurnTag.TURN_TYPE_DELIMITER.toLowerCase(), "");
+        return result.trim();
+    }
+```
+
+To learn more about the code, please look at the comments in the source code for the check.  
+[InvalidTurnLanesValueCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheck.java)

--- a/docs/checks/invalidTurnLanesValueCheck.md
+++ b/docs/checks/invalidTurnLanesValueCheck.md
@@ -82,15 +82,9 @@ if the resulting trimmed string is non-empty, that means `turn:lanes` is malform
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        final String turnLanesTag = object.getTag(TurnLanesTag.KEY).isPresent()
-                ? object.getTag(TurnLanesTag.KEY).get().toLowerCase()
-                : "";
-        final String turnLanesForwardTag = object.getTag(TurnLanesForwardTag.KEY).isPresent()
-                ? object.getTag(TurnLanesForwardTag.KEY).get().toLowerCase()
-                : "";
-        final String turnLanesBackwardTag = object.getTag(TurnLanesBackwardTag.KEY).isPresent()
-                ? object.getTag(TurnLanesBackwardTag.KEY).get().toLowerCase()
-                : "";
+        final String turnLanesTag = object.getTag(TurnLanesTag.KEY).orElse("");
+        final String turnLanesForwardTag = object.getTag(TurnLanesForwardTag.KEY).orElse("");
+        final String turnLanesBackwardTag = object.getTag(TurnLanesBackwardTag.KEY).orElse("");
 
         if (!this.trimKeywords(turnLanesTag).isEmpty()
                 || !this.trimKeywords(turnLanesForwardTag).isEmpty()
@@ -110,7 +104,7 @@ Please note that the keywords "LEFT" and "RIGHT" are trimmed towards the end so 
 ```java
     public final String trimKeywords(final String input)
     {
-        String result = input;
+        String result = input.toLowerCase();
         for (final TurnType turnType : TurnTag.TurnType.values())
         {
             if (turnType != TurnTag.TurnType.LEFT && turnType != TurnTag.TurnType.RIGHT)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidLanesTagCheck.java
@@ -1,20 +1,23 @@
 package org.openstreetmap.atlas.checks.validation.tag;
 
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
 import org.openstreetmap.atlas.checks.base.BaseCheck;
 import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.checks.utility.KeyFullyChecked;
 import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
 import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.items.Node;
 import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
+import org.openstreetmap.atlas.tags.BarrierTag;
 import org.openstreetmap.atlas.tags.HighwayTag;
-import org.openstreetmap.atlas.tags.TurnLanesTag;
-import org.openstreetmap.atlas.tags.TurnLanesBackwardTag;
-import org.openstreetmap.atlas.tags.TurnLanesForwardTag;
-import org.openstreetmap.atlas.tags.TurnTag;
-import org.openstreetmap.atlas.tags.TurnTag.TurnType;
+import org.openstreetmap.atlas.tags.LanesTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.tags.filters.TaggableFilter;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
@@ -28,7 +31,16 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
     private static final long serialVersionUID = -1459761692833694715L;
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
-            .asList("Way {0,number,#} has an invalid turn:lanes value.");
+            .asList("Way {0,number,#} has an invalid lanes value.");
+    // Maximum number of connected edges that are checked for toll booth nodes
+    private static final int MAX_TOLL_PLAZA_EDGES = 20;
+    // Valid values of the lanes OSM key
+    @KeyFullyChecked(KeyFullyChecked.Type.TAGGABLE_FILTER)
+    static final String LANES_FILTER_DEFAULT = "lanes->1,1.5,2,3,4,5,6,7,8,9,10";
+    private final TaggableFilter lanesFilter;
+
+    // Edges that can skip the toll booth test, because they have already been checked.
+    private final HashSet<Long> isChecked = new HashSet<>();
 
     /**
      * The default constructor that must be supplied. The Atlas Checks framework will generate the
@@ -41,6 +53,8 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
     public InvalidLanesTagCheck(final Configuration configuration)
     {
         super(configuration);
+        this.lanesFilter = this.configurationValue(configuration, "lanes.filter",
+                LANES_FILTER_DEFAULT, value -> TaggableFilter.forDefinition(value.toString()));
     }
 
     /**
@@ -53,9 +67,9 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return TurnLanesTag.hasTurnLane(object)
+        return Validators.hasValuesFor(object, LanesTag.class)
                 && HighwayTag.isCarNavigableHighway(object) && object instanceof Edge
-                && ((Edge) object).isMainEdge()
+                && ((Edge) object).isMainEdge() && !this.lanesFilter.test(object)
                 && !this.isFlagged(object.getOsmIdentifier());
     }
 
@@ -69,18 +83,13 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        String turnLanesTag = object.getTag(TurnLanesTag.KEY).isPresent()? object.getTag(TurnLanesTag.KEY).get().toLowerCase(): "";
-        String turnLanesForwardTag = object.getTag(TurnLanesForwardTag.KEY).isPresent()? object.getTag(TurnLanesForwardTag.KEY).get().toLowerCase(): "";
-        String turnLanesBackwardTag = object.getTag(TurnLanesBackwardTag.KEY).isPresent()? object.getTag(TurnLanesBackwardTag.KEY).get().toLowerCase(): "";
-
-        if (!trimKeywords(turnLanesTag).isEmpty() || 
-            !trimKeywords(turnLanesForwardTag).isEmpty() || 
-            !trimKeywords(turnLanesBackwardTag).isEmpty())
+        if (this.isChecked.contains(object.getIdentifier()) || !this.partOfTollBooth(object))
         {
-             this.markAsFlagged(object.getOsmIdentifier());
+            this.markAsFlagged(object.getOsmIdentifier());
 
-             return Optional.of(this.createFlag(new OsmWayWalker((Edge) object).collectEdges(),
-                     this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+            // We know that object is an edge from validCheckForObject
+            return Optional.of(this.createFlag(new OsmWayWalker((Edge) object).collectEdges(),
+                    this.getLocalizedInstruction(0, object.getOsmIdentifier())));
         }
         return Optional.empty();
     }
@@ -91,17 +100,78 @@ public class InvalidLanesTagCheck extends BaseCheck<Long>
         return FALLBACK_INSTRUCTIONS;
     }
 
-    public String trimKeywords(String s)
+    /**
+     * Gets the {@link Edge}s that are connected to the input {@link Edge} and have an otherwise
+     * invalid {@code lanes} tag.
+     *
+     * @param object
+     *            an {@link Edge} with an invalid {@code lanes} tag
+     * @return a {@link HashSet} of connected invalid {@code lanes} tag {@link Edge}s
+     */
+    private HashSet<Edge> connectedInvalidLanes(final AtlasObject object)
     {
-        for (TurnType turnType : TurnTag.TurnType.values()) {
-            if (turnType != TurnTag.TurnType.LEFT && turnType != TurnTag.TurnType.RIGHT) {
-                s = s.replaceAll(turnType.name().toLowerCase(), "");
+        // Connected edges with lanes tag values not in the lanesFilter
+        final HashSet<Edge> connectedEdges = new HashSet<>();
+        // Queue of edges to be processed
+        final ArrayDeque<Edge> toProcess = new ArrayDeque<>();
+        Edge polledEdge;
+        int count = 0;
+
+        // Add original edge
+        connectedEdges.add((Edge) object);
+        toProcess.add((Edge) object);
+
+        // Get all connected edges with lanes tag values not in the lanesFilter
+        while (!toProcess.isEmpty() && count < MAX_TOLL_PLAZA_EDGES)
+        {
+            polledEdge = toProcess.poll();
+            for (final Edge edge : polledEdge.connectedEdges())
+            {
+                if (!connectedEdges.contains(edge) && ((Edge) object).isMainEdge()
+                        && Validators.hasValuesFor(edge, LanesTag.class)
+                        && HighwayTag.isCarNavigableHighway(edge) && !this.lanesFilter.test(edge))
+                {
+                    toProcess.add(edge);
+                    connectedEdges.add(edge);
+                }
+            }
+            count++;
+        }
+
+        return connectedEdges;
+    }
+
+    /**
+     * Checks for a node with {@code barrier=toll_booth} amongst the {@link Edge}s that are
+     * connected to the input {@link Edge} and have an otherwise invalid {@code lanes} tag.
+     *
+     * @param object
+     *            an {@link Edge} with an otherwise invalid {@code lanes} tag, to be checked for
+     *            toll booths
+     * @return a boolean that is true when a toll booth is found
+     */
+    private boolean partOfTollBooth(final AtlasObject object)
+    {
+        final HashSet<Edge> connectedInvalidEdges = this.connectedInvalidLanes(object);
+
+        // check for toll booths
+        for (final Edge edge : connectedInvalidEdges)
+        {
+            for (final Node node : edge.connectedNodes())
+            {
+                if (Validators.isOfType(node, BarrierTag.class, BarrierTag.TOLL_BOOTH))
+                {
+                    // If there is a toll booth, mark them so we don't process
+                    // items twice unnecessarily, and return true
+                    connectedInvalidEdges
+                            .forEach(validEdge -> this.markAsFlagged(validEdge.getOsmIdentifier()));
+                    return true;
+                }
             }
         }
-        s = s.replaceAll(TurnTag.TurnType.LEFT.name().toLowerCase(), "");
-        s = s.replaceAll(TurnTag.TurnType.RIGHT.name().toLowerCase(), "");
-        s = s.replaceAll(TurnTag.TURN_LANE_DELIMITER.toLowerCase(), "");
-        s = s.replaceAll(TurnTag.TURN_TYPE_DELIMITER.toLowerCase(), "");
-        return s.trim();
+        // If not a toll booth, mark for flagging so they can skip this toll booth check.
+        connectedInvalidEdges
+                .forEach(invalidEdge -> this.isChecked.add(invalidEdge.getIdentifier()));
+        return false;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheck.java
@@ -45,7 +45,7 @@ public class InvalidTurnLanesValueCheck extends BaseCheck<Long>
 
     public final String trimKeywords(final String input)
     {
-        String result = input;
+        String result = input.toLowerCase();
         for (final TurnType turnType : TurnTag.TurnType.values())
         {
             if (turnType != TurnTag.TurnType.LEFT && turnType != TurnTag.TurnType.RIGHT)
@@ -85,15 +85,9 @@ public class InvalidTurnLanesValueCheck extends BaseCheck<Long>
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
-        final String turnLanesTag = object.getTag(TurnLanesTag.KEY).isPresent()
-                ? object.getTag(TurnLanesTag.KEY).get().toLowerCase()
-                : "";
-        final String turnLanesForwardTag = object.getTag(TurnLanesForwardTag.KEY).isPresent()
-                ? object.getTag(TurnLanesForwardTag.KEY).get().toLowerCase()
-                : "";
-        final String turnLanesBackwardTag = object.getTag(TurnLanesBackwardTag.KEY).isPresent()
-                ? object.getTag(TurnLanesBackwardTag.KEY).get().toLowerCase()
-                : "";
+        final String turnLanesTag = object.getTag(TurnLanesTag.KEY).orElse("");
+        final String turnLanesForwardTag = object.getTag(TurnLanesForwardTag.KEY).orElse("");
+        final String turnLanesBackwardTag = object.getTag(TurnLanesBackwardTag.KEY).orElse("");
 
         if (!this.trimKeywords(turnLanesTag).isEmpty()
                 || !this.trimKeywords(turnLanesForwardTag).isEmpty()

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheck.java
@@ -1,0 +1,107 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.geography.atlas.walker.OsmWayWalker;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.TurnLanesTag;
+import org.openstreetmap.atlas.tags.TurnLanesBackwardTag;
+import org.openstreetmap.atlas.tags.TurnLanesForwardTag;
+import org.openstreetmap.atlas.tags.TurnTag;
+import org.openstreetmap.atlas.tags.TurnTag.TurnType;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Flags {@link Edge}s that have the {@code highway} tag and a {@code lanes} tag with an invalid
+ * value. The valid {@code lanes} values are configurable.
+ *
+ * @author mselaineleong
+ */
+public class InvalidTurnLanesValueCheck extends BaseCheck<Long>
+{
+    private static final long serialVersionUID = -1459761692833694715L;
+
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays
+            .asList("Way {0,number,#} has an invalid turn:lanes value.");
+
+    /**
+     * The default constructor that must be supplied. The Atlas Checks framework will generate the
+     * checks with this constructor, supplying a configuration that can be used to adjust any
+     * parameters that the check uses during operation.
+     *
+     * @param configuration
+     *            the JSON configuration for this check
+     */
+    public InvalidTurnLanesValueCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    /**
+     * This function will validate if the supplied atlas object is valid for the check.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return {@code true} if this object should be checked
+     */
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return TurnLanesTag.hasTurnLane(object)
+                && HighwayTag.isCarNavigableHighway(object) && object instanceof Edge
+                && ((Edge) object).isMainEdge()
+                && !this.isFlagged(object.getOsmIdentifier());
+    }
+
+    /**
+     * This is the actual function that will check to see whether the object needs to be flagged.
+     *
+     * @param object
+     *            the atlas object supplied by the Atlas-Checks framework for evaluation
+     * @return an optional {@link CheckFlag} object that
+     */
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        String turnLanesTag = object.getTag(TurnLanesTag.KEY).isPresent()? object.getTag(TurnLanesTag.KEY).get().toLowerCase(): "";
+        String turnLanesForwardTag = object.getTag(TurnLanesForwardTag.KEY).isPresent()? object.getTag(TurnLanesForwardTag.KEY).get().toLowerCase(): "";
+        String turnLanesBackwardTag = object.getTag(TurnLanesBackwardTag.KEY).isPresent()? object.getTag(TurnLanesBackwardTag.KEY).get().toLowerCase(): "";
+
+        if (!trimKeywords(turnLanesTag).isEmpty() || 
+            !trimKeywords(turnLanesForwardTag).isEmpty() || 
+            !trimKeywords(turnLanesBackwardTag).isEmpty())
+        {
+             this.markAsFlagged(object.getOsmIdentifier());
+
+             return Optional.of(this.createFlag(new OsmWayWalker((Edge) object).collectEdges(),
+                     this.getLocalizedInstruction(0, object.getOsmIdentifier())));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    public String trimKeywords(String s)
+    {
+        for (TurnType turnType : TurnTag.TurnType.values()) {
+            if (turnType != TurnTag.TurnType.LEFT && turnType != TurnTag.TurnType.RIGHT) {
+                s = s.replaceAll(turnType.name().toLowerCase(), "");
+            }
+        }
+        s = s.replaceAll(TurnTag.TurnType.LEFT.name().toLowerCase(), "");
+        s = s.replaceAll(TurnTag.TurnType.RIGHT.name().toLowerCase(), "");
+        s = s.replaceAll(TurnTag.TURN_LANE_DELIMITER.toLowerCase(), "");
+        s = s.replaceAll(TurnTag.TURN_TYPE_DELIMITER.toLowerCase(), "");
+        return s.trim();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheckTest.java
@@ -1,0 +1,37 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+
+/**
+ * Tests for {@link InvalidTurnLanesValueCheck}
+ *
+ * @author mselaineleong
+ */
+public class InvalidTurnLanesValueCheckTest
+{
+    @Rule
+    public InvalidTurnLanesValueCheckTestRule setup = new InvalidTurnLanesValueCheckTestRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    @Test
+    public void invalidTurnLanesValue()
+    {
+        this.verifier.actual(this.setup.invalidTurnLanesValue(),
+                new InvalidTurnLanesValueCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+    }
+
+    @Test
+    public void validTurnLanesValue()
+    {
+        this.verifier.actual(this.setup.validTurnLanesValue(),
+                new InvalidTurnLanesValueCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheckTestRule.java
@@ -1,0 +1,69 @@
+package org.openstreetmap.atlas.checks.validation.tag;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Edge;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Loc;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas.Node;
+
+/**
+ * Tests for {@link InvalidLanesTagCheck}
+ *
+ * @author mselaineleong
+ */
+
+public class InvalidTurnLanesValueCheckTestRule extends CoreTestRule
+{
+    private static final String TEST_1 = "47.2136626201459,-122.443275382856";
+    private static final String TEST_2 = "47.2138327316739,-122.44258668766";
+    private static final String TEST_3 = "47.2136626201459,-122.441897992465";
+    private static final String TEST_4 = "47.2138114677627,-122.440990166979";
+    private static final String TEST_5 = "47.2136200921786,-122.44001973284";
+    private static final String TEST_6 = "47.2135137721113,-122.439127559518";
+    private static final String TEST_7 = "47.2136200921786,-122.438157125378";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_7)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4),
+                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=1.5", "turn:lanes=through|right" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6),
+                            @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })
+    private Atlas validTurnLanesValue;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_5)),
+                    @Node(coordinates = @Loc(value = TEST_7), tags = { "barrier=toll_booth" }) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
+                    @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4),
+                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=11", "turn:lanes=throug|throug|slight_right" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
+                            @Loc(value = TEST_6),
+                            @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })
+    private Atlas invalidTurnLanesValue;
+
+    public Atlas invalidTurnLanesValue()
+    {
+        return this.invalidTurnLanesValue;
+    }
+
+    public Atlas validTurnLanesValue()
+    {
+        return this.validTurnLanesValue;
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/tag/InvalidTurnLanesValueCheckTestRule.java
@@ -33,8 +33,8 @@ public class InvalidTurnLanesValueCheckTestRule extends CoreTestRule
             edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_1),
                     @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }),
                     @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
-                            @Loc(value = TEST_4),
-                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=1.5", "turn:lanes=through|right" }),
+                            @Loc(value = TEST_4), @Loc(value = TEST_5) }, tags = {
+                                    "highway=motorway", "lanes=1.5", "turn:lanes=through|right" }),
                     @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
                             @Loc(value = TEST_6),
                             @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })
@@ -51,7 +51,8 @@ public class InvalidTurnLanesValueCheckTestRule extends CoreTestRule
                     @Loc(value = TEST_2), @Loc(value = TEST_3) }, tags = { "highway=motorway" }),
                     @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_3),
                             @Loc(value = TEST_4),
-                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=11", "turn:lanes=throug|throug|slight_right" }),
+                            @Loc(value = TEST_5) }, tags = { "highway=motorway", "lanes=11",
+                                    "turn:lanes=throug|throug|slight_right" }),
                     @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_5),
                             @Loc(value = TEST_6),
                             @Loc(value = TEST_7) }, tags = { "highway=motorway" }) })


### PR DESCRIPTION
### Description:

This check flags roads that have invalid `turn:lanes` tag values.

Valid values contain keywords found in 
https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/tags/TurnTag.java
```java
    enum TurnType
    {
        LEFT,
        SHARP_LEFT,
        SLIGHT_LEFT,
        THROUGH,
        RIGHT,
        SHARP_RIGHT,
        SLIGHT_RIGHT,
        REVERSE,
        MERGE_TO_LEFT,
        MERGE_TO_RIGHT,
        NONE;
    }
    String TURN_LANE_DELIMITER = "\\|";
    String TURN_TYPE_DELIMITER = ";";
```
e.g. "turn:lanes":"through|through|right" is valid
e.g. "turn:lanes":"through|through|righ" is not valid


#### Live Examples

1. The way [id:730457851](https://www.openstreetmap.org/way/730457851) has an invalid `turn:lanes` 
2. The way [id:836279618](https://www.openstreetmap.org/way/836279618) has an invalid `turn:lanes:forward`

#### Code Review

In [Atlas](https://github.com/osmlab/atlas), OSM elements are represented as Edges, Points, Lines, Nodes & Relations; in our case, we’re are looking at [Edges](https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/geography/atlas/items/Edge.java).

Our first goal is to validate the incoming Atlas object. Valid features for this check will satisfy the following conditions:

* Is an Edge
* Has a `highway` tag that is car navigable
* Has a `turn:lanes` or `turn:lanes:forward` or `turn:lanes:backward` tag
* Is not an OSM way that has already been flagged

```java
@Override
public boolean validCheckForObject(final AtlasObject object)
{
    return TurnLanesTag.hasTurnLane(object) && HighwayTag.isCarNavigableHighway(object)
            && object instanceof Edge && ((Edge) object).isMainEdge()
            && !this.isFlagged(object.getOsmIdentifier());
}
```

The valid objects (i.e. `turn:lanes` or `turn:lanes:forward` or `turn:lanes:backward`) 
are then trimmed to remove all the keywords found in
https://github.com/osmlab/atlas/blob/dev/src/main/java/org/openstreetmap/atlas/tags/TurnTag.java
if the resulting trimmed string is non-empty, that means `turn:lanes` is malformed

Please note that the keywords "LEFT" and "RIGHT" are trimmed towards the end so that the phrases 
"MERGE_TO_LEFT" AND "MERGE_TO_RIGHT" are trimmed first.
```java
    public final String trimKeywords(final String input)
    {
        String result = input;
        for (final TurnType turnType : TurnTag.TurnType.values())
        {
            if (turnType != TurnTag.TurnType.LEFT && turnType != TurnTag.TurnType.RIGHT)
            {
                result = result.replaceAll(turnType.name().toLowerCase(), "");
            }
        }
        result = result.replaceAll(TurnTag.TurnType.LEFT.name().toLowerCase(), "");
        result = result.replaceAll(TurnTag.TurnType.RIGHT.name().toLowerCase(), "");
        result = result.replaceAll(TurnTag.TURN_LANE_DELIMITER.toLowerCase(), "");
        result = result.replaceAll(TurnTag.TURN_TYPE_DELIMITER.toLowerCase(), "");
        return result.trim();
    }
```

### Test Results:

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
| AUS |  80  |  80  |     100     | 80  |  0  | 0%   |
| BOL |  31  | 31   |   100       | 31  | 0   | 0%   |
| COL |  19  |  19  |    100      | 19  | 0   | 0%   |
| GRC |  80  | 80   |  100        | 80  | 0   | 0%   |
| NZL |  14  |  14  |  100        | 14   | 0   | 0%   |
| TUR | 10   | 10   |  100        | 10  | 0   | 0%   |
| URY |    4  |  4  |   100       | 4  |  0  | 0%   |

