### PR TITLE
Highway Intersection Check

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -391,6 +391,12 @@
       "description": "Checks if the object access is overly permissive"
     }
   },
+  "HighwayIntersectionCheck": {
+    "challenge": {
+      "description": "This challenge contains roads that intersect with waterways.",
+      "instruction": "Please disconnect the roads that are connected to waterways."
+    }
+  },
   "HighwayMissingNameAndRefTagCheck": {
     "min.nonContiguous.angle": 30.0,
     "min.highway.type": "tertiary",

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -393,8 +393,8 @@
   },
   "HighwayIntersectionCheck": {
     "challenge": {
-      "description": "This challenge contains roads that intersect with waterways.",
-      "instruction": "Please disconnect the roads that are connected to waterways."
+      "description": "This challenge contains navigable ways that share nodes with non-navigable ways.",
+      "instruction": "Please fix the ways tags or modify the nodes that cause the issue."
     }
   },
   "HighwayMissingNameAndRefTagCheck": {

--- a/docs/available_checks.md
+++ b/docs/available_checks.md
@@ -125,4 +125,5 @@ This document is a list of tables with a description and link to documentation f
 | [LineCrossingWaterBodyCheck](checks/lineCrossingWaterBodyCheck.md) | The purpose of this check is to identify line items (edges or lines) and optionally buildings, that cross water bodies invalidly. |
 | [MalformedPolyLineCheck](checks/malformedPolyLineCheck.md) | This check identifies lines that have only one point, or none, and the ones that are too long. |
 | [SelfIntersectingPolylineCheck](checks/selfIntersectingPolylineCheck.md) | The purpose of this check is to identify all edges/lines/areas in Atlas that have self-intersecting polylines, or geometries that intersects itself in some form. |
-| [WaterWayCheck](checks/waterWayChecks.md) | This check finds closed waterways (circular water motion), waterways without a place for water to go (a "sink"), crossing waterways, and waterways that go uphill (requires elevation data). |
+| [WaterWayCheck](checks/waterWayCheck.md) | This check finds closed waterways (circular water motion), waterways without a place for water to go (a "sink"), crossing waterways, and waterways that go uphill (requires elevation data). |
+| [HighwayIntersectionCheck](checks/highwayIntersectionCheck.md) | The purpose of this check is to identify highways intersecting power or waterway objects invalidly. |

--- a/docs/checks/highwayIntersectionCheck.md
+++ b/docs/checks/highwayIntersectionCheck.md
@@ -1,0 +1,19 @@
+# Highway Intersection Check
+
+#### Description
+
+The purpose of this check is to flag highways intersecting power or waterway objects.
+
+*dam* and *weir* waterway objects are not flagged, these type of waterways can intersect with highways.
+
+For waterway objects the intersection with a highway having *leisure=slipway* or *ford=yes* tag is allowed, and they are not flagged.
+
+#### Configuration
+
+There are no configurables for this check.
+
+#### Code Review
+
+#### More Information
+
+Please see the source code for HighwayIntersectionCheck here: [HighwayIntersectionCheck](../../src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
@@ -36,7 +36,7 @@ import org.openstreetmap.atlas.utilities.configuration.Configuration;
 public class HighwayIntersectionCheck extends BaseCheck<Long>
 {
     private static final long serialVersionUID = -2100623356724302728L;
-    private static final String INSTRUCTION_FORMAT = "The way with id {0,number,#} has invalid intersections with {1}. A navigable way should not share nodes with non-navigable features. Either the way is inproperly tagged or is a combination of what should be two separate ways (highway and the other non-navigable feature).";
+    private static final String INSTRUCTION_FORMAT = "The way with id {0,number,#} has invalid intersections with {1}. A highway way should not share nodes with non-highway features. Either the way is inproperly tagged or is a combination of what should be two separate ways (highway and the other non-highway feature).";
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections
             .singletonList(INSTRUCTION_FORMAT);
 

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
@@ -64,11 +64,8 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
 
         final Set<Edge> invalidconnectingEdges = edgesConnectedToWay
                 .filter(connectedEdge -> TagPredicates.IS_POWER_LINE.test(connectedEdge)
-                        || !FordTag.isYes(edge))
-                .filter(connectedEdge -> TagPredicates.IS_POWER_LINE.test(connectedEdge)
-                        || this.isWaterwayToCheck(connectedEdge))
-                .filter(connectedEdge -> TagPredicates.IS_POWER_LINE.test(connectedEdge)
-                        || !this.isSlipway(edge))
+                        || (!FordTag.isYes(edge) && this.isWaterwayToCheck(connectedEdge)
+                                && !this.isSlipway(edge)))
                 .collect(Collectors.toSet());
 
         if (!invalidconnectingEdges.isEmpty())

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
@@ -48,28 +48,19 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        return !this.isFlagged(object)
-                && TypePredicates.IS_EDGE.test(object)
-                && ((Edge) object).isMainEdge()
-                && HighwayTag.isCarNavigableHighway(object);
+        return !this.isFlagged(object) && TypePredicates.IS_EDGE.test(object)
+                && ((Edge) object).isMainEdge() && HighwayTag.isCarNavigableHighway(object);
     }
 
     @Override
     protected Optional<CheckFlag> flag(final AtlasObject object)
     {
         final Edge edge = (Edge) object;
-        System.out.println("Testing edge: " + edge);
         final OsmWayWalker wayWalker = new OsmWayWalker(edge);
         final Set<Edge> wayEdges = wayWalker.collectEdges();
         final Stream<Edge> edgesConnectedToWay = wayEdges.stream().map(Edge::connectedEdges)
                 .flatMap(Set::stream)
                 .filter(connectedEdge -> !this.hasSameOSMId(connectedEdge, edge));
-        
-        System.out.println("Connected edges");
-        wayEdges.stream().map(Edge::connectedEdges)
-                .flatMap(Set::stream)
-                .filter(connectedEdge -> !this.hasSameOSMId(connectedEdge, edge))
-                .forEach(System.out::println);;
 
         final Set<Edge> invalidconnectingEdges = edgesConnectedToWay
                 .filter(connectedEdge -> TagPredicates.IS_POWER_LINE.test(connectedEdge)
@@ -78,12 +69,7 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
                         || this.isWaterwayToCheck(connectedEdge))
                 .filter(connectedEdge -> TagPredicates.IS_POWER_LINE.test(connectedEdge)
                         || !this.isSlipway(edge))
-                // .filter(connectedEdge -> TagPredicates.IS_POWER_LINE.test(connectedEdge)
-                //         || this.isWaterwayToCheck(connectedEdge))
-                // .filter(connectedEdge -> !(FordTag.isYes(edge) && this.isWaterWay(connectedEdge)))
-                // .filter(connectedEdge -> !(this.isSlipway(edge) && this.isWaterWay(connectedEdge)))
                 .collect(Collectors.toSet());
-        System.out.println("Invalid connected edges");
         invalidconnectingEdges.forEach(System.out::println);
 
         if (!invalidconnectingEdges.isEmpty())
@@ -197,7 +183,6 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
         boolean validForCheck = false;
         if (this.isWaterWay(object))
         {
-            System.out.println("is waterway");
             final Optional<WaterwayTag> waterwayTagValue = WaterwayTag.get(object);
             if (waterwayTagValue.isPresent())
             {
@@ -205,7 +190,6 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
                 validForCheck = !(HighwayTag.highwayTag(object).isPresent()
                         && (WaterwayTag.DAM.toString().equalsIgnoreCase(waterwayTag)
                                 || WaterwayTag.WEIR.toString().equalsIgnoreCase(waterwayTag)));
-                System.out.println("is valid for check? " + validForCheck);
             }
         }
         return validForCheck;

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
@@ -70,7 +70,6 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
                 .filter(connectedEdge -> TagPredicates.IS_POWER_LINE.test(connectedEdge)
                         || !this.isSlipway(edge))
                 .collect(Collectors.toSet());
-        invalidconnectingEdges.forEach(System.out::println);
 
         if (!invalidconnectingEdges.isEmpty())
         {

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
@@ -93,7 +93,7 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
                         .anyMatch(intersection -> isCross(edge, crossingEdge, intersection)))
                 .collect(Collectors.toSet());
 
-        if (invalidIntersectingEdges.size() > 0)
+        if (!invalidIntersectingEdges.isEmpty())
         {
             return this.createHighwayIntersectionCheckFlag(edge, invalidIntersectingEdges);
         }
@@ -158,9 +158,17 @@ public class HighwayIntersectionCheck extends BaseCheck<Long>
      */
     private boolean isWaterwayToCheck(final AtlasObject edge)
     {
-        return Validators.hasValuesFor(edge, WaterwayTag.class)
-                && !(HighwayTag.highwayTag(edge).isPresent()
-                        && (WaterwayTag.get(edge).get().name().equalsIgnoreCase("dam")
-                                || WaterwayTag.get(edge).get().name().equalsIgnoreCase("weir")));
+        boolean validForCheck = false;
+        if (Validators.hasValuesFor(edge, WaterwayTag.class))
+        {
+            final Optional<WaterwayTag> waterwayTagValue = WaterwayTag.get(edge);
+            if (waterwayTagValue.isPresent())
+            {
+                validForCheck = !(HighwayTag.highwayTag(edge).isPresent()
+                        && (waterwayTagValue.get().name().equalsIgnoreCase("dam")
+                                || waterwayTagValue.get().name().equalsIgnoreCase("weir")));
+            }
+        }
+        return validForCheck;
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheck.java
@@ -1,0 +1,166 @@
+package org.openstreetmap.atlas.checks.validation.intersections;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.openstreetmap.atlas.checks.atlas.predicates.TagPredicates;
+import org.openstreetmap.atlas.checks.atlas.predicates.TypePredicates;
+import org.openstreetmap.atlas.checks.base.BaseCheck;
+import org.openstreetmap.atlas.checks.flag.CheckFlag;
+import org.openstreetmap.atlas.geography.Location;
+import org.openstreetmap.atlas.geography.PolyLine;
+import org.openstreetmap.atlas.geography.Rectangle;
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.geography.atlas.items.AtlasObject;
+import org.openstreetmap.atlas.geography.atlas.items.Edge;
+import org.openstreetmap.atlas.tags.FordTag;
+import org.openstreetmap.atlas.tags.HighwayTag;
+import org.openstreetmap.atlas.tags.LeisureTag;
+import org.openstreetmap.atlas.tags.WaterwayTag;
+import org.openstreetmap.atlas.tags.annotations.validation.Validators;
+import org.openstreetmap.atlas.utilities.collections.Iterables;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * Flags waterway and power line edge items that are crossed by navigable edges (having way specific
+ * highway tag). If the way is a waterway and the crossing way has {@code ford=yes} or
+ * {@code leisure=slipway} tags, then the crossing is accepted. {@code dam} and {@code weir}
+ * waterways are not checked, those type of ways can cross other highways.
+ *
+ * @author pako.todea
+ */
+public class HighwayIntersectionCheck extends BaseCheck<Long>
+{
+
+    private static final long serialVersionUID = 1L;
+    private static final String INSTRUCTION_FORMAT = "The water/powerline with id {0,number,#} has invalid crossings "
+            + "with {1}. A navigable way can not cross a power line or a water.";
+    private static final String INVALID_EDGE_FORMAT = "Edge {0,number,#} is crossing invalidly with {1}.";
+    private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INSTRUCTION_FORMAT,
+            INVALID_EDGE_FORMAT);
+
+    /**
+     * Checks whether the given {@link Edge}s cross each other.
+     *
+     * @param edge
+     *            {@link Edge} being crossed
+     * @param crossingEdge
+     *            Crossing {@link Edge}
+     * @param intersection
+     *            Intersection {@link Location}
+     * @return {@code true} if given {@link Edge}s cross each other
+     */
+    private static boolean isCross(final Edge edge, final Edge crossingEdge,
+            final Location intersection)
+    {
+        final PolyLine edgeAsPolyLine = edge.asPolyLine();
+        final PolyLine crossingEdgeAsPolyLine = crossingEdge.asPolyLine();
+        return edgeAsPolyLine.contains(intersection)
+                && crossingEdgeAsPolyLine.contains(intersection);
+    }
+
+    public HighwayIntersectionCheck(final Configuration configuration)
+    {
+        super(configuration);
+    }
+
+    @Override
+    public boolean validCheckForObject(final AtlasObject object)
+    {
+        return TypePredicates.IS_EDGE.test(object)
+                && (TagPredicates.IS_POWER_LINE.test(object) || this.isWaterwayToCheck(object));
+    }
+
+    @Override
+    protected Optional<CheckFlag> flag(final AtlasObject object)
+    {
+        final Edge edge = (Edge) object;
+        final Atlas atlas = edge.getAtlas();
+        final Rectangle edgeBounds = edge.bounds();
+
+        final Set<Edge> invalidIntersectingEdges = Iterables
+                .asList(atlas.edgesIntersecting(edgeBounds, HighwayTag::isWayOnlyTag)).stream()
+                .filter(crossingEdge -> TagPredicates.IS_POWER_LINE.test(edge)
+                        || !FordTag.isYes(crossingEdge))
+                .filter(crossingEdge -> TagPredicates.IS_POWER_LINE.test(edge)
+                        || !Validators.isOfType(crossingEdge, LeisureTag.class, LeisureTag.SLIPWAY))
+                .filter(crossingEdge -> crossingEdge.getIdentifier() != edge.getIdentifier())
+                .filter(crossingEdge -> !crossingEdge.isReversedEdge(edge))
+                .filter(crossingEdge -> this.getIntersection(edge, crossingEdge).stream()
+                        .anyMatch(intersection -> isCross(edge, crossingEdge, intersection)))
+                .collect(Collectors.toSet());
+
+        if (invalidIntersectingEdges.size() > 0)
+        {
+            return this.createHighwayIntersectionCheckFlag(edge, invalidIntersectingEdges);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    protected List<String> getFallbackInstructions()
+    {
+        return FALLBACK_INSTRUCTIONS;
+    }
+
+    /**
+     * Function that creates highway intersection check flag.
+     *
+     * @param edge
+     *            Atlas object.
+     * @param crossingEdges
+     *            collected edges for a given atlas object.
+     * @return newly created highway intersection check flag including crossing edges locations.
+     */
+    private Optional<CheckFlag> createHighwayIntersectionCheckFlag(final Edge edge,
+            final Set<Edge> crossingEdges)
+    {
+        final CheckFlag newFlag = new CheckFlag(this.getTaskIdentifier(edge));
+        this.markAsFlagged(edge.getIdentifier());
+        final Set<Location> points = crossingEdges.stream()
+                .filter(crossEdge -> crossEdge.getIdentifier() != edge.getIdentifier())
+                .flatMap(crossEdge -> this.getIntersection(edge, crossEdge).stream())
+                .collect(Collectors.toSet());
+        newFlag.addInstruction(
+                this.getLocalizedInstruction(0, edge.getOsmIdentifier(), crossingEdges.stream()
+                        .map(AtlasObject::getOsmIdentifier).collect(Collectors.toSet())));
+        newFlag.addPoints(points);
+        newFlag.addObject(edge);
+        return Optional.of(newFlag);
+    }
+
+    /**
+     * This function returns the set of intersection locations for the given edges.
+     *
+     * @param firstEdge
+     *            the first Edge
+     * @param secondEdge
+     *            the second edge
+     * @return set of intersection locations.
+     */
+    private Set<Location> getIntersection(final Edge firstEdge, final Edge secondEdge)
+    {
+        final PolyLine firstEdgeAsPolyLine = firstEdge.asPolyLine();
+        final PolyLine secondEdgeAsPolyLine = secondEdge.asPolyLine();
+        return firstEdgeAsPolyLine.intersections(secondEdgeAsPolyLine);
+    }
+
+    /**
+     * Checks whether the given {@link AtlasObject} is a waterway to check.
+     *
+     * @param edge
+     *            the {@link AtlasObject} to check
+     * @return true if the given {@link AtlasObject} should be ckecked
+     */
+    private boolean isWaterwayToCheck(final AtlasObject edge)
+    {
+        return Validators.hasValuesFor(edge, WaterwayTag.class)
+                && !(HighwayTag.highwayTag(edge).isPresent()
+                        && (WaterwayTag.get(edge).get().name().equalsIgnoreCase("dam")
+                                || WaterwayTag.get(edge).get().name().equalsIgnoreCase("weir")));
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheckTest.java
@@ -5,10 +5,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
 import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
-import org.openstreetmap.atlas.utilities.configuration.Configuration;
 
 /**
  * @author pako.todea
+ * @author brianjor
  */
 public class HighwayIntersectionCheckTest
 {
@@ -19,13 +19,13 @@ public class HighwayIntersectionCheckTest
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
 
-    private final Configuration configuration = ConfigurationResolver.emptyConfiguration();
+    private final HighwayIntersectionCheck check = new HighwayIntersectionCheck(
+            ConfigurationResolver.emptyConfiguration());
 
     @Test
     public void testInvalidCrossingHighwayLeisureEdges()
     {
-        this.verifier.actual(this.setup.invalidCrossingWaterwayLeisureEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.invalidCrossingWaterwayLeisureEdges(), this.check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
@@ -33,8 +33,7 @@ public class HighwayIntersectionCheckTest
     @Test
     public void testInvalidCrossingHighwayPowerLineEdges()
     {
-        this.verifier.actual(this.setup.invalidCrossingHighwayPowerLineEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.invalidCrossingHighwayPowerLineEdges(), this.check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
@@ -42,8 +41,7 @@ public class HighwayIntersectionCheckTest
     @Test
     public void testInvalidCrossingHighwayWaterEdges()
     {
-        this.verifier.actual(this.setup.invalidCrossingHighwayWaterEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.invalidCrossingHighwayWaterEdges(), this.check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
@@ -51,8 +49,7 @@ public class HighwayIntersectionCheckTest
     @Test
     public void testInvalidCrossingPowerLineFordYesEdges()
     {
-        this.verifier.actual(this.setup.invalidCrossingPowerLineFordYesEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.invalidCrossingPowerLineFordYesEdges(), this.check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
@@ -60,8 +57,7 @@ public class HighwayIntersectionCheckTest
     @Test
     public void testInvalidCrossingPowerLineLeisureSlipwayEdges()
     {
-        this.verifier.actual(this.setup.invalidCrossingPowerLineLeisureSlipwayEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.invalidCrossingPowerLineLeisureSlipwayEdges(), this.check);
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
@@ -69,57 +65,50 @@ public class HighwayIntersectionCheckTest
     @Test
     public void testInvalidMultipleCrossingHighwayWaterEdges()
     {
-        this.verifier.actual(this.setup.invalidMultipleCrossingHighwayWaterEdges(),
-                new HighwayIntersectionCheck(this.configuration));
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
+        this.verifier.actual(this.setup.invalidMultipleCrossingHighwayWaterEdges(), this.check);
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test
     public void testNoCrossingHighwayPowerLineEdges()
     {
-        this.verifier.actual(this.setup.noCrossingHighwayPowerLineEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.noCrossingHighwayPowerLineEdges(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
     public void testNoCrossingHighwayWaterEdges()
     {
-        this.verifier.actual(this.setup.noCrossingHighwayWaterEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.noCrossingHighwayWaterEdges(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
     public void testValidCrossingHighwayFordYesEdges()
     {
-        this.verifier.actual(this.setup.validCrossingWaterwayFordYesEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.validCrossingWaterwayFordYesEdges(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
     public void testValidCrossingHighwayLeisureSlipwayEdges()
     {
-        this.verifier.actual(this.setup.validCrossingWaterwayLeisureSlipwayEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.validCrossingWaterwayLeisureSlipwayEdges(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
     public void testValidCrossingHighwayWaterwayDamEdges()
     {
-        this.verifier.actual(this.setup.validCrossingHighwayWaterwayDamEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.validCrossingHighwayWaterwayDamEdges(), this.check);
         this.verifier.verifyEmpty();
     }
 
     @Test
     public void testValidCrossingHighwayWaterwayWeirEdges()
     {
-        this.verifier.actual(this.setup.validCrossingHighwayWaterwayWeirEdges(),
-                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.actual(this.setup.validCrossingHighwayWaterwayWeirEdges(), this.check);
         this.verifier.verifyEmpty();
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionCheckTest.java
@@ -1,0 +1,125 @@
+package org.openstreetmap.atlas.checks.validation.intersections;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openstreetmap.atlas.checks.configuration.ConfigurationResolver;
+import org.openstreetmap.atlas.checks.validation.verifier.ConsumerBasedExpectedCheckVerifier;
+import org.openstreetmap.atlas.utilities.configuration.Configuration;
+
+/**
+ * @author pako.todea
+ */
+public class HighwayIntersectionCheckTest
+{
+
+    @Rule
+    public HighwayIntersectionTestCaseRule setup = new HighwayIntersectionTestCaseRule();
+
+    @Rule
+    public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
+
+    private final Configuration configuration = ConfigurationResolver.emptyConfiguration();
+
+    @Test
+    public void testInvalidCrossingHighwayLeisureEdges()
+    {
+        this.verifier.actual(this.setup.invalidCrossingWaterwayLeisureEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingHighwayPowerLineEdges()
+    {
+        this.verifier.actual(this.setup.invalidCrossingHighwayPowerLineEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingHighwayWaterEdges()
+    {
+        this.verifier.actual(this.setup.invalidCrossingHighwayWaterEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingPowerLineFordYesEdges()
+    {
+        this.verifier.actual(this.setup.invalidCrossingPowerLineFordYesEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidCrossingPowerLineLeisureSlipwayEdges()
+    {
+        this.verifier.actual(this.setup.invalidCrossingPowerLineLeisureSlipwayEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testInvalidMultipleCrossingHighwayWaterEdges()
+    {
+        this.verifier.actual(this.setup.invalidMultipleCrossingHighwayWaterEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testNoCrossingHighwayPowerLineEdges()
+    {
+        this.verifier.actual(this.setup.noCrossingHighwayPowerLineEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testNoCrossingHighwayWaterEdges()
+    {
+        this.verifier.actual(this.setup.noCrossingHighwayWaterEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testValidCrossingHighwayFordYesEdges()
+    {
+        this.verifier.actual(this.setup.validCrossingWaterwayFordYesEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testValidCrossingHighwayLeisureSlipwayEdges()
+    {
+        this.verifier.actual(this.setup.validCrossingWaterwayLeisureSlipwayEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testValidCrossingHighwayWaterwayDamEdges()
+    {
+        this.verifier.actual(this.setup.validCrossingHighwayWaterwayDamEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testValidCrossingHighwayWaterwayWeirEdges()
+    {
+        this.verifier.actual(this.setup.validCrossingHighwayWaterwayWeirEdges(),
+                new HighwayIntersectionCheck(this.configuration));
+        this.verifier.verifyEmpty();
+    }
+}

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionTestCaseRule.java
@@ -27,9 +27,11 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_3),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_3),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas noCrossingHighwayWaterEdges;
 
@@ -42,9 +44,11 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas invalidCrossingHighwayWaterEdges;
 
@@ -57,11 +61,14 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_4),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_4),
                             @TestAtlas.Loc(value = LOCATION_5) }, tags = { "highway=primary" }),
-                    @TestAtlas.Edge(id = "1236000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1236000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas invalidMultipleCrossingHighwayWaterEdges;
 
@@ -74,9 +81,11 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_3),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_3),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas noCrossingHighwayPowerLineEdges;
 
@@ -89,9 +98,11 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas invalidCrossingHighwayPowerLineEdges;
 
@@ -104,9 +115,11 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=dam",
                                     "highway=service" }) })
     private Atlas validCrossingHighwayWaterwayDamEdges;
@@ -120,9 +133,11 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=weir",
                                     "highway=service" }) })
     private Atlas validCrossingHighwayWaterwayWeirEdges;
@@ -136,10 +151,12 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "ford=yes" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas validCrossingWaterwayFordYesEdges;
 
@@ -152,10 +169,12 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "ford=yes" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas invalidCrossingPowerLineFordYesEdges;
 
@@ -168,10 +187,12 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "leisure=slipway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas validCrossingWaterwayLeisureSlipwayEdges;
 
@@ -184,10 +205,12 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "leisure=slipway" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas invalidCrossingPowerLineLeisureSlipwayEdges;
 
@@ -200,10 +223,12 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "leisure=dance" }),
-                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = {
+                            @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas invalidCrossingWaterwayLeisureEdges;
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionTestCaseRule.java
@@ -27,9 +27,9 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_3),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_3),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas noCrossingHighwayWaterEdges;
 
@@ -42,9 +42,9 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas invalidCrossingHighwayWaterEdges;
 
@@ -57,11 +57,11 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_4),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_4),
                             @TestAtlas.Loc(value = LOCATION_5) }, tags = { "highway=primary" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1236000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas invalidMultipleCrossingHighwayWaterEdges;
 
@@ -74,9 +74,9 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_3),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_3),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas noCrossingHighwayPowerLineEdges;
 
@@ -89,9 +89,9 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas invalidCrossingHighwayPowerLineEdges;
 
@@ -104,9 +104,9 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=dam",
                                     "highway=service" }) })
     private Atlas validCrossingHighwayWaterwayDamEdges;
@@ -120,9 +120,9 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=weir",
                                     "highway=service" }) })
     private Atlas validCrossingHighwayWaterwayWeirEdges;
@@ -136,10 +136,10 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "ford=yes" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas validCrossingWaterwayFordYesEdges;
 
@@ -152,10 +152,10 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "ford=yes" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas invalidCrossingPowerLineFordYesEdges;
 
@@ -168,10 +168,10 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "leisure=slipway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas validCrossingWaterwayLeisureSlipwayEdges;
 
@@ -184,10 +184,10 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "leisure=slipway" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
     private Atlas invalidCrossingPowerLineLeisureSlipwayEdges;
 
@@ -200,10 +200,10 @@ public class HighwayIntersectionTestCaseRule extends CoreTestRule
                     @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
             // edges
             edges = {
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                    @TestAtlas.Edge(id = "1234000000", coordinates = { @TestAtlas.Loc(value = LOCATION_1),
                             @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
                                     "leisure=dance" }),
-                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                    @TestAtlas.Edge(id = "1235000000", coordinates = { @TestAtlas.Loc(value = LOCATION_2),
                             @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
     private Atlas invalidCrossingWaterwayLeisureEdges;
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionTestCaseRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/HighwayIntersectionTestCaseRule.java
@@ -1,0 +1,269 @@
+package org.openstreetmap.atlas.checks.validation.intersections;
+
+import org.openstreetmap.atlas.geography.atlas.Atlas;
+import org.openstreetmap.atlas.utilities.testing.CoreTestRule;
+import org.openstreetmap.atlas.utilities.testing.TestAtlas;
+
+/**
+ * {@link HighwayIntersectionCheckTest} data generator
+ *
+ * @author pako.todea
+ */
+public class HighwayIntersectionTestCaseRule extends CoreTestRule
+{
+
+    private static final String LOCATION_1 = "47.576973, -122.304985";
+    private static final String LOCATION_2 = "47.575661, -122.304222";
+    private static final String LOCATION_3 = "47.574612, -122.305855";
+    private static final String LOCATION_4 = "47.575371, -122.308121";
+    private static final String LOCATION_5 = "47.576485, -122.307098";
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_3),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
+    private Atlas noCrossingHighwayWaterEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
+    private Atlas invalidCrossingHighwayWaterEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_4),
+                            @TestAtlas.Loc(value = LOCATION_5) }, tags = { "highway=primary" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
+    private Atlas invalidMultipleCrossingHighwayWaterEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_3),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
+    private Atlas noCrossingHighwayPowerLineEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
+    private Atlas invalidCrossingHighwayPowerLineEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=dam",
+                                    "highway=service" }) })
+    private Atlas validCrossingHighwayWaterwayDamEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=weir",
+                                    "highway=service" }) })
+    private Atlas validCrossingHighwayWaterwayWeirEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
+                                    "ford=yes" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
+    private Atlas validCrossingWaterwayFordYesEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
+                                    "ford=yes" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
+    private Atlas invalidCrossingPowerLineFordYesEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
+                                    "leisure=slipway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
+    private Atlas validCrossingWaterwayLeisureSlipwayEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
+                                    "leisure=slipway" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "power=line" }) })
+    private Atlas invalidCrossingPowerLineLeisureSlipwayEdges;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_1)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_2)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_3)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_4)),
+                    @TestAtlas.Node(coordinates = @TestAtlas.Loc(value = LOCATION_5)) },
+            // edges
+            edges = {
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_1),
+                            @TestAtlas.Loc(value = LOCATION_2) }, tags = { "highway=motorway",
+                                    "leisure=dance" }),
+                    @TestAtlas.Edge(coordinates = { @TestAtlas.Loc(value = LOCATION_2),
+                            @TestAtlas.Loc(value = LOCATION_4) }, tags = { "waterway=stream" }) })
+    private Atlas invalidCrossingWaterwayLeisureEdges;
+
+    public Atlas invalidCrossingHighwayPowerLineEdges()
+    {
+        return this.invalidCrossingHighwayPowerLineEdges;
+    }
+
+    public Atlas invalidCrossingHighwayWaterEdges()
+    {
+        return this.invalidCrossingHighwayWaterEdges;
+    }
+
+    public Atlas invalidCrossingPowerLineFordYesEdges()
+    {
+        return this.invalidCrossingPowerLineFordYesEdges;
+    }
+
+    public Atlas invalidCrossingPowerLineLeisureSlipwayEdges()
+    {
+        return this.invalidCrossingPowerLineLeisureSlipwayEdges;
+    }
+
+    public Atlas invalidCrossingWaterwayLeisureEdges()
+    {
+        return this.invalidCrossingWaterwayLeisureEdges;
+    }
+
+    public Atlas invalidMultipleCrossingHighwayWaterEdges()
+    {
+        return this.invalidMultipleCrossingHighwayWaterEdges;
+    }
+
+    public Atlas noCrossingHighwayPowerLineEdges()
+    {
+        return this.noCrossingHighwayPowerLineEdges;
+    }
+
+    public Atlas noCrossingHighwayWaterEdges()
+    {
+        return this.noCrossingHighwayWaterEdges;
+    }
+
+    public Atlas validCrossingHighwayWaterwayDamEdges()
+    {
+        return this.validCrossingHighwayWaterwayDamEdges;
+    }
+
+    public Atlas validCrossingHighwayWaterwayWeirEdges()
+    {
+        return this.validCrossingHighwayWaterwayWeirEdges;
+    }
+
+    public Atlas validCrossingWaterwayFordYesEdges()
+    {
+        return this.validCrossingWaterwayFordYesEdges;
+    }
+
+    public Atlas validCrossingWaterwayLeisureSlipwayEdges()
+    {
+        return this.validCrossingWaterwayLeisureSlipwayEdges;
+    }
+}


### PR DESCRIPTION
### Description:

Picked up where #643 left off.

Changes are:
* Flagging the highway and the node(s) that intersects with the powerline/waterway instead of the powerline/waterway
* Flags the way instead of just the edge

### Test Results:


| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
|  ARG   |    10         |    10      |     100%       |   10 |   0 | 0%   |
|  AUS |    9         |    9      |     100%       |   9 |   0 | 0%   |
|  TUR |    18         |    18      |     100%       |   18 |   0 | 0%   |

