### PR TITLE
LevelCrossingOnRailwayCheck adding logic for tram_level_crossing and disused:railway  

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 project.ext.versions = [
     checkstyle: '8.18',
     jacoco: '0.8.7',
-    atlas: '6.6.2',
+    atlas: '7.0.6',
     commons:'2.6',
     atlas_generator: '5.3.6',
     atlas_checkstyle: '5.6.9',

--- a/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheck.java
+++ b/src/main/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheck.java
@@ -67,16 +67,15 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
     private final TaggableFilter railwayFilter;
     private static final Long OSM_LAYER_DEFAULT = 0L;
     private final Long layerDefault;
-    private static final String INVALID_TAGGED_OBJECT = "The object (OSM ID: {0,number,#}) has `railway=level_crossing` but is not a node. "
-            + "To fix: Remove `railway=level_crossing` tag.";
+    private static final String INVALID_TAGGED_OBJECT = "The object (OSM ID: {0,number,#}) has `{1}={2}` but is not a node. To fix: Remove `{1}={2}` tag.";
     private static final int INVALID_TAGGED_OBJECT_INDEX = 0;
-    private static final String NODE_CROSSING_MISSING_LC_TAG = "The node (OSM ID: {0,number,#}) has a `railway=crossing` tag but should be `railway=level_crossing` tag. "
-            + "To fix: replace the `railway=crossing` tag with a `railway=level_crossing` tag";
+    private static final String NODE_CROSSING_MISSING_LC_TAG = "The node (OSM ID: {0,number,#}) has a `{1}=crossing` tag but should be `{1}=level_crossing` tag. "
+            + "To fix: replace the `{1}=crossing` tag with a `{1}=level_crossing` tag";
     private static final int NODE_CROSSING_MISSING_LC_TAG_INDEX = 1;
-    private static final String NODE_MISSING_LC_TAG = "The intersection node (OSM ID: {0,number,#}) is missing a `railway=level_crossing` tag. "
+    private static final String NODE_MISSING_LC_TAG = "The intersection node (OSM ID: {0,number,#}) is missing a `{1}=level_crossing` tag. "
             + "This means that there are at least one valid railway and one car navigable highway on the same layer at this node. "
             + "To fix: If the two ways should be on different layers then adjust the layer tags for each way appropriately. "
-            + "If the two ways do intersect on the same layer then add the `railway=level_crossing` tag to this node.";
+            + "If the two ways do intersect on the same layer then add the `{1}=level_crossing` tag to this node.";
     private static final int NODE_MISSING_LC_TAG_INDEX = 2;
     private static final String NODE_INVALID_LC_TAG_NO_HIGHWAY = "The node (OSM ID: {0,number,#}) has `{1}={2}` tag, but there is no car navigable highway at this intersection. "
             + "To fix: Verify that no highway crosses the railway at this node on the same layer and then remove `{1}={2}` tag.";
@@ -84,19 +83,19 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
     private static final String NODE_INVALID_LC_TAG_NO_RAILWAY = "The node (OSM ID: {0,number,#}) has `{1}={2}` tag, but there are no existing rails at this intersection. "
             + "To fix: Verify that no railway crosses the highway at this node on the same layer and then remove `{1}={2}` tag.";
     private static final int NODE_INVALID_LC_TAG_NO_RAILWAY_INDEX = 4;
-    private static final String NODE_INVALID_LC_TAG_LAYERS = "The node (OSM ID: {0,number,#}) has `railway=level_crossing` tag, but there are no railway and highway intersection on the same layer. "
+    private static final String NODE_INVALID_LC_TAG_LAYERS = "The node (OSM ID: {0,number,#}) has `{1}={2}` tag, but there are no railway and highway intersection on the same layer. "
             + "To fix: If the railway and highway should be on the same layer then update the layer tags for both ways to be equal. "
-            + "If the ways are on different layers then remove `railway=level_crossing` tag.";
+            + "If the ways are on different layers then remove `{1}={2}` tag.";
     private static final int NODE_INVALID_LC_TAG_LAYERS_INDEX = 5;
     private static final String INTERSECTION_MISSING_NODE = "The railway (OSM ID: {0,number,#}) has one or more car navigable intersections on the same layer that are missing intersection nodes. "
             + "To fix: If highway crosses the railway at the same layer then make sure that there is a node connected to both railway and highway at the intersection with `railway=level_crossing` tag. "
             + "If highway and railway are on different layers then update the appropriate layer tag for the way that goes under or over the other way.";
     private static final int INTERSECTION_MISSING_NODE_INDEX = 6;
-    private static final String NODE_INVALID_LC_TAG_PED_ONLY_HIGHWAY = "The node (OSM ID: {0,number,#}) has `railway=level_crossing` tag, but there is no car navigable highway at this intersection, only pedestrian highway(s). "
+    private static final String NODE_INVALID_LC_TAG_PED_ONLY_HIGHWAY = "The node (OSM ID: {0,number,#}) has `{1}={2}` tag, but there is no car navigable highway at this intersection, only pedestrian highway(s). "
             + "To fix: Change `railway=level_crossing` to `railway=crossing`.";
     private static final int NODE_INVALID_LC_TAG_PED_ONLY_HIGHWAY_INDEX = 7;
-    private static final String NODE_INVALID_LC_TAG_CYCLE_ONLY_HIGHWAY = "The node (OSM ID: {0,number,#}) has `railway=level_crossing` tag, but there is no car navigable highway at this intersection, only cycleway highway(s). "
-            + "To fix: Change `railway=level_crossing` to `railway=crossing` and add `bicycle=yes` and `foot=no`.";
+    private static final String NODE_INVALID_LC_TAG_CYCLE_ONLY_HIGHWAY = "The node (OSM ID: {0,number,#}) has `{1}={2}` tag, but there is no car navigable highway at this intersection, only cycleway highway(s). "
+            + "To fix: Change `{1}=level_crossing` to `{1}=crossing` and add `bicycle=yes` and `foot=no`.";
     private static final int NODE_INVALID_LC_TAG_CYCLE_ONLY_HIGHWAY_INDEX = 8;
 
     private static final List<String> FALLBACK_INSTRUCTIONS = Arrays.asList(INVALID_TAGGED_OBJECT,
@@ -226,7 +225,8 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
                                 .createFlag(object,
                                         this.getLocalizedInstruction(
                                                 NODE_INVALID_LC_TAG_CYCLE_ONLY_HIGHWAY_INDEX,
-                                                object.getOsmIdentifier()))
+                                                object.getOsmIdentifier(), this.railwayTagKey,
+                                                this.railwayTagValue))
                                 .addFixSuggestion(FeatureChange.add(
                                         (AtlasEntity) ((CompleteEntity) CompleteEntity
                                                 .from((AtlasEntity) object))
@@ -247,7 +247,8 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
                                 .createFlag(object,
                                         this.getLocalizedInstruction(
                                                 NODE_INVALID_LC_TAG_PED_ONLY_HIGHWAY_INDEX,
-                                                object.getOsmIdentifier()))
+                                                object.getOsmIdentifier(), this.railwayTagKey,
+                                                this.railwayTagValue))
                                 .addFixSuggestion(FeatureChange.add(
                                         (AtlasEntity) ((CompleteEntity) CompleteEntity
                                                 .from((AtlasEntity) object))
@@ -281,7 +282,7 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
                     return Optional.of(this
                             .createFlag(object,
                                     this.getLocalizedInstruction(NODE_CROSSING_MISSING_LC_TAG_INDEX,
-                                            object.getOsmIdentifier()))
+                                            object.getOsmIdentifier(), this.railwayTagKey))
                             .addFixSuggestion(FeatureChange.add(
                                     (AtlasEntity) ((CompleteEntity) CompleteEntity
                                             .from((AtlasEntity) object)).withTags(object.getTags())
@@ -293,7 +294,7 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
                 return Optional.of(this
                         .createFlag(object,
                                 this.getLocalizedInstruction(NODE_MISSING_LC_TAG_INDEX,
-                                        object.getOsmIdentifier()))
+                                        object.getOsmIdentifier(), this.railwayTagKey))
                         .addFixSuggestion(FeatureChange.add(
                                 (AtlasEntity) ((CompleteEntity) CompleteEntity
                                         .from((AtlasEntity) object)).withAddedTag(
@@ -347,9 +348,8 @@ public class LevelCrossingOnRailwayCheck extends BaseCheck<Long>
         if (!(object instanceof LocationItem) && this.isRailwayCrossing(object))
         {
             return Optional.of(this
-                    .createFlag(object,
-                            this.getLocalizedInstruction(INVALID_TAGGED_OBJECT_INDEX,
-                                    object.getOsmIdentifier()))
+                    .createFlag(object, this.getLocalizedInstruction(INVALID_TAGGED_OBJECT_INDEX,
+                            object.getOsmIdentifier(), this.railwayTagKey, this.railwayTagValue))
                     .addFixSuggestion(FeatureChange.add(
                             (AtlasEntity) ((CompleteEntity) CompleteEntity
                                     .from((AtlasEntity) object)).withRemovedTag(RailwayTag.KEY),

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTest.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTest.java
@@ -157,7 +157,7 @@ public class LevelCrossingOnRailwayCheckTest
                 new LevelCrossingOnRailwayCheck(ConfigurationResolver.inlineConfiguration(
                         "{  \"LevelCrossingOnRailwayCheck\": {" + "    \"enabled\": true,"
                                 + "    \"railway.filter\": \"railway->light_rail\"" + " }}")));
-        this.verifier.verifyExpectedSize(1);
+        this.verifier.verifyExpectedSize(3);
         this.verifier.verify(flag -> verifyObjectsAndSuggestions(flag, 1, 0));
     }
 

--- a/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTestRule.java
+++ b/src/test/java/org/openstreetmap/atlas/checks/validation/intersections/LevelCrossingOnRailwayCheckTestRule.java
@@ -133,7 +133,11 @@ public class LevelCrossingOnRailwayCheckTestRule extends CoreTestRule
                     @Node(id = "523456789000000", coordinates = @Loc(value = INT1), tags = {
                             "railway=level_crossing" }),
                     @Node(id = "623456789000000", coordinates = @Loc(value = H2_NODE_1), tags = {}),
-                    @Node(id = "723456789000000", coordinates = @Loc(value = H2_NODE_2), tags = {}) },
+                    @Node(id = "723456789000000", coordinates = @Loc(value = H2_NODE_2), tags = {}),
+                    @Node(id = "823456789000000", coordinates = @Loc(value = INT1), tags = {
+                            "railway=tram_level_crossing" }),
+                    @Node(id = "923456789000000", coordinates = @Loc(value = INT1), tags = {
+                            "disused:railway=level_crossing" }) },
             // edges
             edges = {
                     // 1.1-1.4: intersecting edge with no layer


### PR DESCRIPTION
### Description:

please refer: 
1) https://github.com/osmlab/atlas-checks/issues/672
2) https://github.com/osmlab/atlas-checks/issues/675
3) Atlas version 7.0.6 bump (Atlas version to handle above cases)

### Potential Impact:

 Nodes with valid crossing won't be flagged.

### Unit Test Approach:

Simulate test for tram_level_crossing and disused:railway cases   

### Test Results:

passed
