### PR TITLE
MapRoulette Upload Purge Incomplete Bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -94,7 +94,8 @@ public class MapRouletteConnection implements TaskLoader, Serializable
             throws UnsupportedEncodingException, URISyntaxException
     {
         HttpResource createUpdate = null;
-        final GetResource challengeGet = new GetResource(this.uriBuilder.get().build().resolve(getURI));
+        final GetResource challengeGet = new GetResource(
+                this.uriBuilder.get().build().resolve(getURI));
         this.setAuth(challengeGet);
         try
         {
@@ -194,9 +195,9 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     public long purgeIncompleteTasks(final long challengeID)
             throws UnsupportedEncodingException, URISyntaxException
     {
-        try (HttpResource purge = new DeleteResource(
-                this.uriBuilder.get().setPath(String.format("/api/v2/challenge/%s/tasks", challengeID))
-                        .addParameter("statusFilters", "0,3").build().toString()))
+        try (HttpResource purge = new DeleteResource(this.uriBuilder.get()
+                .setPath(String.format("/api/v2/challenge/%s/tasks", challengeID))
+                .addParameter("statusFilters", "0,3").build().toString()))
         {
             logger.info("challenge {}: purging incomplete tasks...", challengeID);
             this.setAuth(purge);

--- a/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/maproulette/MapRouletteConnection.java
@@ -49,7 +49,7 @@ public class MapRouletteConnection implements TaskLoader, Serializable
     private static final int MAXIMUM_BATCH_SIZE = 5000;
     private static final long serialVersionUID = -8227257938510897604L;
     private final MapRouletteConfiguration configuration;
-    private final Supplier<URIBuilder> uriBuilder;
+    private final transient Supplier<URIBuilder> uriBuilder;
     private final HttpHost proxy;
 
     MapRouletteConnection(final MapRouletteConfiguration configuration, final HttpHost proxy)


### PR DESCRIPTION
### Description:

There is a bug with the purge incomplete tasks switch for the maproulette upload command. When this switch is true a `statusFilters` parameter is added to the shared url builder used in MapRouletteConnection. This addition persists and increases every time a task is deleted by the purgeIncompleteTasks method. The result is that urls start to look like the following:
```
/api/v2/challenge/14150?statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3
```

When extreme enough, this can cause upload failures due to a maximum url length being hit. 

To fix this MapRouletteConnection will no longer share a url builder, but will instead be supplied a new one for each api call. 

### Potential Impact:

Should only effect the MR commands.

### Unit Test Approach:

None, as the project does not have PowerMock. So unit tests for MapRouletteConnection are not viable. 

### Test Results:
Tested running the command 3 times. The first time was just to upload some data to a project. 
The second time the same data was uploaded to the same project with purge incomplete tasks on, and no code changes. This resulted in the final API call having the url tail `POST /api/v2/tasks?statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3&statusFilters=0%2C3`.
The third time was the same as the second, but with the code changes in this PR. The final API call this time has the url tail `POST /api/v2/tasks`.

