### PR TITLE
InvalidGeometryCheckTest add roller coaster logic

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": false
+    "enabled.value.default": true
   },
   "PoolSizeCheck": {
     "surface": {

--- a/config/configuration.json
+++ b/config/configuration.json
@@ -4,7 +4,7 @@
       "org.openstreetmap.atlas.checks.validation"
     ],
     "type": "org.openstreetmap.atlas.checks.base.BaseCheck",
-    "enabled.value.default": true
+    "enabled.value.default": false
   },
   "PoolSizeCheck": {
     "surface": {
@@ -499,6 +499,7 @@
     }
   },
   "InvalidGeometryCheck": {
+    "tags.filter": "attraction->!roller_coaster&roller_coaster->!",
     "challenge": {
       "description": "Tasks containing Ways with invalid geometries",
       "blurb": "Invalid Geometries",

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/geometry/InvalidGeometryCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/geometry/InvalidGeometryCheckTest.java
@@ -20,7 +20,8 @@ public class InvalidGeometryCheckTest
     public InvalidGeometryCheckTestRule setup = new InvalidGeometryCheckTestRule();
     @Rule
     public ConsumerBasedExpectedCheckVerifier verifier = new ConsumerBasedExpectedCheckVerifier();
-    private final Configuration configuration = ConfigurationResolver.emptyConfiguration();
+    private final Configuration configuration = ConfigurationResolver.inlineConfiguration(
+            "{\"InvalidGeometryCheck\":{\"tags.filter\":\"attraction->!roller_coaster&roller_coaster->!\"}}");
 
     @Test
     public void borderSlicedPolygonTest()
@@ -80,6 +81,14 @@ public class InvalidGeometryCheckTest
     public void testFinePolygonTest()
     {
         this.verifier.actual(this.setup.getFinePolygonAtlas(),
+                new InvalidGeometryCheck(this.configuration));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testNotValidLinearRollerCoasterTest()
+    {
+        this.verifier.actual(this.setup.getNotValidLinearRollerCoasterAtlas(),
                 new InvalidGeometryCheck(this.configuration));
         this.verifier.verifyEmpty();
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/geometry/InvalidGeometryCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/geometry/InvalidGeometryCheckTestRule.java
@@ -85,6 +85,13 @@ public class InvalidGeometryCheckTestRule extends CoreTestRule
     private Atlas notValidLinearAtlas;
 
     @TestAtlas(
+            // lines
+            lines = { @Line(id = TEST_ID_2, coordinates = { @Loc(value = LOCATION_8),
+                    @Loc(value = LOCATION_8) }, tags = { "attraction=roller_coaster",
+                            "roller_coaster=anything" }) })
+    private Atlas notValidLinearRollerCoasterAtlas;
+
+    @TestAtlas(
             // areas
             areas = { @Area(id = TEST_ID_5, coordinates = { @Loc(value = LOCATION_1),
                     @Loc(value = LOCATION_4), @Loc(value = LOCATION_2), @Loc(value = LOCATION_3),
@@ -129,6 +136,11 @@ public class InvalidGeometryCheckTestRule extends CoreTestRule
     public Atlas getNotValidLinearAtlas()
     {
         return this.notValidLinearAtlas;
+    }
+
+    public Atlas getNotValidLinearRollerCoasterAtlas()
+    {
+        return this.notValidLinearRollerCoasterAtlas;
     }
 
 }


### PR DESCRIPTION
Description:

please refer to: https://github.com/osmlab/atlas-checks/issues/645
implemented in check Configuration. attraction->!roller_coaster&roller_coaster->!

Potential Impact:

OSM objects with tags "roller_coaster=*" and "attraction=roller_coaster" will be filtered out from check.

Unit Test Approach:

Created unit test for "roller_coaster=*" and "attraction=roller_coaster" cases.

Test Results:

passed.