### PR TITLE
MapRouletteUploadCommand Support Configuration Country Overrides

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommand.java
@@ -249,6 +249,7 @@ public class MapRouletteUploadCommand extends MapRouletteCommand
             final Optional<List<String>> undiscoverableChallenges)
     {
         final Map<String, String> challengeMap = fallbackConfiguration
+                .configurationForKeyword(countryCode)
                 .get(this.getChallengeParameter(checkName), Collections.emptyMap()).value();
         final Gson gson = new GsonBuilder().disableHtmlEscaping()
                 .registerTypeAdapter(Challenge.class, new ChallengeDeserializer()).create();

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteUploadCommandTest.java
@@ -120,7 +120,8 @@ public class MapRouletteUploadCommandTest
         Assert.assertEquals("Canada - Spiky Buildings", challengeNames.get(0));
         Assert.assertEquals("Mexico, Belize - Intersecting Lines", challengeNames.get(1));
         Assert.assertEquals("United States - Address Point Match", challengeNames.get(2));
-        Assert.assertEquals("Uruguay - Address Point Match", challengeNames.get(3));
+        Assert.assertEquals("Uruguay - Address Point Match / Coincidencia de punto de dirección",
+                challengeNames.get(3));
     }
 
     @Test

--- a/src/test/resources/org/openstreetmap/atlas/checks/maproulette/checksConfig.json
+++ b/src/test/resources/org/openstreetmap/atlas/checks/maproulette/checksConfig.json
@@ -1,7 +1,8 @@
 {
   "SomeCheck": {
     "challenge": {
-      "name": "Address Point Match"
+      "name": "Address Point Match",
+      "override.URY.name": "Address Point Match / Coincidencia de punto de dirección"
     }
   },
   "SomeOtherCheck": {


### PR DESCRIPTION
### Description:

This adds support for the [configuration country override system](https://github.com/osmlab/atlas-checks/blob/dev/docs/configuration.md#override) to the MapRouletteUploadCommand.

### Potential Impact:
No downstream impact.
Fully backwards compatible. 

### Unit Test Approach:

Update the existing custom configuration name test.

### Test Results:

Ran a test with custom challenge names and an override for WaterWayCheck:
<img width="1157" alt="Screen Shot 2022-02-23 at 1 10 20 PM" src="https://user-images.githubusercontent.com/24948563/155409070-68748f08-03f3-489f-b758-378caff5cdf3.png">
![Screen Shot 2022-02-23 at 1 05 18 PM](https://user-images.githubusercontent.com/24948563/155409084-954cbbab-ef47-42e3-8259-0045d901c76d.png)

