### PR TITLE
EdgeCrossingEdgeCheck Rework for Execution Time

### DIFF
--- a/config/configuration.json
+++ b/config/configuration.json
@@ -308,6 +308,7 @@
     "crossing.car.navigable": true,
     "crossing.pedestrian.navigable": false,
     "indoor.mapping": "indoor->*|highway->corridor,steps|level->*",
+    "cluster.distance": 500.0,
     "challenge": {
       "description": "Tasks contain ways that do not have shared nodes but cross each other.",
       "blurb": "Crossing Ways",

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -167,7 +167,8 @@ public class EdgeCrossingEdgeCheckTest
     public void testInvalidMultiClusterAtlas()
     {
         this.verifier.actual(this.setup.invalidMultiClusterAtlas(),
-                new EdgeCrossingEdgeCheck(this.configuration));
+                new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
+                        "{\"EdgeCrossingEdgeCheck\":{\"cluster.distance\": 500.0}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
         this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -164,6 +164,15 @@ public class EdgeCrossingEdgeCheckTest
     }
 
     @Test
+    public void testInvalidMultiClusterAtlas()
+    {
+        this.verifier.actual(this.setup.invalidMultiClusterAtlas(),
+                new EdgeCrossingEdgeCheck(this.configuration));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
     public void testNoCrossingItemsAtlas()
     {
         this.verifier.actual(this.setup.noCrossingItemsAtlas(),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTest.java
@@ -27,7 +27,7 @@ public class EdgeCrossingEdgeCheckTest
                                 + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
 
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -39,7 +39,7 @@ public class EdgeCrossingEdgeCheckTest
                                 + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
 
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(7, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class EdgeCrossingEdgeCheckTest
                                 + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
 
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -63,7 +63,7 @@ public class EdgeCrossingEdgeCheckTest
                                 + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
 
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(7, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class EdgeCrossingEdgeCheckTest
                         "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":true,\"pedestrian.navigable\":true,\"crossing.car.navigable\":true,\"crossing.pedestrian.navigable\":false,"
                                 + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
 
-        this.verifier.globallyVerify(flags -> Assert.assertEquals(2, flags.size()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class EdgeCrossingEdgeCheckTest
                 new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.verifyNotEmpty();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class EdgeCrossingEdgeCheckTest
                 new EdgeCrossingEdgeCheck(ConfigurationResolver.inlineConfiguration(
                         "{\"EdgeCrossingEdgeCheck\":{\"minimum.highway.type\":\"track\"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -133,7 +133,7 @@ public class EdgeCrossingEdgeCheckTest
                 new EdgeCrossingEdgeCheck(this.configuration));
         this.verifier.verifyNotEmpty();
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(7, flag.getFlaggedObjects().size()));
     }
 
     @Test
@@ -144,7 +144,7 @@ public class EdgeCrossingEdgeCheckTest
                         "{\"EdgeCrossingEdgeCheck\":{\"car.navigable\":false,\"pedestrian.navigable\":true,\"crossing.car.navigable\":false,\"crossing.pedestrian.navigable\":true,"
                                 + "\"indoor.mapping\": \"indoor->*|highway->corridor,steps|level->*\"}}")));
         this.verifier.globallyVerify(flags -> Assert.assertEquals(1, flags.size()));
-        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/EdgeCrossingEdgeCheckTestRule.java
@@ -281,6 +281,24 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
                                     @Loc(TEST5) }, tags = { "highway=secondary" }) })
     private Atlas invalidDisconnectedEdgeCrossingAtlas;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = LOCATION_1)),
+                    @Node(coordinates = @Loc(value = LOCATION_2)),
+                    @Node(coordinates = @Loc(value = LOCATION_4)),
+                    @Node(coordinates = @Loc(value = TEST4)),
+                    @Node(coordinates = @Loc(value = TEST5)),
+                    @Node(coordinates = @Loc(value = TEST6)) },
+            // edges
+            edges = {
+                    @Edge(id = "123456789000000", coordinates = { @Loc(value = LOCATION_1),
+                            @Loc(value = TEST6) }, tags = { "highway=motorway" }),
+                    @Edge(id = "223456789000000", coordinates = { @Loc(value = LOCATION_2),
+                            @Loc(value = LOCATION_4) }, tags = { "highway=motorway" }),
+                    @Edge(id = "323456789000000", coordinates = { @Loc(value = TEST4),
+                            @Loc(value = TEST5) }, tags = { "highway=motorway" }) })
+    private Atlas invalidMultiClusterAtlas;
+
     public Atlas invalidCrossingItemsAtlas()
     {
         return this.invalidCrossingItemsAtlas;
@@ -329,6 +347,11 @@ public class EdgeCrossingEdgeCheckTestRule extends CoreTestRule
     public Atlas invalidDisconnectedNodesCrossingAtlas()
     {
         return this.invalidDisconnectedNodesCrossingAtlas;
+    }
+
+    public Atlas invalidMultiClusterAtlas()
+    {
+        return this.invalidMultiClusterAtlas;
     }
 
     public Atlas noCrossingItemsAtlas()


### PR DESCRIPTION
### Description:

For some time now the EdgeCrossingEdgeCheck has suffered from very poor efficiency in processing features that have a significant number of invalid intersections. An example is this feature at version 5: https://www.openstreetmap.org/way/1043498633. This has regular increased the overall runtime for checks execution to 6+ times the time it normally takes. 

This stemmed from the way the check would walk a network of invalid intersections a number of times equal to the number of edges in the network. This design was originally implemented to resolve a possible nondeterminism issue, that in review did not really exist. However, there were a couple of other beneficial things added with this. Checks were made simpler, and marked the exact point of intersections. These improvements have both been well received by editors. It also seems, though, there there was a loss of some intersections points in more complex cases. 

This rework removes the redundant network walks, and attempts to build upon the improvements made to flag clarity. The primary change seen in most flags is that all involved edges are now once again shown, along with the points marking the invalid intersections.
Old basic flag:
![Screen Shot 2022-04-22 at 11 24 00 AM](https://user-images.githubusercontent.com/24948563/164772819-994f1514-56e0-4750-a393-d6681b079f0f.png)
New basic flag:
![Screen Shot 2022-04-22 at 11 24 15 AM](https://user-images.githubusercontent.com/24948563/164772848-5c4f928e-86c2-49cb-b372-bde8339ab2a7.png)

To keep the simplicity of flags in cases where there are networks of intersections cover a larger area, a clustering system has been implemented to split these networks in to multiple flags. Intersections in a network are clustered based on a configurable distance, defaulting to 500 meters. Each flag is comprised of the cluster of intersection points, and only the Edges connected to those points. All clusters for a network are calculated the first time any Edge in that network is encountered. The cluster the initial Edge is in is flagged and the rest are stored for latter flagging. As Edges in the other clusters are encountered, the pre-calculated clusters are pulled from the store and flagged. 
An example of the result of this is that the following flag is split into 9 flags:
![Screen Shot 2022-04-22 at 11 50 30 AM](https://user-images.githubusercontent.com/24948563/164776784-3a256735-39ad-480a-8db7-71913740937f.png)
Such as these two cluster flags:
![Screen Shot 2022-04-22 at 11 50 41 AM](https://user-images.githubusercontent.com/24948563/164776867-cd060b44-efd2-4ce3-8b8c-87e25f58fe75.png)
![Screen Shot 2022-04-22 at 11 51 08 AM](https://user-images.githubusercontent.com/24948563/164776880-666e91be-ea11-4a25-83ba-65ba27755b4c.png)
And a closeup of the intersections in the second cluster:
![Screen Shot 2022-04-22 at 11 51 17 AM](https://user-images.githubusercontent.com/24948563/164776962-03712caf-b0f9-4922-acdf-cdefa9a89ebe.png)

Finally, this rework returns some intersection that were missing due to a tie break system that was used by the old multiple walker system. 
Old flag with one intersection:
![Screen Shot 2022-04-22 at 11 42 28 AM](https://user-images.githubusercontent.com/24948563/164777210-2a08bc39-da2f-44c0-93ac-9b60c24a96de.png)
New flag with all three intersections in the network:
![Screen Shot 2022-04-22 at 11 42 18 AM](https://user-images.githubusercontent.com/24948563/164777131-2da08b22-8275-4d2d-b629-4372b945e28e.png)


### Potential Impact:

None

### Unit Test Approach:

Updated unit tests to reflect the additional features that are now part of the flag. Added a unit test to check the clustering system works to make multiple flags. 

### Test Results:

The runtime issue was tested using an Atlas where this checks was hitting the 24 hour timeout in one case. That same Atlas now completes in about a minute, and the flags are as expected.

Additional analysis was done on the counties listed below.

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
|  CRI   |    9       |    9      |     100%       |   9 |   0 | 0%   |
|  SGP   |    2       |    2      |     100%       |   2 |   0 | 0%   |
|  SLV   |    24       |    24      |     100%       |   24 |   0 | 0%   |

