### PR TITLE
MapRoulette Challenge isArchived

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/data/Challenge.java
@@ -38,6 +38,7 @@ public class Challenge implements Serializable
     public static final String KEY_TAGS = "tags";
     public static final String DEFAULT_CHECKIN_COMMENT = "#maproulette";
     public static final String DISCOVERABLE = "enabled";
+    public static final String IS_ARCHIVED = "isArchived";
 
     private static final long serialVersionUID = -8034692909431083341L;
     private static final Gson CHALLENGE_GSON = new GsonBuilder().disableHtmlEscaping()
@@ -64,6 +65,7 @@ public class Challenge implements Serializable
     private String checkName;
     private boolean purge;
     private boolean changesetUrl = false;
+    private boolean isArchived = false;
 
     public Challenge(final Challenge challenge)
     {
@@ -194,6 +196,11 @@ public class Challenge implements Serializable
         return this.tags;
     }
 
+    public boolean isArchived()
+    {
+        return this.isArchived;
+    }
+
     public boolean isEnabled()
     {
         return this.enabled;
@@ -261,6 +268,7 @@ public class Challenge implements Serializable
         challengeJson.add(KEY_ACTIVE, new JsonPrimitive(true));
         challengeJson.add(KEY_UPDATE_TASKS, new JsonPrimitive(this.updateTasks));
         challengeJson.add(DISCOVERABLE, new JsonPrimitive(this.enabled));
+        challengeJson.add(IS_ARCHIVED, new JsonPrimitive(this.isArchived));
 
         // Do not override the name if it's already set
         if (this.name.isEmpty())

--- a/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/maproulette/data/ChallengeSerializationTest.java
@@ -92,6 +92,7 @@ public class ChallengeSerializationTest
         Assert.assertNotNull(deserializedChallenge.getHighPriorityRule());
         Assert.assertNotNull(deserializedChallenge.getMediumPriorityRule());
         Assert.assertNull(deserializedChallenge.getLowPriorityRule());
+        Assert.assertFalse(deserializedChallenge.isArchived());
     }
 
     /**


### PR DESCRIPTION
### Description:

This adds the `isArchived` field to the Challenge class, and adds it as a value in the challenge json. For now it is set to always be false, as challenges must be unarchived for tasks to be uploaded to them through the API. 
This will cause any archived challenges to be unarchived by the MapRouletteUploadCommand before it attempts to upload tasks to the given challenges. This is useful for dealing with the new challenge auto-archiving after 6 months of inactivity.  

### Potential Impact:
Challenges will be unarchived by the MR Upload command before attempting to upload tasks to them.

### Unit Test Approach:

Added the new field in the serialization unit test. 

### Test Results:
Tested uploading to an archived challenge before and after this change. Before, the challenge remained archived and no tasks were uploaded. After, the challenge was unarchived and tasks were uploaded as expected. 

