### PR TITLE
MapRouletteCommand Optional Proxy Parameter

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteClient.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.Project;
 import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
@@ -81,6 +82,11 @@ public class MapRouletteClient implements Serializable
     public MapRouletteClient(final MapRouletteConfiguration configuration)
     {
         this(configuration, new MapRouletteConnection(configuration));
+    }
+
+    public MapRouletteClient(final MapRouletteConfiguration configuration, final HttpHost proxy)
+    {
+        this(configuration, new MapRouletteConnection(configuration, proxy));
     }
 
     MapRouletteClient(final MapRouletteConfiguration configuration, final TaskLoader taskLoader)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 import org.apache.http.HttpHost;
-import org.openstreetmap.atlas.checks.constants.CommonConstants;
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.ChallengeDifficulty;
 import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
@@ -39,7 +38,8 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
             "Full path to file where project id, challenge id are stored after creation in MapRoulette.",
             StringConverter.IDENTITY);
     private static final Switch<String> PROXY = new Switch<>("proxy",
-            "hostname:port for an http proxy", StringConverter.IDENTITY, Optionality.OPTIONAL);
+            "scheme://hostname:port for an http proxy", StringConverter.IDENTITY,
+            Optionality.OPTIONAL);
 
     private MapRouletteClient mapRouletteClient;
 
@@ -101,8 +101,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
         if (proxyOptional.isPresent())
         {
             logger.info("Using Proxy: {}", proxyOptional.get());
-            final String[] proxyArray = proxyOptional.get().split(CommonConstants.COLON);
-            proxy = new HttpHost(proxyArray[0], Integer.parseInt(proxyArray[1]), "https");
+            proxy = HttpHost.create(proxyOptional.get());
         }
 
         if (mapRoulette != null)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -102,7 +102,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
         {
             logger.info("Using Proxy: {}", proxyOptional.get());
             final String[] proxyArray = proxyOptional.get().split(CommonConstants.COLON);
-            proxy = new HttpHost(proxyArray[0], Integer.parseInt(proxyArray[1]));
+            proxy = new HttpHost(proxyArray[0], Integer.parseInt(proxyArray[1]), "https");
         }
 
         if (mapRoulette != null)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -100,6 +100,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
         final Optional<String> proxyOptional = (Optional<String>) commandMap.getOption(PROXY);
         if (proxyOptional.isPresent())
         {
+            logger.info("Using Proxy: {}", proxyOptional.get());
             final String[] proxyArray = proxyOptional.get().split(CommonConstants.COLON);
             proxy = new HttpHost(proxyArray[0], Integer.parseInt(proxyArray[1]));
         }

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteCommand.java
@@ -3,8 +3,10 @@ package org.openstreetmap.atlas.checks.maproulette;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
+import org.apache.http.HttpHost;
+import org.openstreetmap.atlas.checks.constants.CommonConstants;
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.ChallengeDifficulty;
 import org.openstreetmap.atlas.checks.maproulette.data.ProjectConfiguration;
@@ -36,6 +38,8 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
     protected static final Switch<String> OUTPUT_PATH = new Switch<>("outputPath",
             "Full path to file where project id, challenge id are stored after creation in MapRoulette.",
             StringConverter.IDENTITY);
+    private static final Switch<String> PROXY = new Switch<>("proxy",
+            "hostname:port for an http proxy", StringConverter.IDENTITY, Optionality.OPTIONAL);
 
     private MapRouletteClient mapRouletteClient;
 
@@ -89,14 +93,22 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
     }
 
     protected int onRun(final CommandMap commandMap,
-            final Function<MapRouletteConfiguration, MapRouletteClient> clientConstructor)
+            final BiFunction<MapRouletteConfiguration, HttpHost, MapRouletteClient> clientConstructor)
     {
         final MapRouletteConfiguration mapRoulette = this.fromCommandMap(commandMap);
+        HttpHost proxy = null;
+        final Optional<String> proxyOptional = (Optional<String>) commandMap.getOption(PROXY);
+        if (proxyOptional.isPresent())
+        {
+            final String[] proxyArray = proxyOptional.get().split(CommonConstants.COLON);
+            proxy = new HttpHost(proxyArray[0], Integer.parseInt(proxyArray[1]));
+        }
+
         if (mapRoulette != null)
         {
             try
             {
-                this.mapRouletteClient = clientConstructor.apply(mapRoulette);
+                this.mapRouletteClient = clientConstructor.apply(mapRoulette, proxy);
             }
             catch (final IllegalArgumentException e)
             {
@@ -111,7 +123,7 @@ public abstract class MapRouletteCommand extends AtlasLoadingCommand
     @Override
     protected SwitchList switches()
     {
-        return super.switches().with(MAP_ROULETTE);
+        return super.switches().with(MAP_ROULETTE, PROXY);
     }
 
     protected void uploadTasks()

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -213,7 +213,6 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     {
         resource.setHeader(KEY_API_KEY, this.configuration.getApiKey());
         resource.setProxy(this.proxy);
-        logger.info("Connecting with proxy: {}", this.proxy);
         return resource;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -213,6 +213,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     {
         resource.setHeader(KEY_API_KEY, this.configuration.getApiKey());
         resource.setProxy(this.proxy);
+        logger.info("Connecting with proxy: {}", this.proxy);
         return resource;
     }
 

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -53,6 +53,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
 
     MapRouletteConnection(final MapRouletteConfiguration configuration, final HttpHost proxy)
     {
+        this.proxy = proxy;
         if (configuration == null || !this.isAbleToConnectToMapRoulette(configuration))
         {
             throw new IllegalArgumentException(
@@ -61,7 +62,6 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         this.configuration = configuration;
         this.uriBuilder = new URIBuilder().setScheme(this.configuration.getScheme())
                 .setHost(this.configuration.getServer()).setPort(this.configuration.getPort());
-        this.proxy = proxy;
     }
 
     MapRouletteConnection(final MapRouletteConfiguration configuration)

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -270,6 +270,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
                             configuration.getScheme(), configuration.getServer(),
                             configuration.getPort());
                     final GetResource homepage = new GetResource(serverConnection);
+                    homepage.setProxy(this.proxy);
                     final int statusCode = homepage.getStatusCode();
                     if (statusCode != HttpStatus.SC_OK)
                     {

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
@@ -48,8 +49,9 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     private static final long serialVersionUID = -8227257938510897604L;
     private final MapRouletteConfiguration configuration;
     private final URIBuilder uriBuilder;
+    private final HttpHost proxy;
 
-    MapRouletteConnection(final MapRouletteConfiguration configuration)
+    MapRouletteConnection(final MapRouletteConfiguration configuration, final HttpHost proxy)
     {
         if (configuration == null || !this.isAbleToConnectToMapRoulette(configuration))
         {
@@ -59,6 +61,12 @@ public class MapRouletteConnection implements TaskLoader, Serializable
         this.configuration = configuration;
         this.uriBuilder = new URIBuilder().setScheme(this.configuration.getScheme())
                 .setHost(this.configuration.getServer()).setPort(this.configuration.getPort());
+        this.proxy = proxy;
+    }
+
+    MapRouletteConnection(final MapRouletteConfiguration configuration)
+    {
+        this(configuration, null);
     }
 
     /**
@@ -204,6 +212,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     public HttpResource setAuth(final HttpResource resource)
     {
         resource.setHeader(KEY_API_KEY, this.configuration.getApiKey());
+        resource.setProxy(this.proxy);
         return resource;
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -156,6 +156,14 @@ public class MapRouletteUploadCommandTest
                 Arrays.asList("SomeOtherCheck", "AnotherCheck"));
     }
 
+    @Test
+    public void testproxy()
+    {
+        final String[] additionalArguments = { "-proxy=http://127.0.0.1:80" };
+        final TestMapRouletteConnection connection = this.run(additionalArguments);
+        Assert.assertEquals("http://127.0.0.1:80", connection.getProxy().toString());
+    }
+
     @Before
     public void writeFiles()
     {
@@ -196,14 +204,17 @@ public class MapRouletteUploadCommandTest
         // Set up some arguments
         final MapRouletteCommand command = new MapRouletteUploadCommand();
         final String[] arguments = { String.format("-logfiles=%s", FOLDER.getPathString()),
-                MAPROULETTE_CONFIG };
+                MAPROULETTE_CONFIG, };
         final CommandMap map = command
                 .getCommandMap((String[]) ArrayUtils.addAll(arguments, additionalArguments));
         final TestMapRouletteConnection connection = new TestMapRouletteConnection();
 
         // Run the command
-        command.onRun(map,
-                (configuration, proxy) -> new MapRouletteClient(configuration, connection));
+        command.onRun(map, (configuration, proxy) ->
+        {
+            connection.setProxy(proxy);
+            return new MapRouletteClient(configuration, connection);
+        });
 
         return connection;
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -202,7 +202,8 @@ public class MapRouletteUploadCommandTest
         final TestMapRouletteConnection connection = new TestMapRouletteConnection();
 
         // Run the command
-        command.onRun(map, configuration -> new MapRouletteClient(configuration, connection));
+        command.onRun(map,
+                (configuration, proxy) -> new MapRouletteClient(configuration, connection));
 
         return connection;
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/TestMapRouletteConnection.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.http.HttpHost;
 import org.openstreetmap.atlas.checks.maproulette.data.Challenge;
 import org.openstreetmap.atlas.checks.maproulette.data.Project;
 import org.openstreetmap.atlas.checks.maproulette.data.Task;
@@ -17,6 +18,7 @@ import com.google.gson.JsonArray;
  * A stub MapRouletteConnection that doesn't actually connect to anything.
  *
  * @author nachtm
+ * @author bbreithaupt
  */
 public class TestMapRouletteConnection implements TaskLoader
 {
@@ -24,6 +26,7 @@ public class TestMapRouletteConnection implements TaskLoader
     private final Map<Project, Set<Challenge>> projectToChallenges;
     private final Map<Long, Set<Task>> challengeToTasks;
     private Map<String, Long> projectNameToId;
+    private HttpHost proxy = null;
 
     public TestMapRouletteConnection()
     {
@@ -68,6 +71,11 @@ public class TestMapRouletteConnection implements TaskLoader
         return "";
     }
 
+    public HttpHost getProxy()
+    {
+        return this.proxy;
+    }
+
     @Override
     public long purgeIncompleteTasks(final long challengeID) throws URISyntaxException
     {
@@ -84,6 +92,11 @@ public class TestMapRouletteConnection implements TaskLoader
     public void setProjectNameToId(final Map<String, Long> projectIdMap)
     {
         this.projectNameToId = projectIdMap;
+    }
+
+    public void setProxy(final HttpHost proxy)
+    {
+        this.proxy = proxy;
     }
 
     public Set<Task> tasksForChallenge(final Challenge challenge)


### PR DESCRIPTION
### Description:

This adds a new optional `-proxy` parameter to the MapRouletteCommand. The proxy is defined in the format `scheme://host:port`, and is fed through to the underlying apache HttpClients. 
A number of new constructors are created to achieve this, but everything is backwards compatible. 

### Potential Impact:
None, everything is backwards compatible.

### Unit Test Approach:
Updated the test connection class, and added a unit test to ensure the proxy param is parsed correctly. 

### Test Results:
Tested running with a proxy from behind a restricted network.
Project, challenges, and tasks were created successfully:

![Screen Shot 2022-02-18 at 9 51 35 AM](https://user-images.githubusercontent.com/24948563/154742397-e82e6766-7c54-40c3-b4a4-0287c329e2be.png)

