### PR TITLE
Handled FloatingEdgeCheck Airport Relations Bug

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -155,7 +155,7 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
         // Consider navigable main edges
         return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMainEdge()
                 && HighwayTag.isCarNavigableHighway(object) && this.isMinimumHighwayType(object)
-                && !this.intersectsAirport((Edge) object);
+                && !intersectsAirport((Edge) object);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheck.java
@@ -18,6 +18,8 @@ import org.openstreetmap.atlas.tags.SyntheticBoundaryNodeTag;
 import org.openstreetmap.atlas.tags.annotations.validation.Validators;
 import org.openstreetmap.atlas.utilities.configuration.Configuration;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This check will look for any edges outside of airport boundaries that do not contain any incoming
@@ -47,6 +49,8 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
 
     private static final RelationOrAreaToMultiPolygonConverter RELATION_OR_AREA_TO_MULTI_POLYGON_CONVERTER = new RelationOrAreaToMultiPolygonConverter();
     // class variable to store the maximum distance for the floating road
+
+    private static final Logger logger = LoggerFactory.getLogger(FloatingEdgeCheck.class);
     private final Distance maximumDistance;
     // class variable to store the minimum distance for the floating road
     private final Distance minimumDistance;
@@ -83,7 +87,7 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
             }
             catch (final MultiplePolyLineToPolygonsConverter.OpenPolygonException exception)
             {
-                exception.printStackTrace();
+                logger.error("There is an open location", exception);
             }
         }
         return false;
@@ -131,11 +135,6 @@ public class FloatingEdgeCheck extends BaseCheck<Long>
     @Override
     public boolean validCheckForObject(final AtlasObject object)
     {
-        if (((Edge) object).isMainEdge() && HighwayTag.isCarNavigableHighway(object)
-                && this.isMinimumHighwayType(object) && !intersectsAirport((Edge) object))
-        {
-            System.out.println("print edge " + object.getIdentifier());
-        }
         // Consider navigable main edges
         return TypePredicates.IS_EDGE.test(object) && ((Edge) object).isMainEdge()
                 && HighwayTag.isCarNavigableHighway(object) && this.isMinimumHighwayType(object)

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTest.java
@@ -70,6 +70,14 @@ public class FloatingEdgeCheckTest
     }
 
     @Test
+    public void testHighwayEdgesWithinRelation()
+    {
+        this.verifier.actual(this.setup.highwayEdgeWithinRelation(),
+                new FloatingEdgeCheck(ConfigurationResolver.emptyConfiguration()));
+        this.verifier.globallyVerify(flags -> Assert.assertEquals(0, flags.size()));
+    }
+
+    @Test
     public void testInlineConfigFloatingEdge()
     {
         this.verifier.actual(this.setup.floatingEdgeAtlas(), this.minimumHighwayCheck);

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/linear/edges/FloatingEdgeCheckTestRule.java
@@ -29,6 +29,21 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
     private static final String TEST_8 = "47.6025,-122.3181";
     private static final String TEST_9 = "47.6011,-122.3177";
 
+    private static final String TEST_10 = "47.2136626201459,-122.443275382856";
+    private static final String TEST_11 = "47.2138327316739,-122.44258668766";
+    private static final String TEST_12 = "47.2136626201459,-122.441897992465";
+    private static final String TEST_13 = "47.2138114677627,-122.440990166979";
+    private static final String TEST_14 = "47.2136200921786,-122.44001973284";
+    private static final String TEST_15 = "47.2135137721113,-122.439127559518";
+    private static final String TEST_16 = "47.2136200921786,-122.438157125378";
+    private static final String TEST_17 = "47.2136413561665,-122.437468430183";
+    private static final String TEST_18 = "47.2137689399148,-122.436717126333";
+    private static final String TEST_19 = "47.2136413561665,-122.436028431137";
+    private static final String TEST_20 = "47.2141623212065,-122.443729295599";
+    private static final String TEST_21 = "47.2132054427106,-122.44382320858";
+    private static final String TEST_22 = "47.2132267068647,-122.435339735941";
+    private static final String TEST_23 = "47.2142154806167,-122.435355388105";
+
     private static final String LOCATION_1 = "1.11,1.11";
     private static final String LOCATION_2 = "1.12,1.12";
 
@@ -104,6 +119,32 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
                                                     "construction=RESIDENTIAL" }) })
     private Atlas floatingEdgeConstructionAtlas;
 
+    @TestAtlas(
+            // nodes
+            nodes = { @Node(coordinates = @Loc(value = TEST_10)),
+                    @Node(coordinates = @Loc(value = TEST_12)),
+                    @Node(coordinates = @Loc(value = TEST_14)),
+                    @Node(coordinates = @Loc(value = TEST_16)) },
+            // edges
+            edges = { @Edge(id = "1000000001", coordinates = { @Loc(value = TEST_10),
+                    @Loc(value = TEST_11), @Loc(value = TEST_12) }, tags = { "highway=motorway" }),
+                    @Edge(id = "1001000001", coordinates = { @Loc(value = TEST_12),
+                            @Loc(value = TEST_13), @Loc(value = TEST_14) }, tags = {
+                                    "highway=motorway", "aeroway=taxiway" }),
+                    @Edge(id = "1002000001", coordinates = { @Loc(value = TEST_14),
+                            @Loc(value = TEST_15),
+                            @Loc(value = TEST_16) }, tags = { "aeroway=aerodrome" }) },
+            // areas
+            lines = { @Line(id = "1000", coordinates = { @Loc(value = TEST_20),
+                    @Loc(value = TEST_21), @Loc(value = TEST_22), @Loc(value = TEST_14),
+                    @Loc(value = TEST_20) }) },
+            // relations
+            relations = { @TestAtlas.Relation(members = {
+                    @TestAtlas.Relation.Member(id = "1000000001", type = "edge", role = "") }, tags = {
+                            "aeroway=aerodrome", "type=multipolygon" }) })
+
+    private Atlas highwayEdgeWithinRelation;
+
     public Atlas airportAtlas()
     {
         return this.airportAtlas;
@@ -132,6 +173,11 @@ public class FloatingEdgeCheckTestRule extends CoreTestRule
     public Atlas floatingEdgeInAirportPolygon()
     {
         return this.floatingEdgeInAirportAtlas;
+    }
+
+    public Atlas highwayEdgeWithinRelation()
+    {
+        return this.highwayEdgeWithinRelation;
     }
 
     public Atlas mixedAtlas()


### PR DESCRIPTION
### Description:

Describe the bug
FloatingEdgeCheck is supposed to ignore edges inside of airports. It currently does this by checking for overlap with areas that have an aero way tag. This leaves out the many airports that are modeled as multi-polygon relations. This PR enhanced the check to test overlap with multi-polygon airports.
For example, it should not flag  this way -> 874001205

### Potential Impact:

-NA-
### Unit Test Approach:
 **FloatingEdgeCheck:**
  **Country  |  baseline  |  PR_test_result**
   AGO           	10                    9
   ARE            	16                    13
   BRA            	76                   75
   CHE           	 29                  27
   CHN         	10194             10190
   CUB              3                     2
   CZE              3                     2
   ESH              4                      3
   GAB             6                      5
  GRC              6                       2 
  HUN             15                       9
   ISL               2                        1
   KAZ             17                        15
   KGZ              3                          2
  MEX              21                        19
  MLI              196                        195
  NLD               29                         25
  NOR              57                          56
  OMN             18                          12
  PHL               42                          41
  POL             221                           220
 RUS              246                          224
 SRB                92                              91
SWE             103                                102
 SYR               21                                 18
 UKR               58                               56
 ZAF                  4                                3

### Test Results:

| ISO | Total Flags | Sampled  | Sampling % | TP | FP | False Positive Rate |
|-----|-------------|----------|------------|----|----| ------------------- |
|  MEX   |    21         |    21      |     100%       |   100 |   0 | 0   |
|  UKR   |    58         |    58      |     100%       |   100 |   0 | 0   |

