### PR TITLE
SinkIslandCheck Ferry and Car Access Update

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -252,8 +252,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
 
     /**
      * Finds the car accessibility value for an {@link Edge} by returning the first value found,
-     * using a descending list of tags to check. If no values are found fort the list of tags the
-     * value is assumed to be YES.
+     * using a descending list of tags to check. If no values are found for the list of tags the
+     * default is used.
      *
      * @param edge
      *            {@link Edge}

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -257,6 +257,8 @@ public class SinkIslandCheck extends BaseCheck<Long>
      *
      * @param edge
      *            {@link Edge}
+     * @param defaultValue
+     *            {@link String} to return as the default value if no others are found
      * @return {@link String} car accessibility value
      */
     @SuppressWarnings({ "squid:S3740" })
@@ -314,6 +316,9 @@ public class SinkIslandCheck extends BaseCheck<Long>
      *
      * @param edge
      *            any Edge
+     * @param defaultValue
+     *            {@link String} to use for default navigability if the edge has no car
+     *            accessibility tags
      * @return true if the edge is navigable
      */
     private boolean isCarNavigable(final Edge edge, final String defaultValue)

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -49,7 +49,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
             AmenityTag.PARKING_SPACE, AmenityTag.MOTORCYCLE_PARKING, AmenityTag.PARKING_ENTRANCE };
     private static final String DEFAULT_MINIMUM_HIGHWAY_TYPE = "SERVICE";
     private static final List<String> FALLBACK_INSTRUCTIONS = Collections.singletonList(
-            "This network does not allow vehicles to navigate out of it. Check for missing connections, and over restrictive access tags.");
+            "This network does not allow cars to navigate out of it. Check for missing connections, and tags restricting car access.");
     private static final float LOAD_FACTOR = 0.8f;
     private static final Predicate<AtlasObject> SERVICE_ROAD = object -> Validators.isOfType(object,
             HighwayTag.class, HighwayTag.SERVICE);

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheck.java
@@ -259,7 +259,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
      *            {@link Edge}
      * @return {@link String} car accessibility value
      */
-    @SuppressWarnings({ "squid:S3740", "squid:S3655" })
+    @SuppressWarnings({ "squid:S3740" })
     private String getCarAccess(final Edge edge, final String defaultValue)
     {
         final List<Class> carAccessTagsPrecedence = Arrays.asList(MotorcarTag.class,
@@ -268,7 +268,7 @@ public class SinkIslandCheck extends BaseCheck<Long>
         {
             if (Validators.hasValuesFor(edge, tagClass))
             {
-                return Validators.from(tagClass, edge).get().toString();
+                return edge.tag(Validators.findTagNameIn(tagClass)).toUpperCase();
             }
         }
         return defaultValue;

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -83,6 +83,14 @@ public class SinkIslandCheckTest
     }
 
     @Test
+    public void testMotorcarOverrideVehicleAtlas()
+    {
+        this.verifier.actual(this.setup.motorcarOverrideVehicleAtlas(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testNonCarNavigableEdges()
     {
         this.verifier.actual(this.setup.getNonCarNavigableEdges(), new SinkIslandCheck(
@@ -96,6 +104,15 @@ public class SinkIslandCheckTest
         this.verifier.actual(this.setup.getParkingGarageEntranceOrExit(), new SinkIslandCheck(
                 ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 3}")));
         this.verifier.verifyEmpty();
+    }
+
+    @Test
+    public void testPedestrianFerry()
+    {
+        this.verifier.actual(this.setup.pedestrianFerryAtlas(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 6}")));
+        this.verifier.verifyExpectedSize(2);
+        this.verifier.verify(flag -> Assert.assertEquals(2, flag.getFlaggedObjects().size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -57,19 +57,10 @@ public class SinkIslandCheckTest
     }
 
     @Test
-    public void testFerryInvalid()
-    {
-        this.verifier.actual(this.setup.ferryAtlas(), new SinkIslandCheck(
-                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 6}")));
-        this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> Assert.assertEquals(6, flag.getFlaggedObjects().size()));
-    }
-
-    @Test
     public void testFerryValid()
     {
         this.verifier.actual(this.setup.ferryAtlas(), new SinkIslandCheck(
-                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 5}")));
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 6}")));
         this.verifier.verifyEmpty();
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTest.java
@@ -57,6 +57,23 @@ public class SinkIslandCheckTest
     }
 
     @Test
+    public void testFerryInvalid()
+    {
+        this.verifier.actual(this.setup.ferryAtlas(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 6}")));
+        this.verifier.verifyExpectedSize(1);
+        this.verifier.verify(flag -> Assert.assertEquals(6, flag.getFlaggedObjects().size()));
+    }
+
+    @Test
+    public void testFerryValid()
+    {
+        this.verifier.actual(this.setup.ferryAtlas(), new SinkIslandCheck(
+                ConfigurationResolver.inlineConfiguration("{\"SinkIslandCheck.tree.size\": 5}")));
+        this.verifier.verifyEmpty();
+    }
+
+    @Test
     public void testHighwayImportanceConfiguration()
     {
         this.verifier.actual(this.setup.getServiceSinkIsland(),
@@ -71,7 +88,7 @@ public class SinkIslandCheckTest
         this.verifier.actual(this.setup.getInvalidEdges(),
                 new SinkIslandCheck(ConfigurationResolver.emptyConfiguration()));
         this.verifier.verifyExpectedSize(1);
-        this.verifier.verify(flag -> Assert.assertEquals(3, flag.getFlaggedObjects().size()));
+        this.verifier.verify(flag -> Assert.assertEquals(4, flag.getFlaggedObjects().size()));
     }
 
     @Test

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -234,6 +234,33 @@ public class SinkIslandCheckTestRule extends CoreTestRule
                             "highway=primary", "oneway=yes", "vehicle=permissive" }), })
     private Atlas permittedSelectAccessAtlas;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2) }, tags = { "highway=primary", "oneway=yes" }),
+                    @Edge(id = "-1000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_1) }, tags = { "highway=primary", "oneway=yes" }),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "route=ferry", "motor_vehicle=yes" }),
+                    @Edge(id = "-2000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_2) }, tags = { "route=ferry", "motor_vehicle=yes" }),
+                    @Edge(id = "3000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4) }, tags = { "highway=primary", "oneway=yes" }),
+                    @Edge(id = "-3000000", coordinates = { @Loc(value = TEST_4),
+                            @Loc(value = TEST_3) }, tags = { "highway=primary", "oneway=yes" }) })
+    private Atlas ferryAtlas;
+
+    public Atlas ferryAtlas()
+    {
+        return this.ferryAtlas;
+    }
+
     public Atlas getEdgeConnectedToPedestrianNetwork()
     {
         return this.pedestrianNetwork;

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/SinkIslandCheckTestRule.java
@@ -243,18 +243,60 @@ public class SinkIslandCheckTestRule extends CoreTestRule
             // edges
             edges = {
                     @Edge(id = "1000000", coordinates = { @Loc(value = TEST_1),
-                            @Loc(value = TEST_2) }, tags = { "highway=primary", "oneway=yes" }),
+                            @Loc(value = TEST_2) }, tags = { "highway=primary" }),
                     @Edge(id = "-1000000", coordinates = { @Loc(value = TEST_2),
-                            @Loc(value = TEST_1) }, tags = { "highway=primary", "oneway=yes" }),
+                            @Loc(value = TEST_1) }, tags = { "highway=primary" }),
                     @Edge(id = "2000000", coordinates = { @Loc(value = TEST_2),
                             @Loc(value = TEST_3) }, tags = { "route=ferry", "motor_vehicle=yes" }),
                     @Edge(id = "-2000000", coordinates = { @Loc(value = TEST_3),
                             @Loc(value = TEST_2) }, tags = { "route=ferry", "motor_vehicle=yes" }),
                     @Edge(id = "3000000", coordinates = { @Loc(value = TEST_3),
-                            @Loc(value = TEST_4) }, tags = { "highway=primary", "oneway=yes" }),
+                            @Loc(value = TEST_4) }, tags = { "highway=primary" }),
                     @Edge(id = "-3000000", coordinates = { @Loc(value = TEST_4),
-                            @Loc(value = TEST_3) }, tags = { "highway=primary", "oneway=yes" }) })
+                            @Loc(value = TEST_3) }, tags = { "highway=primary" }) })
     private Atlas ferryAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2) }, tags = { "highway=primary" }),
+                    @Edge(id = "-1000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_1) }, tags = { "highway=primary" }),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "route=ferry" }),
+                    @Edge(id = "-2000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_2) }, tags = { "route=ferry" }),
+                    @Edge(id = "3000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_4) }, tags = { "highway=primary" }),
+                    @Edge(id = "-3000000", coordinates = { @Loc(value = TEST_4),
+                            @Loc(value = TEST_3) }, tags = { "highway=primary" }) })
+    private Atlas pedestrianFerryAtlas;
+
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_1)),
+                    @Node(coordinates = @Loc(value = TEST_2)),
+                    @Node(coordinates = @Loc(value = TEST_3)),
+                    @Node(coordinates = @Loc(value = TEST_4)) },
+            // edges
+            edges = {
+                    @Edge(id = "1000000", coordinates = { @Loc(value = TEST_1),
+                            @Loc(value = TEST_2) }, tags = { "highway=primary" }),
+                    @Edge(id = "-1000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_1) }, tags = { "highway=primary" }),
+                    @Edge(id = "2000000", coordinates = { @Loc(value = TEST_2),
+                            @Loc(value = TEST_3) }, tags = { "highway=primary", "vehicle=no",
+                                    "motorcar=yes" }),
+                    @Edge(id = "-2000000", coordinates = { @Loc(value = TEST_3),
+                            @Loc(value = TEST_2) }, tags = { "highway=primary", "vehicle=no",
+                                    "motorcar=yes" }) })
+    private Atlas motorcarOverrideVehicleAtlas;
 
     public Atlas ferryAtlas()
     {
@@ -339,6 +381,16 @@ public class SinkIslandCheckTestRule extends CoreTestRule
     public Atlas getTwoEdgesWithAmenityAtlas()
     {
         return this.twoEdgesWithAmenityAtlas;
+    }
+
+    public Atlas motorcarOverrideVehicleAtlas()
+    {
+        return this.motorcarOverrideVehicleAtlas;
+    }
+
+    public Atlas pedestrianFerryAtlas()
+    {
+        return this.pedestrianFerryAtlas;
     }
 
     public Atlas permittedSelectAccessAtlas()


### PR DESCRIPTION
### Description:

This update is to resolve two issues with the SinkIslandCheck.

This fixes https://github.com/osmlab/atlas-checks/issues/585. It does this by making car ferries a valid terminus for a road network. Thus ways like the following are no longer flagged:
![Screen Shot 2022-05-25 at 10 03 48 AM](https://user-images.githubusercontent.com/24948563/170320238-bae90e2f-46ce-46ad-afcf-fbea9320688d.png)

This also fixes an issue with the way car navigability was derived from the vehicle, motor_vehicle, and motorcar tags. These tags act in a hierarchical fashion. This was previously ignored, so that if any of these tags had a navigable value the other's values were irrelevant. 
Example, this way was flagged because it had vehicle=yes and its motor_vehicle=permit was ignored while the connected ways just had motor_vehicle=permit:
![Screen Shot 2022-05-25 at 10 10 52 AM](https://user-images.githubusercontent.com/24948563/170322047-61471995-e8a0-424c-9f5e-4afcab79bf46.png)

### Potential Impact:

None

### Unit Test Approach:

Added unit tests for car ferries, pedestrian ferries, and car access hierarchy. 

### Test Results:

Analysis was done on the difference in flags from the previous version of this check to the updates here. 

Subtracted Flags:
| ISO | Total Flags | Sampled  | Sampling % | TN | FN | Differential False Negative Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
|  Global   |    94        |    94      |     100%       |   88 |   6 | 6.3%   |

There were 2 types of new false negative flags introduced.
The first is when ferries connect piers with missing access tags:
https://www.openstreetmap.org/way/822360979
The second is when ferries connected roads that had misplaced one way connections:
https://www.openstreetmap.org/way/604212684


Added Flags:
| ISO | Total Flags | Sampled  | Sampling % | TP | FP | Differential False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
|  Global   |    287        |    29     |     10.1%       |   29 |   0 | 0%   |

The new true positives added where situations where ways were connected to roads that had something like vehicle=yes & motorcar=no. Previously these connected ways were seen as car route-able, when in fact they should not have been.
https://www.openstreetmap.org/way/784709925
https://www.openstreetmap.org/way/717145350
