### PR TITLE
MapRouletteUploadCommand Challenge Country Name Parameter

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.7',
-    atlas: '6.5.7',
+    atlas: '6.6.2',
     commons:'2.6',
     atlas_generator: '5.3.6',
     atlas_checkstyle: '5.6.9',

--- a/docs/maproulette_upload.md
+++ b/docs/maproulette_upload.md
@@ -24,6 +24,8 @@ Each Challenge is added to the project provided in the MapRoulette connection ur
 * **undiscoverableChallenges** (optional) - Check names listed here are made into undiscoverable challenges. If you define this, leave discoverableChallenges undefined. Supply a comma-delimited list for cherry-picking undiscoverable challenges (in which case all other checks are converted to discoverable challenges), or an empty string to make all challenges undiscoverable, or do not define. If undefined, checks in discoverableChallenges are made discoverable, but if discoverableChallenges is null, all challenges are made undiscoverable. 
 * **discoverableChallenges** (optional) - Check names listed here are made into discoverable challenges. If you define this, leave undiscoverableChallenges undefined. Supply a comma-delimited list for cherry-picking discoverable challenges (in which case all other checks are converted to undiscoverable challenges), or an empty string to make all challenges discoverable, or do not define. If undefined, see undiscoverableChallenges.
 * **discoverableProject** (optional) - Whether the project is discoverable (enabled) in MapRoulette.
+* **purgeIncompleteTasks** (optional) - Whether challenges should be purged of all incomplete tasks before uploading new tasks (true/false, default: false).
+* **countryDisplayNames** (optional) - Whether ISO country codes should be converted to display names for challenge titles (true/false, default: true).
 ## Example
 
 The following command will upload EdgeCrossingEdge & SinkIsland checks to the `checks_example_project` Project on maproulette.org. 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -241,6 +241,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
      *            the MapRoulette checkinComment
      * @return the check's challenge parameters, stored as a Challenge object.
      */
+    @SuppressWarnings("squid:S107")
     private Challenge getChallenge(final String checkName,
             final Configuration fallbackConfiguration, final String countryCode,
             final boolean useDisplayNames, final String checkinCommentPrefix,

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -51,6 +51,22 @@ public class MapRouletteUploadCommandTest
     }
 
     @Test
+    public void testCountryDisplayNamesFalse()
+    {
+        final String[] additionalArguments = { "-countryDisplayNames=false" };
+        final TestMapRouletteConnection connection = this.run(additionalArguments);
+        final Set<Project> projects = connection.uploadedProjects();
+        final List<String> challengeNames = projects.stream().flatMap(project -> connection
+                .challengesForProject(project).stream().map(Challenge::getName)).sorted()
+                .collect(Collectors.toList());
+
+        Assert.assertEquals("CAN - SomeOtherCheck", challengeNames.get(0));
+        Assert.assertEquals("MEX,BLZ - AnotherCheck", challengeNames.get(1));
+        Assert.assertEquals("URY - SomeCheck", challengeNames.get(2));
+        Assert.assertEquals("USA - SomeCheck", challengeNames.get(3));
+    }
+
+    @Test
     public void testCountryFilter()
     {
         final String[] additionalArguments = { "-countries=CAN" };


### PR DESCRIPTION
### Description:

This adds a new optional parameter to the MapRouletteUploadCommand to select whether to use the ISO code or country display name in uploaded challenge titles. 
Currently challenge titles are created with the pattern "Country Display Name - Check Name". When this new parameter is true, which it is by default, this same pattern will be used. When the parameter is false the pattern will be "ISO - Check Name".

Additionally this adds some missing docs, and bumps the atlas version.

### Potential Impact:
This should be fully backwards compatible. 

### Unit Test Approach:

Added a unit test for when the param is false. 

### Test Results:
Ran three test runs with the param true, false, and not given. 

True:
![Screen Shot 2022-02-11 at 2 45 38 PM](https://user-images.githubusercontent.com/24948563/153680889-e2610336-c69b-436d-94d6-3eadf944f972.png)

False:
![Screen Shot 2022-02-11 at 2 45 27 PM](https://user-images.githubusercontent.com/24948563/153680909-2de8b5c5-4a80-4396-aec0-984ea681e3f0.png)

Default:
![Screen Shot 2022-02-11 at 2 45 21 PM](https://user-images.githubusercontent.com/24948563/153680927-b2cf1c49-d12d-4f1b-bbd3-644661b7243e.png)

